### PR TITLE
Fix QoS cake flow-isolation parsing and NAT option

### DIFF
--- a/backend/routers/qos/qos.py
+++ b/backend/routers/qos/qos.py
@@ -444,12 +444,6 @@ def _parse_precedences(raw) -> List[QoSPrecedence]:
     return result
 
 
-def _parse_flow_isolation(raw) -> tuple[Optional[str], bool]:
-    fi = _as_dict(raw)
-    mode = next((m for m in FLOW_ISOLATION_MODES if m in fi), None)
-    return mode, ("nat" in fi)
-
-
 def _parse_policy(ptype: str, name: str, raw) -> QoSPolicy:
     raw = _as_dict(raw)
     policy = QoSPolicy(type=ptype, name=name)
@@ -470,8 +464,11 @@ def _parse_policy(ptype: str, name: str, raw) -> QoSPolicy:
     policy.burst = raw.get("burst")
     policy.latency = raw.get("latency")
 
-    if "flow-isolation" in raw:
-        policy.flow_isolation, policy.flow_isolation_nat = _parse_flow_isolation(raw.get("flow-isolation"))
+    # `flow-isolation` is a leaf node holding a single mode value (e.g.
+    # "src-host"); `flow-isolation-nat` is a separate valueless sibling.
+    fi = raw.get("flow-isolation")
+    policy.flow_isolation = fi if isinstance(fi, str) and fi in FLOW_ISOLATION_MODES else None
+    policy.flow_isolation_nat = "flow-isolation-nat" in raw
 
     classes_raw = _as_dict(raw.get("class"))
     policy.classes = sorted(

--- a/frontend/src/components/qos/QoSPolicyModal.tsx
+++ b/frontend/src/components/qos/QoSPolicyModal.tsx
@@ -83,21 +83,23 @@ export function QoSPolicyModal({
   };
 
   // Flow isolation (cake) ---------------------------------------------------
-  const currentMode = draft.flags.find((fl) => fl.startsWith("flow-isolation/") && fl !== "flow-isolation/nat");
+  // Mode is the leaf `flow-isolation/<mode>`; NAT is the sibling leaf
+  // `flow-isolation-nat` (no slash, so it never matches the mode prefix).
+  const currentMode = draft.flags.find((fl) => fl.startsWith("flow-isolation/"));
   const modeValue = currentMode ? currentMode.split("/")[1] : "";
-  const natOn = draft.flags.includes("flow-isolation/nat");
+  const natOn = draft.flags.includes("flow-isolation-nat");
 
   const setMode = (mode: string) => {
     setDraft((d) => {
-      const flags = d.flags.filter((fl) => !(fl.startsWith("flow-isolation/") && fl !== "flow-isolation/nat"));
+      const flags = d.flags.filter((fl) => !fl.startsWith("flow-isolation/"));
       if (mode) flags.push(`flow-isolation/${mode}`);
       return { ...d, flags };
     });
   };
   const setNat = (on: boolean) => {
     setDraft((d) => {
-      const flags = d.flags.filter((fl) => fl !== "flow-isolation/nat");
-      if (on) flags.push("flow-isolation/nat");
+      const flags = d.flags.filter((fl) => fl !== "flow-isolation-nat");
+      if (on) flags.push("flow-isolation-nat");
       return { ...d, flags };
     });
   };

--- a/frontend/src/lib/api/qos.ts
+++ b/frontend/src/lib/api/qos.ts
@@ -179,7 +179,7 @@ export interface PolicyDraft {
   type: string;
   name: string;
   values: Record<string, string>;
-  flags: string[]; // e.g. "flow-isolation/nat", "flow-isolation/host"
+  flags: string[]; // e.g. "flow-isolation/host", "flow-isolation-nat"
   classes: ClassDraft[];
   default: ClassDraft | null;
   precedences: PrecedenceDraft[];
@@ -295,7 +295,7 @@ export function policyToDraft(p: QoSPolicy): PolicyDraft {
   }
   const flags: string[] = [];
   if (p.flow_isolation) flags.push(`flow-isolation/${p.flow_isolation}`);
-  if (p.flow_isolation_nat) flags.push("flow-isolation/nat");
+  if (p.flow_isolation_nat) flags.push("flow-isolation-nat");
   return {
     type: p.type,
     name: p.name,


### PR DESCRIPTION
The config parser treated `flow-isolation` as a nested node and searched for the mode key inside it, but VyOS stores it as a leaf value (e.g. `flow-isolation src-host`). A configured mode was therefore never read back and the UI always fell through to the default (triple-isolate).

NAT was also modeled wrong: VyOS uses a separate sibling leaf `flow-isolation-nat`, not a `nat` child of `flow-isolation`. The old code could neither read it nor write a valid value (it emitted an invalid `flow-isolation nat`).

- Parse `flow-isolation` as a leaf mode value, validated against the known isolation modes
- Read and write NAT via the `flow-isolation-nat` node on both the backend parser and the frontend policy modal/serializer