### PR TITLE
Add BFD live sessions view with dynamic peer support

### DIFF
--- a/backend/bfd_status.py
+++ b/backend/bfd_status.py
@@ -1,0 +1,157 @@
+"""BFD operational peer status.
+
+Parses the text output of the op-mode ``show bfd peers`` command (fetched via the
+GraphQL ``Show`` op, path ``["bfd", "peers"]``) into structured per-session data.
+
+This surfaces *running* BFD sessions — including ``dynamic`` peers created by a
+routing protocol (BGP/OSPF/IS-IS with ``bfd`` enabled), which never appear under
+``protocols bfd peer`` in the configuration and so are invisible to the config-driven
+Peers table.
+"""
+
+import json
+import re
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class BfdPeerStatus(BaseModel):
+    """A single live BFD session as reported by ``show bfd peers``."""
+    peer: str
+    peer_type: Optional[str] = None        # "configured" or "dynamic"
+    status: Optional[str] = None           # "up" or "down"
+    multihop: bool = False
+    passive: bool = False
+    local_address: Optional[str] = None
+    vrf: Optional[str] = None
+    interface: Optional[str] = None
+    uptime: Optional[str] = None           # set when status == "up"
+    downtime: Optional[str] = None         # set when status == "down"
+    diagnostic: Optional[str] = None
+    remote_diagnostic: Optional[str] = None
+    minimum_ttl: Optional[int] = None
+    detect_multiplier: Optional[int] = None
+    receive_interval: Optional[int] = None     # ms (local)
+    transmit_interval: Optional[int] = None     # ms (local)
+    echo_receive_interval: Optional[int] = None  # ms (local), None when disabled
+
+
+def bfd_peers_gql_query(key_literal: str) -> dict:
+    """GraphQL body fetching ``show bfd peers`` via the generic ``Show`` op.
+
+    ``key_literal`` must be a JSON-encoded API key (``json.dumps(key)``).
+    """
+    path = json.dumps(["bfd", "peers"])
+    field = f"BfdPeers: Show(data: {{key: {key_literal}, path: {path}}}) {{ data {{ result }} }}"
+    return {"query": "{ " + field + " }"}
+
+
+def _ms(value: str) -> Optional[int]:
+    """Parse an interval like ``300ms`` to ``300``; ``disabled`` -> None."""
+    if not value:
+        return None
+    m = re.match(r"^\s*(\d+)\s*ms\s*$", value)
+    return int(m.group(1)) if m else None
+
+
+def _int(value: str) -> Optional[int]:
+    try:
+        return int(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _parse_header(line: str) -> dict:
+    """Parse a ``peer <addr> [multihop] [local-address X] [vrf Y] [interface Z]`` line."""
+    tokens = line.split()
+    data = {
+        "peer": tokens[1] if len(tokens) > 1 else "",
+        "multihop": False,
+        "local_address": None,
+        "vrf": None,
+        "interface": None,
+    }
+    i = 2
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "multihop":
+            data["multihop"] = True
+            i += 1
+        elif tok in ("local-address", "vrf", "interface") and i + 1 < len(tokens):
+            key = "local_address" if tok == "local-address" else tok
+            data[key] = tokens[i + 1]
+            i += 2
+        else:
+            i += 1
+    return data
+
+
+def parse_bfd_peers(text: str) -> List[BfdPeerStatus]:
+    """Parse ``show bfd peers`` text output into a list of BfdPeerStatus."""
+    peers: List[BfdPeerStatus] = []
+    current: Optional[dict] = None
+    section = "info"  # "info" | "local" | "remote"
+
+    def _flush() -> None:
+        if current is not None:
+            peers.append(BfdPeerStatus(**current))
+
+    for raw in (text or "").splitlines():
+        line = raw.strip()
+        if not line or line == "BFD Peers:":
+            continue
+
+        if line.startswith("peer "):
+            _flush()
+            current = _parse_header(line)
+            section = "info"
+            continue
+
+        if current is None:
+            continue
+
+        if line == "Local timers:":
+            section = "local"
+            continue
+        if line == "Remote timers:":
+            section = "remote"
+            continue
+
+        if line in ("Active mode", "Passive mode"):
+            current["passive"] = line == "Passive mode"
+            continue
+
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+
+        if section == "info":
+            if key == "Status":
+                current["status"] = value.lower()
+            elif key == "Uptime":
+                current["uptime"] = value
+            elif key == "Downtime":
+                current["downtime"] = value
+            elif key == "Diagnostics":
+                current["diagnostic"] = value
+            elif key == "Remote diagnostics":
+                current["remote_diagnostic"] = value
+            elif key == "Peer Type":
+                current["peer_type"] = value.lower()
+            elif key == "Minimum TTL":
+                current["minimum_ttl"] = _int(value)
+        elif section == "local":
+            if key == "Detect-multiplier":
+                current["detect_multiplier"] = _int(value)
+            elif key == "Receive interval":
+                current["receive_interval"] = _ms(value)
+            elif key == "Transmission interval":
+                current["transmit_interval"] = _ms(value)
+            elif key == "Echo receive interval":
+                current["echo_receive_interval"] = _ms(value)
+
+    _flush()
+    return peers

--- a/backend/routers/bfd/bfd.py
+++ b/backend/routers/bfd/bfd.py
@@ -13,7 +13,10 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import BfdBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+from bfd_status import BfdPeerStatus, bfd_peers_gql_query, parse_bfd_peers
 import inspect
+import json
+import httpx
 import logging
 logger = logging.getLogger(__name__)
 
@@ -72,6 +75,11 @@ class BfdConfig(BaseModel):
     """Complete BFD configuration."""
     peers: List[BfdPeer] = []
     profiles: List[BfdProfile] = []
+
+
+class BfdStatusResponse(BaseModel):
+    """Live BFD session status (operational, includes dynamic peers)."""
+    peers: List[BfdPeerStatus] = []
 
 
 class BfdBatchOperation(BaseModel):
@@ -140,6 +148,49 @@ async def get_bfd_config(http_request: Request, refresh: bool = False):
         profiles = parse_profiles(bfd_config.get("profile", {}))
 
         return BfdConfig(peers=peers, profiles=profiles)
+    except Exception as e:
+        logger.exception("Unhandled error")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ============================================================================
+# Endpoint: Operational Status (live / dynamic peers)
+# ============================================================================
+
+
+@router.get("/status", response_model=BfdStatusResponse)
+async def get_bfd_status(request: Request):
+    """Get live BFD sessions via the GraphQL ``Show`` op (``show bfd peers``).
+
+    Unlike ``/config``, this reflects the running BFD daemon and therefore
+    includes ``dynamic`` peers created by routing protocols (BGP/OSPF/IS-IS with
+    ``bfd`` enabled) that have no ``protocols bfd peer`` configuration node.
+    """
+    await require_read_permission(request, FeatureGroup.BFD)
+
+    try:
+        service = get_session_vyos_service(request)
+        api_key = str(service.config.apikey)
+        url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
+        payload = bfd_peers_gql_query(json.dumps(api_key))
+
+        async with httpx.AsyncClient(verify=service.config.verify, timeout=15.0) as client:
+            resp = await client.post(url, json=payload, auth=("vyos", api_key))
+
+        if resp.status_code != 200:
+            logger.error("BFD status GraphQL HTTP error %d", resp.status_code)
+            raise HTTPException(status_code=502, detail="Failed to fetch BFD status")
+
+        body = resp.json()
+        if "errors" in body:
+            logger.warning("BFD status GraphQL field errors: %s", body["errors"])
+
+        node = (body.get("data") or {}).get("BfdPeers") or {}
+        result = (node.get("data") or {}).get("result")
+        peers = parse_bfd_peers(result if isinstance(result, str) else "")
+        return BfdStatusResponse(peers=peers)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/frontend/src/components/bfd/BfdContent.tsx
+++ b/frontend/src/components/bfd/BfdContent.tsx
@@ -22,6 +22,7 @@ import {
   Trash2,
   Radio,
   FileSliders,
+  Waypoints,
 } from "lucide-react";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import {
@@ -30,6 +31,7 @@ import {
   BfdCapabilities,
   BfdPeer,
   BfdProfile,
+  BfdPeerStatus,
 } from "@/lib/api/bfd";
 import { BfdPeerModal } from "./BfdPeerModal";
 import { DeleteBfdPeerModal } from "./DeleteBfdPeerModal";
@@ -42,6 +44,11 @@ export function BfdContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("peers");
+
+  // Live (operational) BFD sessions — includes dynamic peers from routing protocols
+  const [liveSessions, setLiveSessions] = useState<BfdPeerStatus[]>([]);
+  const [liveLoading, setLiveLoading] = useState(false);
+  const [liveError, setLiveError] = useState<string | null>(null);
 
   // Peer modal state
   const [peerModalOpen, setPeerModalOpen] = useState(false);
@@ -70,13 +77,28 @@ export function BfdContent() {
     }
   }, []);
 
+  const loadLiveSessions = useCallback(async () => {
+    try {
+      setLiveLoading(true);
+      setLiveError(null);
+      const status = await bfdService.getStatus();
+      setLiveSessions(status.peers);
+    } catch (err) {
+      setLiveError(err instanceof Error ? err.message : "Failed to load live BFD sessions");
+    } finally {
+      setLiveLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     loadData();
-  }, [loadData]);
+    loadLiveSessions();
+  }, [loadData, loadLiveSessions]);
 
   // Stats
   const peerCount = config?.peers.length ?? 0;
   const profileCount = config?.profiles.length ?? 0;
+  const liveCount = liveSessions.length;
   const activePeers = config?.peers.filter((p) => !p.shutdown).length ?? 0;
   const multihopPeers = config?.peers.filter((p) => p.multihop).length ?? 0;
 
@@ -173,7 +195,7 @@ export function BfdContent() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => loadData(true)}
+              onClick={() => { loadData(true); loadLiveSessions(); }}
             >
               <RefreshCw className="h-4 w-4 mr-2" />
               Refresh
@@ -251,6 +273,12 @@ export function BfdContent() {
                 Peers
                 {peerCount > 0 && (
                   <Badge variant="secondary" className="ml-2">{peerCount}</Badge>
+                )}
+              </TabsTrigger>
+              <TabsTrigger value="live">
+                Live Sessions
+                {liveCount > 0 && (
+                  <Badge variant="secondary" className="ml-2">{liveCount}</Badge>
                 )}
               </TabsTrigger>
               <TabsTrigger value="profiles">
@@ -383,6 +411,106 @@ export function BfdContent() {
                                   <Trash2 className="h-4 w-4" />
                                 </Button>
                               </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </ScrollArea>
+                </Card>
+              )}
+            </TabsContent>
+
+            {/* ============================================================ */}
+            {/* Live Sessions Tab (operational, includes dynamic peers) */}
+            {/* ============================================================ */}
+            <TabsContent value="live">
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-sm text-muted-foreground">
+                  Running BFD sessions from the routing daemon, including dynamic peers
+                  created by protocols (BGP/OSPF) with BFD enabled. Read-only.
+                </p>
+                <Button variant="outline" size="sm" onClick={loadLiveSessions} disabled={liveLoading}>
+                  <RefreshCw className={`h-4 w-4 mr-2 ${liveLoading ? "animate-spin" : ""}`} />
+                  Refresh
+                </Button>
+              </div>
+
+              {liveError && (
+                <div className="mb-4 p-3 rounded-md bg-destructive/10 text-destructive text-sm">
+                  {liveError}
+                </div>
+              )}
+
+              {liveCount === 0 ? (
+                <Card>
+                  <CardContent className="flex flex-col items-center justify-center py-12">
+                    <Waypoints className="h-12 w-12 text-muted-foreground/30 mb-4" />
+                    <p className="text-sm text-muted-foreground mb-2">No active BFD sessions</p>
+                    <p className="text-xs text-muted-foreground">
+                      Dynamic sessions appear here when a routing protocol negotiates BFD with a neighbor
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : (
+                <Card>
+                  <ScrollArea>
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>Peer</TableHead>
+                          <TableHead>Type</TableHead>
+                          <TableHead>Status</TableHead>
+                          <TableHead>Interface</TableHead>
+                          <TableHead>VRF</TableHead>
+                          <TableHead>Uptime</TableHead>
+                          <TableHead>Tx / Rx</TableHead>
+                          <TableHead>Multiplier</TableHead>
+                          <TableHead>Diagnostic</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {liveSessions.map((s, idx) => (
+                          <TableRow key={`${s.peer}-${s.vrf ?? ""}-${s.interface ?? ""}-${idx}`}>
+                            <TableCell className="font-medium font-mono">
+                              {s.peer}
+                              {s.multihop && (
+                                <Badge variant="outline" className="ml-2 text-xs">Multihop</Badge>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={s.peer_type === "dynamic" ? "secondary" : "outline"}>
+                                {s.peer_type ?? "unknown"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>
+                              {s.status === "up" ? (
+                                <Badge variant="secondary" className="bg-green-500/10 text-green-600">Up</Badge>
+                              ) : (
+                                <Badge variant="secondary" className="bg-red-500/10 text-red-600">
+                                  {s.status ? s.status.charAt(0).toUpperCase() + s.status.slice(1) : "Down"}
+                                </Badge>
+                              )}
+                            </TableCell>
+                            <TableCell className="font-mono text-sm">
+                              {s.interface || <span className="text-muted-foreground">-</span>}
+                            </TableCell>
+                            <TableCell className="font-mono text-sm">
+                              {s.vrf || <span className="text-muted-foreground">-</span>}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {s.status === "up"
+                                ? (s.uptime || <span className="text-muted-foreground">-</span>)
+                                : <span className="text-muted-foreground">{s.downtime || "-"}</span>}
+                            </TableCell>
+                            <TableCell className="font-mono text-sm">
+                              {s.transmit_interval != null ? `${s.transmit_interval}ms` : "300ms"} / {s.receive_interval != null ? `${s.receive_interval}ms` : "300ms"}
+                            </TableCell>
+                            <TableCell>
+                              {s.detect_multiplier ?? <span className="text-muted-foreground">3</span>}
+                            </TableCell>
+                            <TableCell className="text-sm">
+                              {s.diagnostic || <span className="text-muted-foreground">-</span>}
                             </TableCell>
                           </TableRow>
                         ))}

--- a/frontend/src/lib/api/bfd.ts
+++ b/frontend/src/lib/api/bfd.ts
@@ -43,6 +43,30 @@ export interface BfdConfig {
   profiles: BfdProfile[];
 }
 
+export interface BfdPeerStatus {
+  peer: string;
+  peer_type: string | null;        // "configured" | "dynamic"
+  status: string | null;           // "up" | "down"
+  multihop: boolean;
+  passive: boolean;
+  local_address: string | null;
+  vrf: string | null;
+  interface: string | null;
+  uptime: string | null;
+  downtime: string | null;
+  diagnostic: string | null;
+  remote_diagnostic: string | null;
+  minimum_ttl: number | null;
+  detect_multiplier: number | null;
+  receive_interval: number | null;
+  transmit_interval: number | null;
+  echo_receive_interval: number | null;
+}
+
+export interface BfdStatusResponse {
+  peers: BfdPeerStatus[];
+}
+
 export interface BfdCapabilities {
   version: string;
   features: {
@@ -88,6 +112,10 @@ class BfdService {
     return apiClient.get<BfdConfig>("/vyos/bfd/config", {
       refresh: refresh.toString(),
     });
+  }
+
+  async getStatus(): Promise<BfdStatusResponse> {
+    return apiClient.get<BfdStatusResponse>("/vyos/bfd/status");
   }
 
   async refreshConfig(): Promise<VyOSResponse> {


### PR DESCRIPTION
## Summary

Fixes #389.

The BFD page only read `protocols bfd peer` configuration, so **dynamic** BFD sessions — created by routing protocols (e.g. BGP/OSPF with `bfd` enabled) — never appeared in the UI, even when up. Only statically configured peers were shown, which is why the reporter saw "0 Peers" while `show bfd peers` listed an active `Peer Type: dynamic` session.

This adds a read-only **Live Sessions** tab that surfaces running BFD sessions (configured *and* dynamic) with operational state.

## Changes

**Backend**
- `bfd_status.py` (new): parses `show bfd peers` text into structured `BfdPeerStatus` (type, up/down, interface, vrf, multihop, local timers, diagnostics) and builds the GraphQL `Show` query.
- `routers/bfd/bfd.py`: new `GET /vyos/bfd/status` endpoint that fetches `show bfd peers` via the GraphQL `Show` op (path `["bfd","peers"]`) and returns parsed sessions.

**Frontend**
- `lib/api/bfd.ts`: `BfdPeerStatus` / `BfdStatusResponse` types + `getStatus()`.
- `components/bfd/BfdContent.tsx`: new read-only **Live Sessions** tab with a Type (dynamic/configured) badge and up/down status. Loads on mount and refreshes via the page and tab Refresh buttons (manual; no polling).

## Notes
- The configured-peers (`/config`) path is unchanged and was verified to work — a configured peer still shows in the Peers tab as before.
- Parser was validated against real `show bfd peers` output from a VyOS 1.4 host for both configured and dynamic (incl. interface-bound) peers.
- Refresh is currently manual; auto-refresh-while-visible can be added if desired.