### PR TITLE
Add OpenVPN status dashboard card via the shared SSE stream

### DIFF
--- a/backend/openvpn_status.py
+++ b/backend/openvpn_status.py
@@ -1,0 +1,117 @@
+"""OpenVPN live status for the dashboard stream.
+
+Parses the structured ``ShowOpenvpn`` GraphQL op (one per mode: server / client /
+site_to_site) into per-tunnel status with connected clients, and builds the
+GraphQL alias fields the dashboard broadcaster folds into its shared query.
+
+Note: the op-mode reports ``rx_bytes`` / ``tx_bytes`` as human-formatted strings
+(e.g. "2.8 MB"), not raw integers — so this is connection/status data, not a live
+bandwidth source.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+# GraphQL alias -> ShowOpenvpn mode (the mode is an enum, so it's unquoted).
+_OPENVPN_MODES = [
+    ("OpenvpnServer", "server"),
+    ("OpenvpnClient", "client"),
+    ("OpenvpnS2S", "site_to_site"),
+]
+
+
+class OpenVpnClient(BaseModel):
+    name: Optional[str] = None
+    remote_host: Optional[str] = None
+    remote_port: Optional[str] = None
+    tunnel: Optional[str] = None       # VPN-assigned IP
+    rx_bytes: Optional[str] = None     # human-formatted, e.g. "2.8 MB"
+    tx_bytes: Optional[str] = None
+    online_since: Optional[str] = None
+
+
+class OpenVpnTunnel(BaseModel):
+    mode: str                          # server / client / site_to_site
+    interface: str
+    local_host: Optional[str] = None
+    local_port: Optional[str] = None
+    state: Optional[str] = None        # UP / DOWN
+    description: Optional[str] = None
+    date: Optional[str] = None         # status-file timestamp
+    configured_clients: List[str] = []
+    clients: List[OpenVpnClient] = []
+
+
+def openvpn_configured(full_config) -> bool:
+    """True when any OpenVPN interface is configured (gates the dashboard fetch)."""
+    ifaces = (full_config or {}).get("interfaces", {}) or {}
+    return bool(ifaces.get("openvpn"))
+
+
+def openvpn_gql_fields(key_literal: str) -> List[str]:
+    """GraphQL alias fields fetching OpenVPN status for all three modes.
+
+    ``key_literal`` must be a JSON-encoded API key (``json.dumps(key)``).
+    """
+    return [
+        f"{alias}: ShowOpenvpn(data: {{key: {key_literal}, mode: {mode}}}) {{ success data {{ result }} }}"
+        for alias, mode in _OPENVPN_MODES
+    ]
+
+
+def _op_result(data: dict, alias: str) -> list:
+    """Extract a ShowOpenvpn op's list result, or [] (no tunnels of that mode)."""
+    node = (data or {}).get(alias)
+    if not isinstance(node, dict) or not node.get("success"):
+        return []
+    inner = node.get("data")
+    if isinstance(inner, dict) and isinstance(inner.get("result"), list):
+        return inner["result"]
+    return []
+
+
+def _parse_tunnels(result: list, mode_label: str) -> List[OpenVpnTunnel]:
+    tunnels: List[OpenVpnTunnel] = []
+    if not isinstance(result, list):
+        return tunnels
+    for t in result:
+        if not isinstance(t, dict):
+            continue
+        clients = [
+            OpenVpnClient(
+                name=c.get("name"),
+                remote_host=c.get("remote_host"),
+                remote_port=c.get("remote_port"),
+                tunnel=c.get("tunnel"),
+                rx_bytes=c.get("rx_bytes"),
+                tx_bytes=c.get("tx_bytes"),
+                online_since=c.get("online_since"),
+            )
+            for c in (t.get("clients") or [])
+            if isinstance(c, dict)
+        ]
+        tunnels.append(OpenVpnTunnel(
+            mode=t.get("mode") or mode_label,
+            interface=t.get("intf") or "",
+            local_host=t.get("local_host") or None,
+            local_port=t.get("local_port") or None,
+            state=t.get("state") or None,
+            description=t.get("description") or None,
+            date=t.get("date") or None,
+            configured_clients=t.get("configured_clients") or [],
+            clients=clients,
+        ))
+    return tunnels
+
+
+def build_openvpn_status(gql: dict) -> dict:
+    """Build the ``openvpn-status`` SSE payload from the shared GraphQL result."""
+    servers = _parse_tunnels(_op_result(gql, "OpenvpnServer"), "server")
+    clients = _parse_tunnels(_op_result(gql, "OpenvpnClient"), "client")
+    site_to_site = _parse_tunnels(_op_result(gql, "OpenvpnS2S"), "site_to_site")
+    return {
+        "servers": [t.dict() for t in servers],
+        "clients": [t.dict() for t in clients],
+        "site_to_site": [t.dict() for t in site_to_site],
+    }

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -29,6 +29,7 @@ from routers.qos.qos import (
     parse_shaper_qos_json,
     parse_cake_qos_json,
 )
+from openvpn_status import openvpn_configured, openvpn_gql_fields, build_openvpn_status
 import logging
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ def _wg_alias(iface_name: str) -> str:
     return f"WGStatus_{safe}"
 
 
-def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None) -> dict:
+def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> dict:
     """
     Build the JSON body for the slow dashboard GraphQL query.
 
@@ -132,6 +133,8 @@ def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Opti
         f"InterfaceCounters: ShowCountersInterfaces(data: {{key: {k}}}) {{ data {{ result }} }}",
     ]
     fields += qos_gql_fields(k, cake_targets or [])
+    if include_openvpn:
+        fields += openvpn_gql_fields(k)
     if include_wireguard:
         fields.append(
             f'WireGuardConfig: ShowConfig(data: {{key: {k}, path: ["interfaces", "wireguard"]}}) {{ data {{ result }} }}'
@@ -150,7 +153,7 @@ def _build_gql_wg_status_payload(api_key: str, iface_names: List[str]) -> dict:
     return {"query": "{ " + " ".join(fields) + " }"}
 
 
-async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None) -> Optional[dict]:
+async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> Optional[dict]:
     """
     Fire a single GraphQL POST for the full dashboard data.
 
@@ -159,7 +162,7 @@ async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_target
     api_key = str(service.config.apikey)
     url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
     verify = service.config.verify
-    payload = _build_gql_payload(api_key, include_wireguard, cake_targets)
+    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_openvpn)
 
     try:
         async with httpx.AsyncClient(verify=verify, timeout=15.0) as client:
@@ -179,25 +182,28 @@ async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_target
         return None
 
 
-def _build_fast_gql_payload(api_key: str, cake_targets: Optional[list] = None) -> dict:
-    """Build the fast GraphQL payload: interface counters + (gated) QoS stats.
+def _build_fast_gql_payload(api_key: str, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> dict:
+    """Build the fast GraphQL payload: interface counters + (gated) QoS + OpenVPN.
 
     QoS rides this 3 s call so its live bandwidth stays smooth. ``ShowShaperQos``
     is always included (it returns ``success:false`` when nothing is applied, which
     can't break the other fields); per-cake ``ShowCakeQos`` aliases are added only
-    for the cake interfaces discovered from config — none means no cake fields.
+    for the cake interfaces discovered from config. OpenVPN status (3 modes) is
+    added only when OpenVPN is configured.
     """
     k = json.dumps(api_key)
     fields = [f"InterfaceCounters: ShowCountersInterfaces(data: {{key: {k}}}) {{ data {{ result }} }}"]
     fields += qos_gql_fields(k, cake_targets or [])
+    if include_openvpn:
+        fields += openvpn_gql_fields(k)
     return {"query": "{ " + " ".join(fields) + " }"}
 
 
-async def _fetch_graphql_fast(service, cake_targets: Optional[list] = None) -> Optional[dict]:
-    """Fire a minimal GraphQL POST for interface counters + QoS stats."""
+async def _fetch_graphql_fast(service, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> Optional[dict]:
+    """Fire a minimal GraphQL POST for interface counters + QoS + OpenVPN status."""
     api_key = str(service.config.apikey)
     url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
-    payload = _build_fast_gql_payload(api_key, cake_targets)
+    payload = _build_fast_gql_payload(api_key, cake_targets, include_openvpn)
     try:
         async with httpx.AsyncClient(verify=service.config.verify, timeout=15.0) as client:
             resp = await client.post(url, json=payload, auth=("vyos", api_key))
@@ -903,6 +909,8 @@ class DeviceDataBroadcaster:
         # Cake interfaces (interface, policy) discovered from config; refreshed on
         # the slow cycle and used to build per-cake GraphQL aliases each cycle.
         self._cached_cake_targets: list = []
+        # Whether OpenVPN is configured (gates the ShowOpenvpn fetch).
+        self._openvpn_configured: bool = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -1036,14 +1044,22 @@ class DeviceDataBroadcaster:
             logger.exception("Broadcaster: qos-stats parse error")
             self._push_to_all({"type": "error", "data": {"channel": "qos-stats", "message": "Parse failed"}})
 
-    async def _refresh_cake_targets(self) -> None:
-        """Refresh the cached cake-interface list from the (cached) config."""
+    async def _refresh_config_state(self) -> None:
+        """Refresh config-derived gates (cake interfaces, OpenVPN presence)."""
         try:
-            self._cached_cake_targets = await run_in_threadpool(
-                lambda: find_cake_targets(self._service.get_full_config(refresh=False))
-            )
+            cfg = await run_in_threadpool(self._service.get_full_config, refresh=False)
+            self._cached_cake_targets = find_cake_targets(cfg)
+            self._openvpn_configured = openvpn_configured(cfg)
         except Exception:
-            logger.exception("Broadcaster: cake-target refresh error")
+            logger.exception("Broadcaster: config-state refresh error")
+
+    def _broadcast_openvpn(self, gql: dict) -> None:
+        """Parse OpenVPN status from the shared GraphQL result and push an event."""
+        try:
+            self._push_to_all({"type": "openvpn-status", "data": build_openvpn_status(gql)})
+        except Exception:
+            logger.exception("Broadcaster: openvpn-status parse error")
+            self._push_to_all({"type": "error", "data": {"channel": "openvpn-status", "message": "Parse failed"}})
 
     def _on_task_done(self, fut: asyncio.Future) -> None:
         """Clean up if _run() exits unexpectedly."""
@@ -1065,25 +1081,31 @@ class DeviceDataBroadcaster:
         try:
             while self._subscribers:
                 if cycle % _SLOW_EVERY == 0:
-                    # Refresh which interfaces have cake before building the query.
-                    await self._refresh_cake_targets()
+                    # Refresh config-derived gates before building the query.
+                    await self._refresh_config_state()
                     targets = self._cached_cake_targets
-                    # Full query: counters + system info + QoS + WireGuard config
-                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets)
+                    ovpn = self._openvpn_configured
+                    # Full query: counters + system info + QoS + OpenVPN + WireGuard
+                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_openvpn=ovpn)
                     if gql is not None:
                         self._broadcast_interface_counters(gql)
                         self._broadcast_system_info(gql)
                         self._handle_wg_cycle(gql)
                         self._broadcast_qos(gql, targets)
+                        if ovpn:
+                            self._broadcast_openvpn(gql)
                     else:
                         self._push_to_all({"type": "error", "data": {"channel": "all", "message": "GraphQL fetch failed"}})
                 else:
-                    # Fast query: interface counters + QoS stats
+                    # Fast query: interface counters + QoS + OpenVPN status
                     targets = self._cached_cake_targets
-                    gql = await _fetch_graphql_fast(self._service, cake_targets=targets)
+                    ovpn = self._openvpn_configured
+                    gql = await _fetch_graphql_fast(self._service, cake_targets=targets, include_openvpn=ovpn)
                     if gql is not None:
                         self._broadcast_interface_counters(gql)
                         self._broadcast_qos(gql, targets)
+                        if ovpn:
+                            self._broadcast_openvpn(gql)
                     else:
                         self._push_to_all({"type": "error", "data": {"channel": "interface-counters", "message": "GraphQL fast fetch failed"}})
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,7 @@ import { SystemInfoCard } from "@/components/dashboard/SystemInfoCard";
 import { WireGuardPeersCard } from "@/components/dashboard/WireGuardPeersCard";
 import { NetworkSpeedCard } from "@/components/dashboard/NetworkSpeedCard";
 import { QoSStatsCard } from "@/components/dashboard/QoSStatsCard";
+import { OpenVpnCard } from "@/components/dashboard/OpenVpnCard";
 import { AddCardModal } from "@/components/dashboard/AddCardModal";
 import {
   DndContext,
@@ -359,6 +360,9 @@ export default function Home() {
     if (cardType === "qos-statistics") {
       defaultSpan = 2;
     }
+    if (cardType === "openvpn-status") {
+      defaultSpan = 2;
+    }
     // system-info defaults to 1 column (already set above)
 
     // New cards always start at column 0
@@ -482,6 +486,8 @@ export default function Home() {
         return <NetworkSpeedCard {...baseProps} />;
       case "qos-statistics":
         return <QoSStatsCard {...baseProps} />;
+      case "openvpn-status":
+        return <OpenVpnCard {...baseProps} />;
       default:
         return null;
     }

--- a/frontend/src/components/dashboard/AddCardModal.tsx
+++ b/frontend/src/components/dashboard/AddCardModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Network, Plus, Server, Shield, Lock, TrendingUp, Gauge } from "lucide-react";
+import { Network, Plus, Server, Shield, Lock, TrendingUp, Gauge, ShieldCheck } from "lucide-react";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 
@@ -55,6 +55,13 @@ const AVAILABLE_CARDS: AvailableCard[] = [
     description: "Live per-class shaper bandwidth, drops and policy effectiveness for QoS-enabled interfaces",
     icon: Gauge,
     requiredPermission: FeatureGroup.QOS,
+  },
+  {
+    type: "openvpn-status",
+    name: "OpenVPN",
+    description: "Live status of OpenVPN servers, clients and site-to-site tunnels with connected client details",
+    icon: ShieldCheck,
+    requiredPermission: FeatureGroup.OPENVPN,
   },
 ];
 

--- a/frontend/src/components/dashboard/OpenVpnCard.tsx
+++ b/frontend/src/components/dashboard/OpenVpnCard.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  X,
+  ShieldCheck,
+  RefreshCw,
+  Settings,
+  ArrowDown,
+  ArrowUp,
+  Clock,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { OpenVpnStatus, OpenVpnTunnel } from "@/lib/api/openvpn";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
+
+interface OpenVpnCardProps {
+  onRemove?: () => void;
+  span?: number;
+  onSpanChange?: (newSpan: number) => void;
+  config?: Record<string, unknown>;
+  onConfigChange?: (config: Record<string, unknown>) => void;
+}
+
+function StateBadge({ state }: { state: string | null }) {
+  const up = (state ?? "").toUpperCase() === "UP";
+  return (
+    <Badge
+      variant="outline"
+      className={`text-[10px] h-4 px-1 font-medium ${
+        up
+          ? "border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
+          : "border-muted-foreground/30 text-muted-foreground"
+      }`}
+    >
+      {state ?? "—"}
+    </Badge>
+  );
+}
+
+function ClientRow({ client }: { client: OpenVpnTunnel["clients"][number] }) {
+  const remote = client.remote_host
+    ? `${client.remote_host}${client.remote_port ? `:${client.remote_port}` : ""}`
+    : null;
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 pl-9 text-xs border-b last:border-0 bg-muted/5">
+      <span className="font-mono font-medium truncate w-24 shrink-0" title={client.name ?? undefined}>
+        {client.name || "—"}
+      </span>
+      <div className="flex-1 min-w-0 text-muted-foreground truncate">
+        {remote && <span className="font-mono">{remote}</span>}
+        {client.tunnel && client.tunnel !== "N/A" && (
+          <span className="font-mono"> → {client.tunnel}</span>
+        )}
+      </div>
+      <span className="flex items-center gap-0.5 shrink-0 tabular-nums" title="received">
+        <ArrowDown className="h-3 w-3 text-blue-500" />
+        {client.rx_bytes || "0"}
+      </span>
+      <span className="flex items-center gap-0.5 shrink-0 tabular-nums" title="sent">
+        <ArrowUp className="h-3 w-3 text-orange-500" />
+        {client.tx_bytes || "0"}
+      </span>
+    </div>
+  );
+}
+
+function TunnelGroup({ title, tunnels }: { title: string; tunnels: OpenVpnTunnel[] }) {
+  if (tunnels.length === 0) return null;
+  return (
+    <div className="border-b last:border-0">
+      <div className="px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground bg-muted/20 border-b">
+        {title}
+      </div>
+      {tunnels.map((t) => {
+        const localEndpoint = `${t.local_host || ""}${t.local_port ? `:${t.local_port}` : ""}`;
+        return (
+          <div key={`${t.mode}-${t.interface}`}>
+            <div className="flex items-center gap-2 px-3 py-2 text-sm border-b last:border-0">
+              <span className="font-mono font-medium shrink-0">{t.interface}</span>
+              <StateBadge state={t.state} />
+              {localEndpoint && <span className="text-xs text-muted-foreground font-mono shrink-0">{localEndpoint}</span>}
+              {t.description && (
+                <span className="text-xs text-muted-foreground truncate" title={t.description}>
+                  {t.description}
+                </span>
+              )}
+              <div className="flex-1" />
+              {t.mode === "server" && (
+                <span className="text-[11px] text-muted-foreground shrink-0">
+                  {t.clients.length} {t.clients.length === 1 ? "client" : "clients"}
+                </span>
+              )}
+              {t.mode !== "server" && t.clients[0]?.online_since && t.clients[0].online_since !== "N/A" && (
+                <span className="flex items-center gap-1 text-[11px] text-muted-foreground shrink-0">
+                  <Clock className="h-3 w-3" />
+                  {t.clients[0].online_since}
+                </span>
+              )}
+            </div>
+            {t.clients.map((c, i) => (
+              <ClientRow key={`${t.interface}-${c.name ?? i}-${i}`} client={c} />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function OpenVpnCard({ onRemove, span = 1, onSpanChange }: OpenVpnCardProps) {
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const { status: sseStatus, data: sseData } = useDashboardData();
+  // Snapshot the stream so "Paused" freezes the displayed status.
+  const [snapshot, setSnapshot] = useState<OpenVpnStatus | null>(null);
+  useEffect(() => {
+    if (autoRefresh && sseData.openvpnStatus) setSnapshot(sseData.openvpnStatus);
+  }, [autoRefresh, sseData.openvpnStatus]);
+
+  const status = snapshot;
+  const loading = status === null;
+  const total = status
+    ? status.servers.length + status.clients.length + status.site_to_site.length
+    : 0;
+
+  return (
+    <Card className="flex flex-col h-[520px]">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5 text-primary" />
+          <CardTitle className="text-lg font-medium">OpenVPN</CardTitle>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant={autoRefresh ? "default" : "outline"}
+            size="sm"
+            onClick={() => setAutoRefresh((v) => !v)}
+            title={autoRefresh ? `Live via dashboard stream (${sseStatus})` : "Paused"}
+          >
+            <RefreshCw className={`h-4 w-4 mr-1 ${autoRefresh && sseStatus === "connected" ? "animate-spin" : ""}`} />
+            {autoRefresh ? "Live" : "Paused"}
+          </Button>
+          {onSpanChange && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <Settings className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {([1, 2, 3] as const).map((n) => (
+                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
+                    <div className="flex items-center justify-between w-full">
+                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
+                      {span === n && <span className="ml-2 text-primary">✓</span>}
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          {onRemove && (
+            <Button variant="ghost" size="sm" onClick={onRemove}>
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col flex-1 min-h-0 p-0">
+        {loading ? (
+          <div className="px-4 py-6 text-center text-muted-foreground text-sm">Loading…</div>
+        ) : total === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            No OpenVPN tunnels configured.
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            <TunnelGroup title="Servers" tunnels={status!.servers} />
+            <TunnelGroup title="Clients" tunnels={status!.clients} />
+            <TunnelGroup title="Site-to-Site" tunnels={status!.site_to_site} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useDashboardSSE.ts
+++ b/frontend/src/hooks/useDashboardSSE.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { InterfaceCounter } from "@/lib/api/show";
 import { QoSStatsResponse } from "@/lib/api/qos";
+import { OpenVpnStatus } from "@/lib/api/openvpn";
 
 // ============================================================================
 // Types
@@ -93,6 +94,7 @@ export interface DashboardSSEData {
   systemInfo: SystemInfoData | null;
   wireguardPeers: WireGuardPeersData | null;
   qosStats: QoSStatsResponse | null;
+  openvpnStatus: OpenVpnStatus | null;
 }
 
 export interface DashboardSSEState {
@@ -107,7 +109,7 @@ export interface DashboardSSEState {
 
 export function useDashboardSSE(): DashboardSSEState {
   const [status, setStatus] = useState<SSEStatus>("disconnected");
-  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null });
+  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null });
   const [error, setError] = useState<string | null>(null);
   const esRef = useRef<EventSource | null>(null);
 
@@ -153,6 +155,15 @@ export function useDashboardSSE(): DashboardSSEState {
       try {
         const payload = JSON.parse(event.data) as QoSStatsResponse;
         setData((prev) => ({ ...prev, qosStats: payload }));
+      } catch {
+        // Ignore malformed payloads
+      }
+    });
+
+    es.addEventListener("openvpn-status", (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as OpenVpnStatus;
+        setData((prev) => ({ ...prev, openvpnStatus: payload }));
       } catch {
         // Ignore malformed payloads
       }

--- a/frontend/src/lib/api/openvpn.ts
+++ b/frontend/src/lib/api/openvpn.ts
@@ -184,6 +184,37 @@ export interface VyOSResponse {
   error?: string | null;
 }
 
+// ----- Live status (from ShowOpenvpn; delivered over the dashboard SSE stream) -----
+// rx_bytes/tx_bytes are pre-formatted strings (e.g. "2.8 MB"), not raw bytes.
+
+export interface OpenVpnStatusClient {
+  name: string | null;
+  remote_host: string | null;
+  remote_port: string | null;
+  tunnel: string | null;        // VPN-assigned IP
+  rx_bytes: string | null;
+  tx_bytes: string | null;
+  online_since: string | null;
+}
+
+export interface OpenVpnTunnel {
+  mode: string;                 // server / client / site_to_site
+  interface: string;
+  local_host: string | null;
+  local_port: string | null;
+  state: string | null;         // UP / DOWN
+  description: string | null;
+  date: string | null;
+  configured_clients: string[];
+  clients: OpenVpnStatusClient[];
+}
+
+export interface OpenVpnStatus {
+  servers: OpenVpnTunnel[];
+  clients: OpenVpnTunnel[];
+  site_to_site: OpenVpnTunnel[];
+}
+
 export interface OpenvpnBatchOperation {
   op: string;
   value?: string;


### PR DESCRIPTION
A dashboard card showing live OpenVPN tunnel status, fetched on the same GraphQL call as the interface counters (no separate poll).

Backend:
- openvpn_status.py: parse the structured ShowOpenvpn op (server / client / site_to_site modes) into per-tunnel status with connected clients, build the GraphQL alias fields, and gate on OpenVPN being configured.
- DeviceDataBroadcaster folds the 3 ShowOpenvpn ops into its existing GraphQL query (gated on config, like cake) and pushes an openvpn-status SSE event. An unconfigured/empty mode returns [] without affecting the other fields.

Frontend:
- OpenVpnCard reads the dashboard stream and groups tunnels by mode (Servers / Clients / Site-to-Site); servers expand to connected clients with name, remote, VPN IP and rx/tx totals. Registered in Add Card (gated by FeatureGroup.OPENVPN) and the page card renderer.
- Live status types + SSE handling for the openvpn-status event.

Note: rx/tx come from op-mode as pre-formatted strings, so the card shows transfer totals rather than a live-bandwidth graph.