### PR TITLE
Fix policy route TCP flags and state serialization and round-trip

### DIFF
--- a/backend/routers/route/route.py
+++ b/backend/routers/route/route.py
@@ -66,7 +66,9 @@ class MatchConditions(BaseModel):
     
     # Protocol
     protocol: Optional[str] = None
-    tcp_flags: Optional[str] = None
+    # TCP flags are valueless child nodes in VyOS (e.g. "syn", "not fin"),
+    # so this is a normalized list like ["syn", "not fin"], matching the firewall.
+    tcp_flags: Optional[List[str]] = None
     
     # ICMP (IPv4)
     icmp_code: Optional[str] = None
@@ -390,13 +392,23 @@ def parse_match_conditions(rule_data: dict, match: MatchConditions):
     else:
         match.protocol = protocol_value
 
-    # TCP
+    # TCP flags (valueless child nodes: {"syn": {}, "not": {"fin": {}, "rst": {}}})
     if "tcp" in rule_data:
-        tcp_flags_value = rule_data["tcp"].get("flags")
-        if isinstance(tcp_flags_value, list):
-            match.tcp_flags = tcp_flags_value[0] if tcp_flags_value else None
-        else:
-            match.tcp_flags = tcp_flags_value
+        flags_data = rule_data["tcp"].get("flags")
+        tcp_flags: List[str] = []
+        if isinstance(flags_data, dict):
+            for flag_key, flag_value in flags_data.items():
+                if flag_key == "not":
+                    if isinstance(flag_value, dict):
+                        for inverted_flag in flag_value.keys():
+                            tcp_flags.append(f"not {inverted_flag}")
+                else:
+                    tcp_flags.append(flag_key)
+        elif isinstance(flags_data, list):
+            tcp_flags = flags_data
+        elif isinstance(flags_data, str):
+            tcp_flags = [flags_data]
+        match.tcp_flags = tcp_flags if tcp_flags else None
 
     # ICMP (IPv4)
     if "icmp" in rule_data:
@@ -830,13 +842,18 @@ def _recreate_match_conditions(builder, policy_type: str, policy_name: str, rule
         if proto:
             builder.set_match_protocol(policy_type, policy_name, rule_num, proto)
 
-    # TCP
-    if "tcp" in rule_data:
-        tcp = rule_data["tcp"]
-        if "flags" in tcp:
-            flags = _get_value(tcp, "flags")
-            if flags:
-                builder.set_match_tcp_flags(policy_type, policy_name, rule_num, flags)
+    # TCP flags (valueless child nodes; recreate each flag individually)
+    if "tcp" in rule_data and "flags" in rule_data["tcp"]:
+        flags_data = rule_data["tcp"]["flags"]
+        if isinstance(flags_data, dict):
+            for flag_key, flag_value in flags_data.items():
+                if flag_key == "not" and isinstance(flag_value, dict):
+                    for inverted_flag in flag_value.keys():
+                        builder.set_match_tcp_flags(policy_type, policy_name, rule_num, f"not {inverted_flag}")
+                else:
+                    builder.set_match_tcp_flags(policy_type, policy_name, rule_num, flag_key)
+        elif isinstance(flags_data, str) and flags_data:
+            builder.set_match_tcp_flags(policy_type, policy_name, rule_num, flags_data)
 
     # ICMP
     if "icmp" in rule_data:

--- a/backend/vyos_builders/route/route_batch_builder.py
+++ b/backend/vyos_builders/route/route_batch_builder.py
@@ -223,9 +223,14 @@ class RouteBatchBuilder:
         return self.add_set(path)
 
     def set_match_tcp_flags(self, policy_type: str, name: str, rule: str, flags: str) -> "RouteBatchBuilder":
-        """Match TCP flags."""
+        """Match a TCP flag ("syn" or "not syn"). Call once per flag."""
         path = self.mappers[self.mapper_key].get_match_tcp_flags(policy_type, name, rule, flags)
         return self.add_set(path)
+
+    def delete_match_tcp_flags(self, policy_type: str, name: str, rule: str) -> "RouteBatchBuilder":
+        """Delete all matched TCP flags for a rule."""
+        path = self.mappers[self.mapper_key].get_match_tcp_flags_delete(policy_type, name, rule)
+        return self.add_delete(path)
 
     # ========================================================================
     # Match - ICMP (IPv4)
@@ -319,6 +324,11 @@ class RouteBatchBuilder:
         """Match connection state."""
         path = self.mappers[self.mapper_key].get_match_state(policy_type, name, rule, state)
         return self.add_set(path)
+
+    def delete_match_state(self, policy_type: str, name: str, rule: str) -> "RouteBatchBuilder":
+        """Delete all matched connection states for a rule."""
+        path = self.mappers[self.mapper_key].get_match_state_delete(policy_type, name, rule)
+        return self.add_delete(path)
 
     def set_match_ipsec(self, policy_type: str, name: str, rule: str, value: str) -> "RouteBatchBuilder":
         """Match IPsec."""

--- a/backend/vyos_mappers/route/route.py
+++ b/backend/vyos_mappers/route/route.py
@@ -144,9 +144,18 @@ class RouteMapper(BaseFeatureMapper):
         """Match protocol."""
         return ["policy", policy_type, name, "rule", rule, "protocol", protocol]
 
-    def get_match_tcp_flags(self, policy_type: str, name: str, rule: str, flags: str) -> List[str]:
-        """Match TCP flags."""
-        return ["policy", policy_type, name, "rule", rule, "tcp", "flags", flags]
+    def get_match_tcp_flags(self, policy_type: str, name: str, rule: str, flag: str) -> List[str]:
+        """Match a TCP flag.
+
+        Flags are valueless child nodes, so ``flag`` is a single flag name
+        ("syn") or an inverted flag ("not syn"). VyOS expects:
+        set policy <type> <name> rule <n> tcp flags [not] <flag>
+        """
+        return ["policy", policy_type, name, "rule", rule, "tcp", "flags"] + flag.split()
+
+    def get_match_tcp_flags_delete(self, policy_type: str, name: str, rule: str) -> List[str]:
+        """Delete all matched TCP flags for a rule."""
+        return ["policy", policy_type, name, "rule", rule, "tcp", "flags"]
 
     # ========================================================================
     # Match Conditions - ICMP (IPv4)
@@ -227,6 +236,10 @@ class RouteMapper(BaseFeatureMapper):
     def get_match_state(self, policy_type: str, name: str, rule: str, state: str) -> List[str]:
         """Match connection state."""
         return ["policy", policy_type, name, "rule", rule, "state", state]
+
+    def get_match_state_delete(self, policy_type: str, name: str, rule: str) -> List[str]:
+        """Delete all matched connection states for a rule."""
+        return ["policy", policy_type, name, "rule", rule, "state"]
 
     def get_match_ipsec(self, policy_type: str, name: str, rule: str, value: str) -> List[str]:
         """Match IPsec (match-ipsec or match-none)."""

--- a/frontend/src/components/policies/CreateRouteRuleModal.tsx
+++ b/frontend/src/components/policies/CreateRouteRuleModal.tsx
@@ -270,7 +270,7 @@ export function CreateRouteRuleModal({
 
       // Match - Protocol
       if (protocol && protocol !== "all") match.protocol = protocol;
-      if (tcpFlags.length > 0) match.tcp_flags = tcpFlags.join(",");
+      if (tcpFlags.length > 0) match.tcp_flags = tcpFlags;
 
       // Match - ICMP
       if (policyType === "route") {

--- a/frontend/src/components/policies/EditRouteRuleModal.tsx
+++ b/frontend/src/components/policies/EditRouteRuleModal.tsx
@@ -339,7 +339,7 @@ export function EditRouteRuleModal({
 
     // Match - Protocol
     setProtocol(match.protocol || "");
-    setTcpFlags(match.tcp_flags ? match.tcp_flags.split(",") : []);
+    setTcpFlags(match.tcp_flags ?? []);
 
     // Match - ICMP
     setIcmpType(match.icmp_type || "");
@@ -483,7 +483,7 @@ export function EditRouteRuleModal({
 
       // Match - Protocol
       if (protocol && protocol !== "all") match.protocol = protocol;
-      if (tcpFlags.length > 0) match.tcp_flags = tcpFlags.join(",");
+      if (tcpFlags.length > 0) match.tcp_flags = tcpFlags;
 
       // Match - ICMP
       if (policyType === "route") {
@@ -561,6 +561,7 @@ export function EditRouteRuleModal({
         log: log ? "true" : undefined,
         match: Object.keys(match).length > 0 ? match : undefined,
         set: Object.keys(set).length > 0 ? set : undefined,
+        originalMatch: rule.match,
       });
 
       handleClose();

--- a/frontend/src/lib/api/route.ts
+++ b/frontend/src/lib/api/route.ts
@@ -30,7 +30,7 @@ export interface MatchConditions {
   
   // Protocol
   protocol?: string | null;
-  tcp_flags?: string | null;
+  tcp_flags?: string[] | null; // e.g. ["syn", "not fin"]
   
   // ICMP (IPv4)
   icmp_code?: string | null;
@@ -344,6 +344,9 @@ class RouteService {
       log?: string;
       match?: Partial<MatchConditions>;
       set?: Partial<SetActions>;
+      // The rule's current match conditions, used to clean up additive nodes
+      // (e.g. TCP flags) that delete_match does not cover.
+      originalMatch?: Partial<MatchConditions>;
     }
   ): Promise<VyOSResponse> {
     const operations: RouteBatchOperation[] = [];
@@ -351,6 +354,18 @@ class RouteService {
     // Delete existing match and set (clean slate approach)
     operations.push({ op: "delete_match" });
     operations.push({ op: "delete_set" });
+
+    // delete_match only clears source/destination, so additive nodes that aren't
+    // overwritten by a later set must be cleared explicitly. These are valueless
+    // child nodes (e.g. TCP flags, connection states), so a removed entry would
+    // otherwise linger. Only delete when the node actually exists, to avoid
+    // VyOS 1.5 erroring on a non-existent path.
+    if (config.originalMatch?.tcp_flags && config.originalMatch.tcp_flags.length > 0) {
+      operations.push({ op: "delete_match_tcp_flags" });
+    }
+    if (config.originalMatch?.state) {
+      operations.push({ op: "delete_match_state" });
+    }
 
     // Basic config - Description
     if (config.description !== undefined) {
@@ -442,7 +457,11 @@ class RouteService {
     
     // Protocol
     if (match.protocol) operations.push({ op: "set_match_protocol", value: match.protocol });
-    if (match.tcp_flags) operations.push({ op: "set_match_tcp_flags", value: match.tcp_flags });
+    if (match.tcp_flags) {
+      for (const flag of match.tcp_flags) {
+        if (flag) operations.push({ op: "set_match_tcp_flags", value: flag });
+      }
+    }
     
     // ICMP (IPv4)
     if (match.icmp_code) operations.push({ op: "set_match_icmp_code", value: match.icmp_code });


### PR DESCRIPTION
VyOS returns policy route tcp flags as valueless child nodes (e.g. {"syn": {}, "not": {"fin": {}}}), but the route code modeled tcp_flags as a plain string. That produced a Pydantic serialization warning on read and built an invalid "tcp flags syn,ack" path on write.

- Normalize tcp_flags to a list (["syn", "not fin"]) on parse/recreate
- Split flags into path components and add delete paths in mapper/builder
- Frontend types and modals updated to arrays; emit one op per flag
- Add guarded deletes for tcp flags and connection state on edit so removed entries no longer linger (only when the node exists)

Closes #382 