### PR TITLE
Add OpenVPN server client config (.ovpn) export

### DIFF
--- a/backend/routers/interfaces/openvpn.py
+++ b/backend/routers/interfaces/openvpn.py
@@ -5,10 +5,13 @@ All OpenVPN interface endpoints for VyOS configuration.
 OpenVPN provides secure tunneling with site-to-site, client, and server modes.
 """
 
+import base64
 import inspect
 import logging
 from typing import Dict, List, Optional, Any
 
+from cryptography import x509
+from cryptography.x509.oid import NameOID
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field, ConfigDict
 from starlette.concurrency import run_in_threadpool
@@ -245,6 +248,37 @@ class OpenvpnInterfacesConfigResponse(BaseModel):
     total: int = 0
 
 
+class OpenvpnClientExportRequest(BaseModel):
+    interface: str = Field(..., description="Server-mode OpenVPN interface (e.g. vtun0)")
+    ca: Optional[str] = Field(None, description="PKI CA name; defaults to the server's tls ca-certificate")
+    certificate: str = Field(..., description="PKI certificate name issued to the client")
+    key: Optional[str] = Field(None, description="PKI certificate key name; defaults to the certificate name")
+    remote_host: Optional[str] = Field(None, description="Public address/hostname clients connect to (fills the remote line)")
+
+
+class OpenvpnClientExportResponse(BaseModel):
+    success: bool
+    filename: Optional[str] = None
+    config: Optional[str] = None
+    error: Optional[str] = None
+
+
+class OpenvpnExportCertificate(BaseModel):
+    name: str
+    cn: Optional[str] = None
+
+
+class OpenvpnExportOptions(BaseModel):
+    """PKI material available for building a client export, with decoded CNs.
+
+    The certificate CN is what matches a server's per-client (`server client
+    <name>`) settings, so the UI can map an assigned client to a certificate.
+    """
+
+    cas: List[str] = Field(default_factory=list)
+    certificates: List[OpenvpnExportCertificate] = Field(default_factory=list)
+
+
 # ============================================================================
 # Endpoints
 # ============================================================================
@@ -367,4 +401,163 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
         )
     except Exception:
         logger.exception("Unhandled error in batch_configure")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ============================================================================
+# Client config export (operational `generate openvpn client-config`)
+# ============================================================================
+
+
+def _certificate_cn(cert_b64: Optional[str]) -> Optional[str]:
+    """Decode the Common Name from a base64 DER certificate (as stored in PKI).
+
+    Returns None for missing/unissued (e.g. ACME) or unparseable certificates.
+    """
+    if not cert_b64:
+        return None
+    try:
+        der = base64.b64decode(cert_b64 + "=" * (-len(cert_b64) % 4))
+        cert = x509.load_der_x509_certificate(der)
+        attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        return attrs[0].value if attrs else None
+    except Exception:
+        logger.warning("Could not decode certificate CN", exc_info=True)
+        return None
+
+
+@router.get("/export-options", response_model=OpenvpnExportOptions)
+async def get_export_options(http_request: Request) -> OpenvpnExportOptions:
+    """List PKI CAs and certificates (with decoded CNs) for the export dialog."""
+    await require_read_permission(http_request, FeatureGroup.OPENVPN)
+    service = get_session_vyos_service(http_request)
+    full_config = await run_in_threadpool(service.get_full_config)
+
+    pki = full_config.get("pki", {}) or {}
+    cas = sorted((pki.get("ca", {}) or {}).keys())
+    certificates = [
+        OpenvpnExportCertificate(name=name, cn=_certificate_cn((data or {}).get("certificate")))
+        for name, data in (pki.get("certificate", {}) or {}).items()
+    ]
+    certificates.sort(key=lambda c: c.name)
+    return OpenvpnExportOptions(cas=cas, certificates=certificates)
+
+
+def _apply_remote_host(ovpn: str, remote_host: str) -> str:
+    """Rewrite the `remote <host> <port>` line with the user-supplied host.
+
+    VyOS only fills a real address when the server has `local-host` set;
+    otherwise it emits a `x.x.x.x` placeholder. The port (and any trailing
+    tokens) are preserved.
+    """
+    lines = ovpn.splitlines()
+    for idx, line in enumerate(lines):
+        if line.strip().startswith("remote "):
+            parts = line.split()
+            rest = parts[2:]  # everything after the placeholder host (port, etc.)
+            lines[idx] = " ".join(["remote", remote_host, *rest])
+            break
+    return "\n".join(lines) + ("\n" if ovpn.endswith("\n") else "")
+
+
+def _build_tls_key_block(secret_hex: str, *, is_crypt: bool) -> str:
+    """Build a <tls-auth>/<tls-crypt> inline block from a PKI shared-secret.
+
+    VyOS stores the static key as a single hex line wrapped in the standard
+    OpenVPN Static key V1 markers (matching the on-router .key file). tls-auth
+    additionally needs `key-direction 1` on the client side (server uses 0).
+    """
+    tag = "tls-crypt" if is_crypt else "tls-auth"
+    block = (
+        f"<{tag}>\n"
+        "-----BEGIN OpenVPN Static key V1-----\n"
+        f"{secret_hex}\n"
+        "-----END OpenVPN Static key V1-----\n"
+        f"</{tag}>\n"
+    )
+    if not is_crypt:
+        block += "key-direction 1\n"
+    return block
+
+
+@router.post("/client-export", response_model=OpenvpnClientExportResponse)
+async def client_export(http_request: Request, request: OpenvpnClientExportRequest) -> OpenvpnClientExportResponse:
+    """Generate a ready-to-use client .ovpn for a server-mode OpenVPN interface.
+
+    Wraps VyOS's `generate openvpn client-config` op-mode command, then fills in
+    the public remote host and embeds the server's TLS auth/crypt key so the
+    resulting profile connects without hand-editing. Reveals private key
+    material, so it requires write permission (same as PKI reveal).
+    """
+    await require_write_permission(http_request, FeatureGroup.OPENVPN)
+
+    try:
+        service = get_session_vyos_service(http_request)
+        full_config = await run_in_threadpool(service.get_full_config)
+
+        iface = request.interface
+        ovpn_cfg = full_config.get("interfaces", {}).get("openvpn", {})
+        iface_cfg = ovpn_cfg.get(iface)
+        if iface_cfg is None:
+            raise HTTPException(status_code=404, detail=f"OpenVPN interface '{iface}' not found")
+        if iface_cfg.get("mode") != "server":
+            raise HTTPException(
+                status_code=400,
+                detail="Client export is only available for server-mode interfaces",
+            )
+
+        tls_cfg = iface_cfg.get("tls", {}) or {}
+        ca = request.ca or tls_cfg.get("ca-certificate")
+        if isinstance(ca, list):
+            ca = ca[0] if ca else None
+        if not ca:
+            raise HTTPException(
+                status_code=400,
+                detail="No CA certificate specified and none configured on the interface",
+            )
+
+        cert = request.certificate
+        path = ["openvpn", "client-config", "interface", iface, "ca", ca, "certificate", cert]
+        if request.key:
+            path += ["key", request.key]
+
+        response = await run_in_threadpool(service.generate, path)
+        if response.status != 200 or not isinstance(response.result, str):
+            error_msg = response.error if response.error else "Failed to generate client config"
+            return OpenvpnClientExportResponse(success=False, error=str(error_msg))
+
+        ovpn = response.result
+        # VyOS prints this (and exits 0) when the interface has no openvpn config.
+        if ovpn.strip() in {"", "OpenVPN not configured"} or "does not exist" in ovpn:
+            return OpenvpnClientExportResponse(success=False, error=ovpn.strip() or "Empty client config")
+
+        if request.remote_host:
+            ovpn = _apply_remote_host(ovpn, request.remote_host)
+
+        # Embed the server's TLS auth/crypt key (VyOS's generator omits it).
+        crypt_key = tls_cfg.get("crypt-key")
+        auth_key = tls_cfg.get("auth-key")
+        secret_name = crypt_key or auth_key
+        if secret_name:
+            shared = (
+                full_config.get("pki", {})
+                .get("openvpn", {})
+                .get("shared-secret", {})
+                .get(secret_name, {})
+            )
+            secret_hex = shared.get("key")
+            if secret_hex:
+                ovpn = ovpn.rstrip("\n") + "\n\n" + _build_tls_key_block(
+                    secret_hex, is_crypt=bool(crypt_key)
+                )
+
+        return OpenvpnClientExportResponse(
+            success=True,
+            filename=f"{iface}-{cert}.ovpn",
+            config=ovpn,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error in client_export")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/vyos_service.py
+++ b/backend/vyos_service.py
@@ -541,6 +541,22 @@ class VyOSService:
         """
         return self.device.config_file_save(file=file)
 
+    def generate(self, path: List[str]) -> ApiResponse:
+        """
+        Run an operational-mode ``generate`` command on the device.
+
+        Used for op-mode generators such as ``generate openvpn client-config``
+        which produce a payload (e.g. an .ovpn file) rather than mutating config.
+
+        Args:
+            path: Op-mode path elements after ``generate``
+                  (e.g. ["openvpn", "client-config", "interface", "vtun0", ...])
+
+        Returns:
+            ApiResponse: ``result`` holds the generated text on success.
+        """
+        return self.device.generate(path=path)
+
     def show_config(self, path: Optional[List[str]] = None) -> Dict[str, Any]:
         """
         Retrieve configuration from VyOS using pyvyos.

--- a/frontend/src/app/vpn/openvpn/page.tsx
+++ b/frontend/src/app/vpn/openvpn/page.tsx
@@ -36,6 +36,7 @@ import {
   Eye,
   Wand2,
   Search,
+  Download,
 } from "lucide-react";
 import {
   openvpnService,
@@ -50,6 +51,7 @@ import { OpenvpnWizard } from "@/components/openvpn/OpenvpnWizard";
 import { CreateOpenvpnModal } from "@/components/openvpn/CreateOpenvpnModal";
 import { EditOpenvpnModal } from "@/components/openvpn/EditOpenvpnModal";
 import { DeleteOpenvpnModal } from "@/components/openvpn/DeleteOpenvpnModal";
+import { ClientExportModal } from "@/components/openvpn/ClientExportModal";
 
 type ModeFilter = "all" | "server" | "client" | "site-to-site";
 
@@ -83,6 +85,7 @@ export default function OpenvpnPage() {
   const [showAdvancedCreate, setShowAdvancedCreate] = useState(false);
   const [editingInterface, setEditingInterface] = useState<OpenvpnInterface | null>(null);
   const [deletingInterface, setDeletingInterface] = useState<OpenvpnInterface | null>(null);
+  const [exportingInterface, setExportingInterface] = useState<OpenvpnInterface | null>(null);
 
   const fetchConfig = async (refresh = false) => {
     try {
@@ -377,6 +380,16 @@ export default function OpenvpnPage() {
                           >
                             <Eye className="h-4 w-4" />
                           </Button>
+                          {hasWrite && iface.mode === "server" && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title="Export client config"
+                              onClick={() => setExportingInterface(iface)}
+                            >
+                              <Download className="h-4 w-4" />
+                            </Button>
+                          )}
                           {hasWrite && (
                             <>
                               <Button
@@ -455,6 +468,15 @@ export default function OpenvpnPage() {
           onOpenChange={(open) => !open && setDeletingInterface(null)}
           onSuccess={handleSuccess}
           interfaceData={deletingInterface}
+        />
+      )}
+
+      {/* Client Config Export */}
+      {hasWrite && exportingInterface && (
+        <ClientExportModal
+          open={true}
+          onOpenChange={(open) => !open && setExportingInterface(null)}
+          interfaceData={exportingInterface}
         />
       )}
     </AppLayout>

--- a/frontend/src/components/openvpn/ClientExportModal.tsx
+++ b/frontend/src/components/openvpn/ClientExportModal.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  Download,
+  Loader2,
+  ArrowLeft,
+} from "lucide-react";
+import {
+  openvpnService,
+  type OpenvpnInterface,
+  type OpenvpnExportCertificate,
+} from "@/lib/api/openvpn";
+import { ApiError } from "@/lib/types/api";
+
+interface ClientExportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  interfaceData: OpenvpnInterface | null;
+}
+
+// Radix Select can't use an empty-string value, so use sentinels.
+const SAME_AS_CERT = "__same__"; // derive client key from the certificate
+const MANUAL = "__manual__"; // pick the certificate by hand (not by assigned client)
+
+export function ClientExportModal({
+  open,
+  onOpenChange,
+  interfaceData,
+}: ClientExportModalProps) {
+  const [caOptions, setCaOptions] = useState<string[]>([]);
+  const [certs, setCerts] = useState<OpenvpnExportCertificate[]>([]);
+
+  const [ca, setCa] = useState("");
+  const [assignedClient, setAssignedClient] = useState(MANUAL);
+  const [certificate, setCertificate] = useState("");
+  const [keyName, setKeyName] = useState(SAME_AS_CERT);
+  const [remoteHost, setRemoteHost] = useState("");
+
+  const [optionsLoading, setOptionsLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [result, setResult] = useState<{ filename: string; config: string } | null>(null);
+
+  // Per-client ("assigned user") entries configured on this server.
+  const clients = useMemo(
+    () => interfaceData?.server?.clients ?? [],
+    [interfaceData]
+  );
+  const hasClients = clients.length > 0;
+
+  // Map a certificate Common Name -> certificate node name (first match wins).
+  const cnToCert = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of certs) {
+      if (c.cn && !map.has(c.cn)) map.set(c.cn, c.name);
+    }
+    return map;
+  }, [certs]);
+
+  // Reset + load PKI material (with decoded CNs) whenever the modal opens.
+  useEffect(() => {
+    if (!open || !interfaceData) return;
+
+    setError(null);
+    setResult(null);
+    setKeyName(SAME_AS_CERT);
+    setCertificate("");
+    setAssignedClient(MANUAL);
+    setCa(interfaceData.tls?.ca_certificates?.[0] ?? "");
+    setRemoteHost(interfaceData.local_host ?? interfaceData.remote_host?.[0] ?? "");
+
+    let cancelled = false;
+    setOptionsLoading(true);
+    openvpnService
+      .getExportOptions()
+      .then((opts) => {
+        if (cancelled) return;
+        setCaOptions(opts.cas);
+        setCerts(opts.certificates);
+
+        const configuredCa = interfaceData.tls?.ca_certificates?.[0];
+        if (configuredCa && opts.cas.includes(configuredCa)) {
+          setCa(configuredCa);
+        } else if (opts.cas.length === 1) {
+          setCa(opts.cas[0]);
+        }
+
+        // If this server has per-client entries, preselect the first enabled
+        // one and auto-match its certificate by CN.
+        const firstClient = clients.find((c) => !c.disable) ?? clients[0];
+        if (firstClient) {
+          setAssignedClient(firstClient.name);
+          const cnMap = new Map<string, string>();
+          for (const c of opts.certificates) {
+            if (c.cn && !cnMap.has(c.cn)) cnMap.set(c.cn, c.name);
+          }
+          setCertificate(cnMap.get(firstClient.name) ?? "");
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError((err as ApiError).message || "Failed to load PKI material");
+      })
+      .finally(() => {
+        if (!cancelled) setOptionsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, interfaceData, clients]);
+
+  const handleAssignedClientChange = (value: string) => {
+    setAssignedClient(value);
+    if (value !== MANUAL) {
+      setCertificate(cnToCert.get(value) ?? "");
+    }
+  };
+
+  const handleCertificateChange = (value: string) => {
+    setCertificate(value);
+    // Manual override breaks the "matched by assigned client" link.
+    if (hasClients) setAssignedClient(MANUAL);
+  };
+
+  // Hint state for the assigned-client matching.
+  const selectedClient =
+    assignedClient !== MANUAL ? clients.find((c) => c.name === assignedClient) : undefined;
+  const matchedCertName =
+    assignedClient !== MANUAL ? cnToCert.get(assignedClient) ?? null : null;
+  const noMatch = assignedClient !== MANUAL && matchedCertName === null;
+
+  const certLabel = (c: OpenvpnExportCertificate) =>
+    c.cn ? `${c.name} — CN: ${c.cn}` : c.name;
+
+  const handleGenerate = async () => {
+    if (!interfaceData) return;
+    if (!ca) {
+      setError("Select a CA certificate");
+      return;
+    }
+    if (!certificate) {
+      setError("Select a client certificate");
+      return;
+    }
+
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await openvpnService.exportClientConfig({
+        interface: interfaceData.name,
+        ca,
+        certificate,
+        key: keyName === SAME_AS_CERT ? undefined : keyName,
+        remote_host: remoteHost.trim() || undefined,
+      });
+      if (res.success && res.config) {
+        setResult({
+          filename: res.filename || `${interfaceData.name}-${certificate}.ovpn`,
+          config: res.config,
+        });
+      } else {
+        setError(res.error || "Failed to generate client config");
+      }
+    } catch (err) {
+      setError((err as ApiError).message || "Failed to generate client config");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleDownload = useCallback(() => {
+    if (!result) return;
+    const blob = new Blob([result.config], { type: "application/x-openvpn-profile" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = result.filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [result]);
+
+  if (!interfaceData) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Download className="h-5 w-5 text-primary" />
+            Export Client Config
+          </DialogTitle>
+          <DialogDescription>
+            {result
+              ? `Client profile for ${interfaceData.name}`
+              : `Generate a ready-to-use .ovpn for ${interfaceData.name}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!result ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="export-remote-host">Server address</Label>
+              <Input
+                id="export-remote-host"
+                value={remoteHost}
+                onChange={(e) => setRemoteHost(e.target.value)}
+                placeholder="vpn.example.com"
+              />
+              <p className="text-xs text-muted-foreground">
+                Public hostname or IP clients connect to. Fills the{" "}
+                <code className="font-mono">remote</code> line.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label>CA certificate</Label>
+              <Select value={ca} onValueChange={setCa} disabled={optionsLoading}>
+                <SelectTrigger>
+                  <SelectValue placeholder={optionsLoading ? "Loading…" : "Select CA"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {caOptions.map((name) => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {hasClients && (
+              <div className="space-y-2">
+                <Label>Assigned client</Label>
+                <Select
+                  value={assignedClient}
+                  onValueChange={handleAssignedClientChange}
+                  disabled={optionsLoading}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {clients.map((c) => (
+                      <SelectItem key={c.name} value={c.name}>
+                        {c.name}
+                        {c.disable ? " (disabled)" : ""}
+                      </SelectItem>
+                    ))}
+                    <SelectItem value={MANUAL}>Other / pick certificate manually</SelectItem>
+                  </SelectContent>
+                </Select>
+                {selectedClient && matchedCertName && (
+                  <p className="text-xs text-muted-foreground">
+                    Matched certificate <span className="font-mono">{matchedCertName}</span>
+                    {selectedClient.ip ? (
+                      <>
+                        {" "}
+                        · server assigns fixed IP{" "}
+                        <span className="font-mono">{selectedClient.ip}</span>
+                      </>
+                    ) : null}
+                  </p>
+                )}
+                {noMatch && (
+                  <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
+                    <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
+                    <p className="text-xs text-amber-700 dark:text-amber-500">
+                      No certificate has a Common Name of{" "}
+                      <span className="font-mono">{assignedClient}</span>. Per-client
+                      settings (fixed IP, routes) won&apos;t apply unless the exported
+                      certificate&apos;s CN matches. Pick a certificate below.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label>Client certificate</Label>
+              <Select
+                value={certificate}
+                onValueChange={handleCertificateChange}
+                disabled={optionsLoading}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={optionsLoading ? "Loading…" : "Select client certificate"}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {certs.map((c) => (
+                    <SelectItem key={c.name} value={c.name}>
+                      {certLabel(c)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Client key</Label>
+              <Select value={keyName} onValueChange={setKeyName} disabled={optionsLoading}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={SAME_AS_CERT}>Same as certificate</SelectItem>
+                  {certs.map((c) => (
+                    <SelectItem key={c.name} value={c.name}>
+                      {c.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {error && (
+              <div className="flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-3">
+                <AlertCircle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+                <p className="text-sm text-destructive whitespace-pre-wrap">{error}</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-start gap-3 rounded-lg border border-green-600/20 bg-green-600/10 p-4">
+              <CheckCircle2 className="h-5 w-5 text-green-600 shrink-0 mt-0.5" />
+              <div className="space-y-1">
+                <p className="text-sm font-medium">Client profile ready</p>
+                <p className="text-xs text-muted-foreground font-mono break-all">
+                  {result.filename}
+                </p>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Includes the CA, client certificate/key and the server&apos;s TLS key.
+              Treat this file as a secret &mdash; anyone with it can connect.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          {!result ? (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={generating}>
+                Cancel
+              </Button>
+              <Button onClick={handleGenerate} disabled={generating || optionsLoading}>
+                {generating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Generating…
+                  </>
+                ) : (
+                  "Generate"
+                )}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => setResult(null)}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+              </Button>
+              <Button onClick={handleDownload}>
+                <Download className="mr-2 h-4 w-4" />
+                Download
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api/openvpn.ts
+++ b/frontend/src/lib/api/openvpn.ts
@@ -220,6 +220,31 @@ export interface OpenvpnBatchOperation {
   value?: string;
 }
 
+export interface OpenvpnClientExportRequest {
+  interface: string;
+  ca?: string;
+  certificate: string;
+  key?: string;
+  remote_host?: string;
+}
+
+export interface OpenvpnClientExportResponse {
+  success: boolean;
+  filename?: string | null;
+  config?: string | null;
+  error?: string | null;
+}
+
+export interface OpenvpnExportCertificate {
+  name: string;
+  cn: string | null;
+}
+
+export interface OpenvpnExportOptions {
+  cas: string[];
+  certificates: OpenvpnExportCertificate[];
+}
+
 // ============================================================================
 // Config shape passed to createInterface (structured from wizard / advanced)
 // ============================================================================
@@ -940,6 +965,19 @@ class OpenvpnService {
 
   async deleteInterface(name: string): Promise<VyOSResponse> {
     return this.batchConfigure(name, [{ op: "delete_interface" }]);
+  }
+
+  async exportClientConfig(
+    request: OpenvpnClientExportRequest
+  ): Promise<OpenvpnClientExportResponse> {
+    return apiClient.post<OpenvpnClientExportResponse>(
+      "/vyos/openvpn/client-export",
+      request
+    );
+  }
+
+  async getExportOptions(): Promise<OpenvpnExportOptions> {
+    return apiClient.get<OpenvpnExportOptions>("/vyos/openvpn/export-options");
   }
 }
 


### PR DESCRIPTION
Adds a "Export client config" action for server-mode OpenVPN interfaces that generates a ready-to-use .ovpn for a client.

Backend (routers/interfaces/openvpn.py):
- POST /vyos/openvpn/client-export wraps VyOS's native `generate openvpn client-config` op-mode command, then fills the public remote host and embeds the server's TLS auth/crypt key (with key-direction for tls-auth) so the profile connects without hand-editing.
- GET /vyos/openvpn/export-options lists PKI CAs and certificates with decoded Common Names, so the UI can map an assigned client to a cert.
- Add VyOSService.generate() helper for op-mode generate commands.

Frontend (ClientExportModal.tsx):
- CN-aware export dialog: when the server has per-client entries, pick the assigned client and the matching certificate is auto-selected by CN; warns when no certificate CN matches. Download-only result step.