### PR TITLE
Fix openvpn get_config crash on multi-value tls ca-certificate

### DIFF
--- a/backend/routers/interfaces/openvpn.py
+++ b/backend/routers/interfaces/openvpn.py
@@ -92,7 +92,7 @@ class OpenvpnEncryption(BaseModel):
 
 class OpenvpnTls(BaseModel):
     auth_key: Optional[str] = None
-    ca_certificate: Optional[str] = None
+    ca_certificates: List[str] = Field(default_factory=list)
     certificate: Optional[str] = None
     crypt_key: Optional[str] = None
     dh_params: Optional[str] = None

--- a/backend/vyos_builders/interfaces/openvpn.py
+++ b/backend/vyos_builders/interfaces/openvpn.py
@@ -345,8 +345,8 @@ class OpenvpnInterfaceBuilderMixin:
     def set_tls_ca_certificate(self, interface: str, cert: str) -> "OpenvpnInterfaceBuilderMixin":
         return self.add_set(self._mapper().get_tls_ca_certificate(interface, cert))
 
-    def delete_tls_ca_certificate(self, interface: str) -> "OpenvpnInterfaceBuilderMixin":
-        return self.add_delete(self._mapper().get_tls_ca_certificate_path(interface))
+    def delete_tls_ca_certificate(self, interface: str, cert: str) -> "OpenvpnInterfaceBuilderMixin":
+        return self.add_delete(self._mapper().get_tls_ca_certificate(interface, cert))
 
     def set_tls_certificate(self, interface: str, cert: str) -> "OpenvpnInterfaceBuilderMixin":
         return self.add_set(self._mapper().get_tls_certificate(interface, cert))

--- a/backend/vyos_mappers/interfaces/openvpn.py
+++ b/backend/vyos_mappers/interfaces/openvpn.py
@@ -696,7 +696,7 @@ class OpenvpnInterfaceMapper(BaseFeatureMapper):
             "hash": config.get("hash"),
             "tls": {
                 "auth_key": tls_config.get("auth-key"),
-                "ca_certificate": tls_config.get("ca-certificate"),
+                "ca_certificates": _as_list(tls_config.get("ca-certificate")),
                 "certificate": tls_config.get("certificate"),
                 "crypt_key": tls_config.get("crypt-key"),
                 "dh_params": tls_config.get("dh-params"),

--- a/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
@@ -342,7 +342,7 @@ export function CreateOpenvpnModal({
     if (sharedSecretKey) config.shared_secret_key = sharedSecretKey;
 
     const tls: NonNullable<OpenvpnCreateConfig["tls"]> = {};
-    if (tlsCa) tls.ca_certificate = tlsCa;
+    if (tlsCa) tls.ca_certificates = [tlsCa];
     if (tlsCert) tls.certificate = tlsCert;
     if (tlsDh) tls.dh_params = tlsDh;
     if (tlsAuthKey) tls.auth_key = tlsAuthKey;

--- a/frontend/src/components/openvpn/EditOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/EditOpenvpnModal.tsx
@@ -105,7 +105,7 @@ export function EditOpenvpnModal({
   const [dataCiphersFallback, setDataCiphersFallback] = useState("");
   const [hash, setHash] = useState("");
 
-  const [tlsCa, setTlsCa] = useState("");
+  const [tlsCas, setTlsCas] = useState<string[]>([]);
   const [tlsCert, setTlsCert] = useState("");
   const [tlsDh, setTlsDh] = useState("");
   const [tlsAuthKey, setTlsAuthKey] = useState("");
@@ -216,7 +216,7 @@ export function EditOpenvpnModal({
     setDataCiphersFallback(i.encryption?.data_ciphers_fallback ?? "");
     setHash(i.hash ?? "");
 
-    setTlsCa(i.tls?.ca_certificate ?? "");
+    setTlsCas(i.tls?.ca_certificates ?? []);
     setTlsCert(i.tls?.certificate ?? "");
     setTlsDh(i.tls?.dh_params ?? "");
     setTlsAuthKey(i.tls?.auth_key ?? "");
@@ -341,7 +341,7 @@ export function EditOpenvpnModal({
     update.shared_secret_key = sharedSecretKey;
 
     update.tls = {
-      ca_certificate: tlsCa,
+      ca_certificates: tlsCas,
       certificate: tlsCert,
       dh_params: tlsDh,
       auth_key: tlsAuthKey,
@@ -801,19 +801,25 @@ export function EditOpenvpnModal({
           <TabsContent value="tls" className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <Label htmlFor="etlsca">CA Certificate</Label>
-                <Select value={tlsCa} onValueChange={setTlsCa}>
-                  <SelectTrigger id="etlsca">
-                    <SelectValue placeholder="Select CA" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {pki?.ca.map((c) => (
-                      <SelectItem key={c.name} value={c.name}>
-                        {c.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Label>CA Certificate(s)</Label>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Select one or more CAs (e.g. an intermediate CA chain).
+                </p>
+                <div className="grid grid-cols-2 gap-2 rounded-md border p-3">
+                  {pki?.ca.map((c) => (
+                    <label key={c.name} className="flex items-center gap-2 text-sm">
+                      <Checkbox
+                        checked={tlsCas.includes(c.name)}
+                        onCheckedChange={(v) =>
+                          setTlsCas(
+                            v ? [...tlsCas, c.name] : tlsCas.filter((x) => x !== c.name),
+                          )
+                        }
+                      />
+                      <span>{c.name}</span>
+                    </label>
+                  ))}
+                </div>
               </div>
               <div>
                 <Label htmlFor="etlscert">Certificate</Label>

--- a/frontend/src/components/openvpn/OpenvpnDetailsDrawer.tsx
+++ b/frontend/src/components/openvpn/OpenvpnDetailsDrawer.tsx
@@ -211,7 +211,7 @@ export function OpenvpnDetailsDrawer({
           <Row label="Data Ciphers Fallback" value={i.encryption?.data_ciphers_fallback} />
           <Row label="Hash" value={i.hash} />
           <Row label="Shared Secret Key" value={i.shared_secret_key} />
-          <Row label="TLS CA Certificate" value={i.tls?.ca_certificate} />
+          <Row label="TLS CA Certificate" value={i.tls?.ca_certificates?.join(", ") || undefined} />
           <Row label="TLS Certificate" value={i.tls?.certificate} />
           <Row label="TLS DH Params" value={i.tls?.dh_params} />
           <Row label="TLS Auth Key" value={i.tls?.auth_key} />

--- a/frontend/src/components/openvpn/OpenvpnWizard.tsx
+++ b/frontend/src/components/openvpn/OpenvpnWizard.tsx
@@ -181,7 +181,7 @@ export function OpenvpnWizard({
     if (sharedSecretKey) config.shared_secret_key = sharedSecretKey;
 
     const tls: NonNullable<OpenvpnCreateConfig["tls"]> = {};
-    if (tlsCa) tls.ca_certificate = tlsCa;
+    if (tlsCa) tls.ca_certificates = [tlsCa];
     if (tlsCert) tls.certificate = tlsCert;
     if (tlsDh) tls.dh_params = tlsDh;
     if (tlsAuthKey) tls.auth_key = tlsAuthKey;

--- a/frontend/src/lib/api/openvpn.ts
+++ b/frontend/src/lib/api/openvpn.ts
@@ -32,7 +32,7 @@ export interface OpenvpnEncryption {
 
 export interface OpenvpnTls {
   auth_key: string | null;
-  ca_certificate: string | null;
+  ca_certificates: string[];
   certificate: string | null;
   crypt_key: string | null;
   dh_params: string | null;
@@ -224,7 +224,7 @@ export interface OpenvpnCreateConfig {
   hash?: string;
   tls?: {
     auth_key?: string;
-    ca_certificate?: string;
+    ca_certificates?: string[];
     certificate?: string;
     crypt_key?: string;
     dh_params?: string;
@@ -355,7 +355,11 @@ function buildInterfaceOps(
 
   if (config.tls) {
     if (config.tls.auth_key) ops.push({ op: "set_tls_auth_key", value: config.tls.auth_key });
-    if (config.tls.ca_certificate) ops.push({ op: "set_tls_ca_certificate", value: config.tls.ca_certificate });
+    if (config.tls.ca_certificates) {
+      for (const ca of config.tls.ca_certificates) {
+        ops.push({ op: "set_tls_ca_certificate", value: ca });
+      }
+    }
     if (config.tls.certificate) ops.push({ op: "set_tls_certificate", value: config.tls.certificate });
     if (config.tls.crypt_key) ops.push({ op: "set_tls_crypt_key", value: config.tls.crypt_key });
     if (config.tls.dh_params) ops.push({ op: "set_tls_dh_params", value: config.tls.dh_params });
@@ -657,9 +661,14 @@ class OpenvpnService {
         if (updated.tls.auth_key) ops.push({ op: "set_tls_auth_key", value: updated.tls.auth_key });
         else ops.push({ op: "delete_tls_auth_key" });
       }
-      if (updated.tls.ca_certificate !== undefined) {
-        if (updated.tls.ca_certificate) ops.push({ op: "set_tls_ca_certificate", value: updated.tls.ca_certificate });
-        else ops.push({ op: "delete_tls_ca_certificate" });
+      if (updated.tls.ca_certificates !== undefined) {
+        const currentCas = current.tls?.ca_certificates ?? [];
+        for (const old of currentCas) {
+          ops.push({ op: "delete_tls_ca_certificate", value: old });
+        }
+        for (const ca of updated.tls.ca_certificates) {
+          ops.push({ op: "set_tls_ca_certificate", value: ca });
+        }
       }
       if (updated.tls.certificate !== undefined) {
         if (updated.tls.certificate) ops.push({ op: "set_tls_certificate", value: updated.tls.certificate });


### PR DESCRIPTION
VyOS treats 'tls ca-certificate' as a multi node (intermediate CA chains), so it returns a list. The OpenvpnTls model expected a single string, raising a ValidationError in get_config for any interface with more than one CA.

Treat the CA certificate as a list end-to-end: parse with _as_list, expose tls.ca_certificates: string[], support per-cert set/delete in the builder, and update the create/edit/wizard/detail UIs accordingly.