### PR TITLE
Show OSPF/OSPFv3 areas assigned only via interfaces

### DIFF
--- a/backend/routers/ospf/ospf.py
+++ b/backend/routers/ospf/ospf.py
@@ -269,10 +269,22 @@ async def get_ospf_config(http_request: Request, refresh: bool = False):
         if not ospf_config:
             return OspfConfig()
 
+        areas = parse_areas(ospf_config.get("area", {}))
+        interfaces = parse_interfaces(ospf_config.get("interface", {}))
+
+        # Interface-based area assignment (`set protocols ospf interface <name> area <id>`)
+        # does not create a `protocols ospf area <id>` node. Surface those areas so
+        # they still appear in the Areas tab even with no explicit area block.
+        known_area_ids = {area.area_id for area in areas}
+        for iface in interfaces:
+            if iface.area and iface.area not in known_area_ids:
+                areas.append(OspfArea(area_id=iface.area))
+                known_area_ids.add(iface.area)
+
         return OspfConfig(
             parameters=parse_parameters(ospf_config.get("parameters", {})),
-            areas=parse_areas(ospf_config.get("area", {})),
-            interfaces=parse_interfaces(ospf_config.get("interface", {})),
+            areas=areas,
+            interfaces=interfaces,
             redistribute=parse_redistribute(ospf_config.get("redistribute", {})),
             default_information=parse_default_information(ospf_config.get("default-information", {})),
             distance=parse_distance(ospf_config),

--- a/backend/routers/ospfv3/ospfv3.py
+++ b/backend/routers/ospfv3/ospfv3.py
@@ -190,10 +190,22 @@ async def get_ospfv3_config(http_request: Request, refresh: bool = False):
         if not ospfv3_config:
             return Ospfv3Config()
 
+        areas = parse_areas(ospfv3_config.get("area", {}))
+        interfaces = parse_interfaces(ospfv3_config.get("interface", {}))
+
+        # Interface-based area assignment (`set protocols ospfv3 interface <name> area <id>`)
+        # does not create a `protocols ospfv3 area <id>` node. Surface those areas so
+        # they still appear in the Areas tab even with no explicit area block.
+        known_area_ids = {area.area_id for area in areas}
+        for iface in interfaces:
+            if iface.area and iface.area not in known_area_ids:
+                areas.append(Ospfv3Area(area_id=iface.area))
+                known_area_ids.add(iface.area)
+
         return Ospfv3Config(
             parameters=parse_parameters(ospfv3_config.get("parameters", {})),
-            areas=parse_areas(ospfv3_config.get("area", {})),
-            interfaces=parse_interfaces(ospfv3_config.get("interface", {})),
+            areas=areas,
+            interfaces=interfaces,
             redistribute=parse_redistribute(ospfv3_config.get("redistribute", {})),
             default_information=parse_default_information(ospfv3_config.get("default-information", {})),
             distance=parse_distance(ospfv3_config),


### PR DESCRIPTION
Interface-based area assignment (`set protocols ospf interface <name> area <id>`) does not create a `protocols ospf area <id>` node, so areas like Area 0 were absent from the Areas tab even though interfaces reported belonging to them.

Merge interface-referenced areas into the /config response for both OSPF and OSPFv3 so they surface in the Areas tab.

Fixes #390