### PR TITLE
Gate 1.5-only openvpn fields in edit modal by capabilities

### DIFF
--- a/backend/routers/interfaces/openvpn.py
+++ b/backend/routers/interfaces/openvpn.py
@@ -359,6 +359,12 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
         )
     except HTTPException:
         raise
+    except NotImplementedError as e:
+        logger.info("Unsupported operation '%s' for this VyOS version: %s", op.op, e)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Operation '{op.op}' is not supported on this VyOS version",
+        )
     except Exception:
         logger.exception("Unhandled error in batch_configure")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/frontend/src/components/openvpn/EditOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/EditOpenvpnModal.tsx
@@ -335,7 +335,9 @@ export function EditOpenvpnModal({
     update.encryption = {
       cipher,
       data_ciphers: dataCiphers,
-      data_ciphers_fallback: dataCiphersFallback,
+      // data-ciphers-fallback is a VyOS 1.5-only node; omit it entirely on 1.4
+      // so the diff never emits an unsupported set/delete operation.
+      ...(is15 ? { data_ciphers_fallback: dataCiphersFallback } : {}),
     };
     update.hash = hash;
     update.shared_secret_key = sharedSecretKey;
@@ -422,7 +424,8 @@ export function EditOpenvpnModal({
       base_reachable_time: ipv6BaseReachableTime,
       disable_forwarding: ipv6DisableForwarding,
       dup_addr_detect_transmits: ipv6DupAddrDetectTransmits,
-      address_interface_identifier: ipv6InterfaceIdentifier,
+      // address interface-identifier is a VyOS 1.5-only node; omit it on 1.4.
+      ...(is15 ? { address_interface_identifier: ipv6InterfaceIdentifier } : {}),
       source_validation: ipv6SourceValidation,
     };
 


### PR DESCRIPTION
Editing an OpenVPN interface on VyOS 1.4 sent delete operations for 1.5-only nodes (encryption data-ciphers-fallback and ipv6 address interface-identifier). The edit modal hid these fields in the UI but still included them in the update payload, so the diff emitted deletes for the empty values, hitting mapper methods that raise NotImplementedError on 1.4.

Confirmed via the VyOS templates on both hosts (1.4.3 sagitta vs 2026.03 circinus) that these two nodes plus data-ciphers/ncp-ciphers are the only version differences; the cipher list is already handled by mapper overrides. Omit the two 1.5-only fields from the edit payload when capabilities report 1.4.

Also harden batch_configure to return a clean 400 for any version-unsupported operation instead of a 500.