### PR TITLE
Fix IPSec PSK identities display and add S2S VTI support

### DIFF
--- a/backend/vyos_mappers/ipsec/ipsec.py
+++ b/backend/vyos_mappers/ipsec/ipsec.py
@@ -495,7 +495,7 @@ class IPSecMapper:
             for psk_name, psk_data in psk_config.items():
                 result["authentication"]["psk"][psk_name] = {
                     "name": psk_name,
-                    "id": self._normalize_to_list(psk_data.get("id")),
+                    "identities": self._normalize_to_list(psk_data.get("id")),
                     "secret": psk_data.get("secret"),
                     "secret_type": psk_data.get("secret-type"),
                     "dhcp_interface": psk_data.get("dhcp-interface"),

--- a/frontend/src/app/vpn/ipsec/page.tsx
+++ b/frontend/src/app/vpn/ipsec/page.tsx
@@ -274,6 +274,7 @@ function IPSecPageInner() {
                           <TableHead>Remote Address</TableHead>
                           <TableHead>IKE Group</TableHead>
                           <TableHead>ESP Group</TableHead>
+                          <TableHead>VTI</TableHead>
                           <TableHead>Tunnels</TableHead>
                           <TableHead>Status</TableHead>
                           {hasWrite && <TableHead className="text-right">Actions</TableHead>}
@@ -295,6 +296,13 @@ function IPSecPageInner() {
                             </TableCell>
                             <TableCell>{peer.ike_group || "-"}</TableCell>
                             <TableCell>{peer.default_esp_group || "-"}</TableCell>
+                            <TableCell>
+                              {peer.vti?.bind ? (
+                                <Badge variant="secondary" className="font-mono text-xs">{peer.vti.bind}</Badge>
+                              ) : (
+                                <span className="text-muted-foreground">-</span>
+                              )}
+                            </TableCell>
                             <TableCell><Badge variant="outline">{peer.tunnels.length}</Badge></TableCell>
                             <TableCell>
                               {peer.disabled ? (

--- a/frontend/src/components/vpn/ipsec/SiteToSiteModal.tsx
+++ b/frontend/src/components/vpn/ipsec/SiteToSiteModal.tsx
@@ -85,6 +85,12 @@ export function SiteToSiteModal({
   // Tunnels
   const [tunnels, setTunnels] = useState<TunnelRow[]>([]);
 
+  // VTI
+  const [vtiBind, setVtiBind] = useState("");
+  const [vtiEspGroup, setVtiEspGroup] = useState("");
+  const [vtiTsLocalPrefix, setVtiTsLocalPrefix] = useState("");
+  const [vtiTsRemotePrefix, setVtiTsRemotePrefix] = useState("");
+
   const [allInterfaces, setAllInterfaces] = useState<InterfaceName[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -105,15 +111,16 @@ export function SiteToSiteModal({
         setConnectionType(existingPeer.connection_type || "initiate");
         setDhcpInterface(existingPeer.dhcp_interface || "");
         setForceUdp(existingPeer.force_udp_encapsulation || false);
-        setAuthMode(existingPeer.auth_mode || "pre-shared-secret");
-        setAuthLocalId(existingPeer.auth_local_id || "");
-        setAuthRemoteId(existingPeer.auth_remote_id || "");
-        setAuthX509CaCert(existingPeer.auth_x509_ca_cert || "");
-        setAuthX509Cert(existingPeer.auth_x509_cert || "");
-        setAuthX509Passphrase(existingPeer.auth_x509_passphrase || "");
-        setAuthRsaLocalKey(existingPeer.auth_rsa_local_key || "");
-        setAuthRsaRemoteKey(existingPeer.auth_rsa_remote_key || "");
-        setAuthRsaPassphrase(existingPeer.auth_rsa_passphrase || "");
+        const auth = existingPeer.authentication;
+        setAuthMode(auth?.mode || "pre-shared-secret");
+        setAuthLocalId(auth?.local_id || "");
+        setAuthRemoteId(auth?.remote_id || "");
+        setAuthX509CaCert(auth?.x509?.ca_certificate?.[0] || "");
+        setAuthX509Cert(auth?.x509?.certificate || "");
+        setAuthX509Passphrase(auth?.x509?.passphrase || "");
+        setAuthRsaLocalKey(auth?.rsa?.local_key || "");
+        setAuthRsaRemoteKey(auth?.rsa?.remote_key || "");
+        setAuthRsaPassphrase(auth?.rsa?.passphrase || "");
         setTunnels(
           existingPeer.tunnels.map((t) => ({
             number: t.number,
@@ -123,6 +130,11 @@ export function SiteToSiteModal({
             protocol: t.protocol || "",
           }))
         );
+        const vti = existingPeer.vti;
+        setVtiBind(vti?.bind || "");
+        setVtiEspGroup(vti?.esp_group || "");
+        setVtiTsLocalPrefix((vti?.traffic_selector?.local_prefix || []).join(", "));
+        setVtiTsRemotePrefix((vti?.traffic_selector?.remote_prefix || []).join(", "));
       } else {
         setName("");
         setDescription("");
@@ -143,6 +155,10 @@ export function SiteToSiteModal({
         setAuthRsaRemoteKey("");
         setAuthRsaPassphrase("");
         setTunnels([]);
+        setVtiBind("");
+        setVtiEspGroup("");
+        setVtiTsLocalPrefix("");
+        setVtiTsRemotePrefix("");
       }
       setError(null);
     }
@@ -191,6 +207,14 @@ export function SiteToSiteModal({
         auth_rsa_remote_key: authMode === "rsa" ? (authRsaRemoteKey || undefined) : undefined,
         auth_rsa_passphrase: authMode === "rsa" ? (authRsaPassphrase || undefined) : undefined,
         force_udp_encapsulation: forceUdp || undefined,
+        vti_bind: vtiBind || undefined,
+        vti_esp_group: vtiBind ? (vtiEspGroup || undefined) : undefined,
+        vti_ts_local_prefix: vtiBind
+          ? (vtiTsLocalPrefix.split(",").map((p) => p.trim()).filter(Boolean) || undefined)
+          : undefined,
+        vti_ts_remote_prefix: vtiBind
+          ? (vtiTsRemotePrefix.split(",").map((p) => p.trim()).filter(Boolean) || undefined)
+          : undefined,
       });
 
       if (!result.success) {
@@ -239,10 +263,11 @@ export function SiteToSiteModal({
         </DialogHeader>
 
         <Tabs defaultValue="general" className="w-full">
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="auth">Authentication</TabsTrigger>
             <TabsTrigger value="tunnels">Tunnels</TabsTrigger>
+            <TabsTrigger value="vti">VTI</TabsTrigger>
           </TabsList>
 
           <TabsContent value="general" className="space-y-4 mt-4">
@@ -384,7 +409,7 @@ export function SiteToSiteModal({
             </div>
             {tunnels.length === 0 ? (
               <div className="text-center py-8 text-muted-foreground text-sm">
-                No tunnels configured. Add a tunnel or use VTI binding instead.
+                No tunnels configured. Add a tunnel or use VTI binding (see the VTI tab) instead.
               </div>
             ) : (
               tunnels.map((t) => (
@@ -431,6 +456,49 @@ export function SiteToSiteModal({
                 </div>
               ))
             )}
+          </TabsContent>
+
+          <TabsContent value="vti" className="space-y-4 mt-4">
+            <p className="text-xs text-muted-foreground">
+              Bind a Virtual Tunnel Interface (VTI) to this peer for route-based VPN. The interface
+              must already exist under Interfaces &rsaquo; VTI.
+            </p>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Bound Interface</Label>
+                <Select value={vtiBind || "_none"} onValueChange={(v) => setVtiBind(v === "_none" ? "" : v)}>
+                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_none">None</SelectItem>
+                    {allInterfaces
+                      .filter((iface) => iface.name.startsWith("vti"))
+                      .map((iface) => <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>ESP Group</Label>
+                <Select value={vtiEspGroup || "_none"} onValueChange={(v) => setVtiEspGroup(v === "_none" ? "" : v)} disabled={!vtiBind}>
+                  <SelectTrigger><SelectValue placeholder="Default" /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_none">Default</SelectItem>
+                    {espGroups.map((g) => <SelectItem key={g.name} value={g.name}>{g.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Traffic Selector — Local Prefix</Label>
+                <Input value={vtiTsLocalPrefix} onChange={(e) => setVtiTsLocalPrefix(e.target.value)} placeholder="0.0.0.0/0" disabled={!vtiBind} />
+                <p className="text-xs text-muted-foreground">Comma-separated for multiple</p>
+              </div>
+              <div className="space-y-2">
+                <Label>Traffic Selector — Remote Prefix</Label>
+                <Input value={vtiTsRemotePrefix} onChange={(e) => setVtiTsRemotePrefix(e.target.value)} placeholder="0.0.0.0/0" disabled={!vtiBind} />
+                <p className="text-xs text-muted-foreground">Comma-separated for multiple</p>
+              </div>
+            </div>
           </TabsContent>
         </Tabs>
 

--- a/frontend/src/lib/api/ipsec.ts
+++ b/frontend/src/lib/api/ipsec.ts
@@ -50,6 +50,32 @@ export interface S2STunnel {
   protocol?: string | null;
 }
 
+export interface S2SPeerAuth {
+  mode?: string | null;
+  local_id?: string | null;
+  remote_id?: string | null;
+  use_x509_id?: boolean;
+  x509?: {
+    ca_certificate?: string[];
+    certificate?: string | null;
+    passphrase?: string | null;
+  };
+  rsa?: {
+    local_key?: string | null;
+    remote_key?: string | null;
+    passphrase?: string | null;
+  };
+}
+
+export interface S2SPeerVti {
+  bind?: string | null;
+  esp_group?: string | null;
+  traffic_selector?: {
+    local_prefix?: string[];
+    remote_prefix?: string[];
+  };
+}
+
 export interface SiteToSitePeer {
   name: string;
   description?: string | null;
@@ -64,22 +90,9 @@ export interface SiteToSitePeer {
   ikev2_reauth?: boolean;
   replay_window?: string | null;
   virtual_address?: string[];
-  childless?: boolean;
-  auth_mode?: string | null;
-  auth_local_id?: string | null;
-  auth_remote_id?: string | null;
-  auth_use_x509_id?: boolean;
-  auth_x509_ca_cert?: string | null;
-  auth_x509_cert?: string | null;
-  auth_x509_passphrase?: string | null;
-  auth_rsa_local_key?: string | null;
-  auth_rsa_remote_key?: string | null;
-  auth_rsa_passphrase?: string | null;
-  auth_ppk_id?: string | null;
-  auth_ppk_required?: boolean;
+  authentication?: S2SPeerAuth;
   tunnels: S2STunnel[];
-  vti_bind?: string | null;
-  vti_esp_group?: string | null;
+  vti?: S2SPeerVti;
 }
 
 export interface RALocalUser {
@@ -361,6 +374,10 @@ class IPSecService {
     auth_rsa_remote_key?: string;
     auth_rsa_passphrase?: string;
     force_udp_encapsulation?: boolean;
+    vti_bind?: string;
+    vti_esp_group?: string;
+    vti_ts_local_prefix?: string[];
+    vti_ts_remote_prefix?: string[];
   }): Promise<VyOSResponse> {
     const ops: BatchOperation[] = [{ op: "create_s2s_peer" }];
     if (config.description) ops.push({ op: "set_s2s_peer_description", value: config.description });
@@ -384,6 +401,18 @@ class IPSecService {
     if (config.auth_rsa_remote_key) ops.push({ op: "set_s2s_peer_auth_rsa_remote_key", value: config.auth_rsa_remote_key });
     if (config.auth_rsa_passphrase) ops.push({ op: "set_s2s_peer_auth_rsa_passphrase", value: config.auth_rsa_passphrase });
     if (config.force_udp_encapsulation) ops.push({ op: "set_s2s_peer_force_udp_encapsulation" });
+    if (config.vti_bind) ops.push({ op: "set_s2s_peer_vti_bind", value: config.vti_bind });
+    if (config.vti_esp_group) ops.push({ op: "set_s2s_peer_vti_esp_group", value: config.vti_esp_group });
+    if (config.vti_ts_local_prefix) {
+      for (const prefix of config.vti_ts_local_prefix) {
+        ops.push({ op: "set_s2s_peer_vti_ts_local_prefix", value: prefix });
+      }
+    }
+    if (config.vti_ts_remote_prefix) {
+      for (const prefix of config.vti_ts_remote_prefix) {
+        ops.push({ op: "set_s2s_peer_vti_ts_remote_prefix", value: prefix });
+      }
+    }
     return this.batchConfigure(name, ops);
   }
 


### PR DESCRIPTION
PSK identities were never shown on the IPSec dashboard or in the edit modal because the backend emitted the field as `id` while the frontend reads `identities`. Align the mapper output key so the parsed identities populate correctly.

Site-to-site peers parsed VTI config (bind, esp-group, traffic selectors) and the builder already exposed the set operations, but the frontend never used them. The peer interface also declared flat `auth_*`/`vti_*` fields that never matched the backend's nested `authentication`/`vti` objects, so auth fields silently failed to prefill on edit.

- Mapper: emit PSK `identities` instead of `id`
- API types: model nested `authentication` and `vti` on the peer to match the backend response
- Modal: read auth fields from the nested shape (fixes auth prefill) and add a VTI tab to configure bind, ESP group, and traffic selectors
- Dashboard: show the bound VTI interface in the S2S peer table

Closes #378
Closes #379