### PR TITLE
Fix OpenVPN page crash on static client IP

### DIFF
--- a/backend/routers/interfaces/openvpn.py
+++ b/backend/routers/interfaces/openvpn.py
@@ -135,7 +135,7 @@ class OpenvpnClientIpv6Pool(BaseModel):
 class OpenvpnServerClient(BaseModel):
     name: str
     disable: bool = False
-    ip: Optional[str] = None
+    ip: List[str] = Field(default_factory=list)
     push_route: List[str] = Field(default_factory=list)
     subnet: List[str] = Field(default_factory=list)
 

--- a/backend/vyos_mappers/interfaces/openvpn.py
+++ b/backend/vyos_mappers/interfaces/openvpn.py
@@ -633,7 +633,7 @@ class OpenvpnInterfaceMapper(BaseFeatureMapper):
             clients.append({
                 "name": client_name,
                 "disable": "disable" in client_cfg,
-                "ip": client_cfg.get("ip"),
+                "ip": _as_list(client_cfg.get("ip")),
                 "push_route": _as_list(client_cfg.get("push-route")),
                 "subnet": _as_list(client_cfg.get("subnet")),
             })

--- a/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
@@ -415,7 +415,7 @@ export function CreateOpenvpnModal({
         .map((c) => ({
           name: c.name,
           disable: c.disable,
-          ip: c.ip || undefined,
+          ip: c.ip ? c.ip.split(/[\s,]+/).filter(Boolean) : undefined,
           subnet: c.subnet ? splitLines(c.subnet) : undefined,
           push_route: c.push_route ? splitLines(c.push_route) : undefined,
         }));
@@ -1251,7 +1251,7 @@ export function CreateOpenvpnModal({
                         }}
                       />
                       <Input
-                        placeholder="IP"
+                        placeholder="IP (comma-separated)"
                         value={c.ip}
                         onChange={(e) => {
                           const next = [...serverClients];

--- a/frontend/src/components/openvpn/EditOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/EditOpenvpnModal.tsx
@@ -246,7 +246,7 @@ export function EditOpenvpnModal({
       (s?.clients ?? []).map((c) => ({
         name: c.name,
         disable: c.disable,
-        ip: c.ip ?? "",
+        ip: (c.ip ?? []).join(", "),
         subnet: joinLines(c.subnet),
         push_route: joinLines(c.push_route),
       }))
@@ -393,7 +393,7 @@ export function EditOpenvpnModal({
           .map((c) => ({
             name: c.name,
             disable: c.disable,
-            ip: c.ip || undefined,
+            ip: c.ip ? c.ip.split(/[\s,]+/).filter(Boolean) : undefined,
             subnet: c.subnet ? splitLines(c.subnet) : undefined,
             push_route: c.push_route ? splitLines(c.push_route) : undefined,
           })),
@@ -1197,7 +1197,7 @@ export function EditOpenvpnModal({
                         }}
                       />
                       <Input
-                        placeholder="IP"
+                        placeholder="IP (comma-separated)"
                         value={c.ip}
                         onChange={(e) => {
                           const next = [...serverClients];

--- a/frontend/src/lib/api/openvpn.ts
+++ b/frontend/src/lib/api/openvpn.ts
@@ -64,7 +64,7 @@ export interface OpenvpnClientIpv6Pool {
 export interface OpenvpnServerClient {
   name: string;
   disable: boolean;
-  ip: string | null;
+  ip: string[];
   push_route: string[];
   subnet: string[];
 }
@@ -313,7 +313,7 @@ export interface OpenvpnCreateConfig {
     clients?: {
       name: string;
       disable?: boolean;
-      ip?: string;
+      ip?: string[];
       push_route?: string[];
       subnet?: string[];
     }[];
@@ -467,7 +467,9 @@ function buildInterfaceOps(
       for (const c of s.clients) {
         ops.push({ op: "set_server_client", value: c.name });
         if (c.disable) ops.push({ op: "set_server_client_disable", value: c.name });
-        if (c.ip) ops.push({ op: "set_server_client_ip", value: `${c.name}:${c.ip}` });
+        if (c.ip) {
+          for (const a of c.ip) ops.push({ op: "set_server_client_ip", value: `${c.name}:${a}` });
+        }
         if (c.push_route) {
           for (const r of c.push_route) ops.push({ op: "set_server_client_push_route", value: `${c.name}:${r}` });
         }


### PR DESCRIPTION
`server client <name> ip` is a VyOS multi node (it allows e.g. one IPv4 and one IPv6), so the config JSON returns it as a list even for a single address. The backend typed it as a string, so any static client IP raised a ValidationError and 500'd the whole OpenVPN config endpoint.

Treat client `ip` as a list end-to-end, consistent with the sibling multi nodes `subnet` and `push-route`:
- backend model -> List[str]; parse with _as_list
- frontend types/op-builder -> string[] (one set op per address)
- create/edit modals join for display and split on commas/whitespace

Fixes #394