### PR TITLE
Add real-time VRRP/HA status dashboard card (#119)

### DIFF
--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -30,6 +30,7 @@ from routers.qos.qos import (
     parse_cake_qos_json,
 )
 from openvpn_status import openvpn_configured, openvpn_gql_fields, build_openvpn_status
+from vrrp_status import vrrp_configured, vrrp_gql_fields, build_vrrp_status
 import logging
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ def _wg_alias(iface_name: str) -> str:
     return f"WGStatus_{safe}"
 
 
-def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> dict:
+def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False) -> dict:
     """
     Build the JSON body for the slow dashboard GraphQL query.
 
@@ -135,6 +136,8 @@ def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Opti
     fields += qos_gql_fields(k, cake_targets or [])
     if include_openvpn:
         fields += openvpn_gql_fields(k)
+    if include_vrrp:
+        fields += vrrp_gql_fields(k)
     if include_wireguard:
         fields.append(
             f'WireGuardConfig: ShowConfig(data: {{key: {k}, path: ["interfaces", "wireguard"]}}) {{ data {{ result }} }}'
@@ -153,7 +156,7 @@ def _build_gql_wg_status_payload(api_key: str, iface_names: List[str]) -> dict:
     return {"query": "{ " + " ".join(fields) + " }"}
 
 
-async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> Optional[dict]:
+async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False) -> Optional[dict]:
     """
     Fire a single GraphQL POST for the full dashboard data.
 
@@ -162,7 +165,7 @@ async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_target
     api_key = str(service.config.apikey)
     url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
     verify = service.config.verify
-    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_openvpn)
+    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_openvpn, include_vrrp)
 
     try:
         async with httpx.AsyncClient(verify=verify, timeout=15.0) as client:
@@ -911,6 +914,8 @@ class DeviceDataBroadcaster:
         self._cached_cake_targets: list = []
         # Whether OpenVPN is configured (gates the ShowOpenvpn fetch).
         self._openvpn_configured: bool = False
+        # Whether any VRRP group is configured (gates the show vrrp fetch).
+        self._vrrp_configured: bool = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -1050,6 +1055,7 @@ class DeviceDataBroadcaster:
             cfg = await run_in_threadpool(self._service.get_full_config, refresh=False)
             self._cached_cake_targets = find_cake_targets(cfg)
             self._openvpn_configured = openvpn_configured(cfg)
+            self._vrrp_configured = vrrp_configured(cfg)
         except Exception:
             logger.exception("Broadcaster: config-state refresh error")
 
@@ -1060,6 +1066,14 @@ class DeviceDataBroadcaster:
         except Exception:
             logger.exception("Broadcaster: openvpn-status parse error")
             self._push_to_all({"type": "error", "data": {"channel": "openvpn-status", "message": "Parse failed"}})
+
+    def _broadcast_vrrp(self, gql: dict) -> None:
+        """Parse live VRRP group state from the shared GraphQL result and push an event."""
+        try:
+            self._push_to_all({"type": "vrrp-status", "data": build_vrrp_status(gql)})
+        except Exception:
+            logger.exception("Broadcaster: vrrp-status parse error")
+            self._push_to_all({"type": "error", "data": {"channel": "vrrp-status", "message": "Parse failed"}})
 
     def _on_task_done(self, fut: asyncio.Future) -> None:
         """Clean up if _run() exits unexpectedly."""
@@ -1085,8 +1099,9 @@ class DeviceDataBroadcaster:
                     await self._refresh_config_state()
                     targets = self._cached_cake_targets
                     ovpn = self._openvpn_configured
-                    # Full query: counters + system info + QoS + OpenVPN + WireGuard
-                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_openvpn=ovpn)
+                    vrrp = self._vrrp_configured
+                    # Full query: counters + system info + QoS + OpenVPN + VRRP + WireGuard
+                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_openvpn=ovpn, include_vrrp=vrrp)
                     if gql is not None:
                         self._broadcast_interface_counters(gql)
                         self._broadcast_system_info(gql)
@@ -1094,6 +1109,8 @@ class DeviceDataBroadcaster:
                         self._broadcast_qos(gql, targets)
                         if ovpn:
                             self._broadcast_openvpn(gql)
+                        if vrrp:
+                            self._broadcast_vrrp(gql)
                     else:
                         self._push_to_all({"type": "error", "data": {"channel": "all", "message": "GraphQL fetch failed"}})
                 else:
@@ -1150,6 +1167,7 @@ async def dashboard_stream(request: Request):
     """
     service = get_session_vyos_service(request)
     include_wireguard = await has_permission(request, FeatureGroup.WIREGUARD, PermissionLevel.READ)
+    include_vrrp = await has_permission(request, FeatureGroup.HIGH_AVAILABILITY, PermissionLevel.READ)
     broadcaster = _get_broadcaster(service)
 
     instance_id: str = service.config.instance_id
@@ -1173,6 +1191,8 @@ async def dashboard_stream(request: Request):
                     yield ": keep-alive\n\n"
                     continue
                 if event["type"] == "wireguard-peers" and not include_wireguard:
+                    continue
+                if event["type"] == "vrrp-status" and not include_vrrp:
                     continue
                 yield f'event: {event["type"]}\ndata: {json.dumps(event["data"])}\n\n'
         finally:

--- a/backend/vrrp_status.py
+++ b/backend/vrrp_status.py
@@ -1,0 +1,131 @@
+"""VRRP / high-availability live status for the dashboard stream.
+
+Parses the text output of the op-mode ``show vrrp`` command (fetched via the
+GraphQL ``Show`` op, path ``["vrrp"]``) into structured per-group state.
+
+This surfaces the *running* VRRP groups managed by keepalived — including their
+live ``MASTER`` / ``BACKUP`` / ``FAULT`` state, which never appears in the
+configuration and so is invisible to the config-driven High Availability page.
+
+The summary table looks like::
+
+    Name         Interface      VRID  State      Priority  Last Transition
+    -----------  -----------  ------  -------  ----------  -----------------
+    foo          eth1             50  MASTER          150  1m4s
+
+When VRRP is configured but no groups are active (or the daemon is not running)
+VyOS prints a single human-readable line such as ``VRRP not configured!`` (1.4)
+or ``VRRP data is not available ...`` (1.5); both parse to zero groups.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class VrrpGroupStatus(BaseModel):
+    """A single live VRRP group as reported by ``show vrrp``."""
+    name: str
+    interface: Optional[str] = None
+    vrid: Optional[int] = None
+    state: Optional[str] = None            # "MASTER" / "BACKUP" / "FAULT"
+    priority: Optional[int] = None
+    last_transition: Optional[str] = None  # e.g. "1m4s"
+
+
+def vrrp_configured(full_config) -> bool:
+    """True when any VRRP group is configured (gates the dashboard fetch)."""
+    ha = (full_config or {}).get("high-availability", {}) or {}
+    vrrp = ha.get("vrrp", {}) or {}
+    return bool(vrrp.get("group"))
+
+
+def vrrp_gql_fields(key_literal: str) -> List[str]:
+    """GraphQL alias field fetching ``show vrrp`` via the generic ``Show`` op.
+
+    ``key_literal`` must be a JSON-encoded API key (``json.dumps(key)``).
+    """
+    return [
+        f'Vrrp: Show(data: {{key: {key_literal}, path: ["vrrp"]}}) {{ data {{ result }} }}'
+    ]
+
+
+def _int(value: str) -> Optional[int]:
+    try:
+        return int(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _column_bounds(separator: str) -> List[tuple]:
+    """Return (start, end) slice bounds for each dashed run in the header rule.
+
+    The ``show vrrp`` summary aligns columns under a rule line of dash groups
+    separated by spaces, e.g. ``-----  -----  ------``. Slicing each data row by
+    these bounds tolerates the right-aligned numeric columns and values that
+    contain spaces far better than ``str.split()``.
+    """
+    bounds: List[tuple] = []
+    start: Optional[int] = None
+    for i, ch in enumerate(separator):
+        if ch == "-":
+            if start is None:
+                start = i
+        elif start is not None:
+            bounds.append((start, i))
+            start = None
+    if start is not None:
+        bounds.append((start, len(separator)))
+    return bounds
+
+
+def parse_vrrp_summary(text: str) -> List[VrrpGroupStatus]:
+    """Parse ``show vrrp`` summary text into a list of VrrpGroupStatus."""
+    lines = (text or "").splitlines()
+
+    # Locate the dashed rule line; the row above it is the header.
+    sep_idx: Optional[int] = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped and set(stripped) <= {"-", " "} and "-" in stripped:
+            sep_idx = idx
+            break
+    if sep_idx is None or sep_idx == 0:
+        return []
+
+    header = lines[sep_idx - 1]
+    bounds = _column_bounds(lines[sep_idx])
+    if not bounds:
+        return []
+
+    def cell(row: str, i: int) -> str:
+        start, end = bounds[i]
+        return row[start:end].strip() if start < len(row) else ""
+
+    # Map header labels to column indices so ordering changes don't break parsing.
+    col = {cell(header, i).lower(): i for i in range(len(bounds))}
+
+    groups: List[VrrpGroupStatus] = []
+    for row in lines[sep_idx + 1:]:
+        if not row.strip():
+            continue
+        name = cell(row, col.get("name", 0))
+        if not name:
+            continue
+        groups.append(VrrpGroupStatus(
+            name=name,
+            interface=cell(row, col["interface"]) or None if "interface" in col else None,
+            vrid=_int(cell(row, col["vrid"])) if "vrid" in col else None,
+            state=(cell(row, col["state"]).upper() or None) if "state" in col else None,
+            priority=_int(cell(row, col["priority"])) if "priority" in col else None,
+            last_transition=(cell(row, col["last transition"]) or None) if "last transition" in col else None,
+        ))
+    return groups
+
+
+def build_vrrp_status(gql: dict) -> dict:
+    """Build the ``vrrp-status`` SSE payload from the shared GraphQL result."""
+    node = (gql or {}).get("Vrrp") or {}
+    result = (node.get("data") or {}).get("result")
+    groups = parse_vrrp_summary(result if isinstance(result, str) else "")
+    return {"groups": [g.dict() for g in groups], "total": len(groups)}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,6 +16,7 @@ import { WireGuardPeersCard } from "@/components/dashboard/WireGuardPeersCard";
 import { NetworkSpeedCard } from "@/components/dashboard/NetworkSpeedCard";
 import { QoSStatsCard } from "@/components/dashboard/QoSStatsCard";
 import { OpenVpnCard } from "@/components/dashboard/OpenVpnCard";
+import { VrrpStatusCard } from "@/components/dashboard/VrrpStatusCard";
 import { AddCardModal } from "@/components/dashboard/AddCardModal";
 import {
   DndContext,
@@ -363,6 +364,9 @@ export default function Home() {
     if (cardType === "openvpn-status") {
       defaultSpan = 2;
     }
+    if (cardType === "vrrp-status") {
+      defaultSpan = 2;
+    }
     // system-info defaults to 1 column (already set above)
 
     // New cards always start at column 0
@@ -488,6 +492,8 @@ export default function Home() {
         return <QoSStatsCard {...baseProps} />;
       case "openvpn-status":
         return <OpenVpnCard {...baseProps} />;
+      case "vrrp-status":
+        return <VrrpStatusCard {...baseProps} />;
       default:
         return null;
     }

--- a/frontend/src/components/dashboard/AddCardModal.tsx
+++ b/frontend/src/components/dashboard/AddCardModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Network, Plus, Server, Shield, Lock, TrendingUp, Gauge, ShieldCheck } from "lucide-react";
+import { Network, Plus, Server, Shield, Lock, TrendingUp, Gauge, ShieldCheck, Waypoints } from "lucide-react";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 
@@ -63,6 +63,13 @@ const AVAILABLE_CARDS: AvailableCard[] = [
     icon: ShieldCheck,
     requiredPermission: FeatureGroup.OPENVPN,
   },
+  {
+    type: "vrrp-status",
+    name: "VRRP / High Availability",
+    description: "Real-time VRRP group state (MASTER/BACKUP/FAULT) with interface, VRID, priority and last transition",
+    icon: Waypoints,
+    requiredPermission: FeatureGroup.HIGH_AVAILABILITY,
+  },
 ];
 
 interface AddCardModalProps {
@@ -85,7 +92,7 @@ export function AddCardModal({ open, onOpenChange, onAddCard }: AddCardModalProp
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="w-[95vw] sm:max-w-4xl flex max-h-[85vh] flex-col">
         <DialogHeader>
           <DialogTitle>Add Dashboard Card</DialogTitle>
           <DialogDescription>
@@ -93,7 +100,7 @@ export function AddCardModal({ open, onOpenChange, onAddCard }: AddCardModalProp
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid gap-4 py-4 md:grid-cols-2">
+        <div className="grid gap-4 py-4 sm:grid-cols-2 lg:grid-cols-3 flex-1 min-h-0 overflow-y-auto">
           {AVAILABLE_CARDS.map((card) => {
             const Icon = card.icon;
             const locked =

--- a/frontend/src/components/dashboard/VrrpStatusCard.tsx
+++ b/frontend/src/components/dashboard/VrrpStatusCard.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { X, Network, RefreshCw, Settings, Clock } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { VrrpStatusData, VrrpGroupData } from "@/hooks/useDashboardSSE";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
+
+interface VrrpStatusCardProps {
+  onRemove?: () => void;
+  span?: number;
+  onSpanChange?: (newSpan: number) => void;
+  config?: Record<string, unknown>;
+  onConfigChange?: (config: Record<string, unknown>) => void;
+}
+
+function StateBadge({ state }: { state: string | null }) {
+  const value = (state ?? "").toUpperCase();
+  const styles: Record<string, string> = {
+    MASTER: "border-emerald-500/30 text-emerald-600 dark:text-emerald-400",
+    BACKUP: "border-blue-500/30 text-blue-600 dark:text-blue-400",
+    FAULT: "border-red-500/30 text-red-600 dark:text-red-400",
+  };
+  return (
+    <Badge
+      variant="outline"
+      className={`text-[10px] h-4 px-1 font-semibold tracking-wide ${
+        styles[value] ?? "border-muted-foreground/30 text-muted-foreground"
+      }`}
+    >
+      {state ?? "—"}
+    </Badge>
+  );
+}
+
+function GroupRow({ group }: { group: VrrpGroupData }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 text-sm border-b last:border-0">
+      <span className="font-mono font-medium truncate shrink-0 max-w-[10rem]" title={group.name}>
+        {group.name}
+      </span>
+      <StateBadge state={group.state} />
+      {group.interface && (
+        <span className="text-xs text-muted-foreground font-mono shrink-0">
+          {group.interface}
+          {group.vrid != null && <span className="opacity-60"> · vrid {group.vrid}</span>}
+        </span>
+      )}
+      <div className="flex-1" />
+      {group.priority != null && (
+        <span className="text-[11px] text-muted-foreground shrink-0 tabular-nums" title="priority">
+          prio {group.priority}
+        </span>
+      )}
+      {group.last_transition && (
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground shrink-0" title="last transition">
+          <Clock className="h-3 w-3" />
+          {group.last_transition}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function VrrpStatusCard({ onRemove, span = 1, onSpanChange }: VrrpStatusCardProps) {
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const { status: sseStatus, data: sseData } = useDashboardData();
+  // Snapshot the stream so "Paused" freezes the displayed status.
+  const [snapshot, setSnapshot] = useState<VrrpStatusData | null>(null);
+  useEffect(() => {
+    if (autoRefresh && sseData.vrrpStatus) setSnapshot(sseData.vrrpStatus);
+  }, [autoRefresh, sseData.vrrpStatus]);
+
+  const status = snapshot;
+  const loading = status === null;
+  const groups = status?.groups ?? [];
+
+  return (
+    <Card className="flex flex-col h-[520px]">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
+        <div className="flex items-center gap-2">
+          <Network className="h-5 w-5 text-primary" />
+          <CardTitle className="text-lg font-medium">VRRP / High Availability</CardTitle>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant={autoRefresh ? "default" : "outline"}
+            size="sm"
+            onClick={() => setAutoRefresh((v) => !v)}
+            title={autoRefresh ? `Live via dashboard stream (${sseStatus})` : "Paused"}
+          >
+            <RefreshCw className={`h-4 w-4 mr-1 ${autoRefresh && sseStatus === "connected" ? "animate-spin" : ""}`} />
+            {autoRefresh ? "Live" : "Paused"}
+          </Button>
+          {onSpanChange && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <Settings className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {([1, 2, 3] as const).map((n) => (
+                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
+                    <div className="flex items-center justify-between w-full">
+                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
+                      {span === n && <span className="ml-2 text-primary">✓</span>}
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          {onRemove && (
+            <Button variant="ghost" size="sm" onClick={onRemove}>
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col flex-1 min-h-0 p-0">
+        {loading ? (
+          <div className="px-4 py-6 text-center text-muted-foreground text-sm">Loading…</div>
+        ) : groups.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            No active VRRP groups.
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {groups.map((g) => (
+              <GroupRow key={`${g.name}-${g.interface ?? ""}-${g.vrid ?? ""}`} group={g} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useDashboardSSE.ts
+++ b/frontend/src/hooks/useDashboardSSE.ts
@@ -89,12 +89,27 @@ export interface WireGuardPeersData {
   total: number;
 }
 
+export interface VrrpGroupData {
+  name: string;
+  interface: string | null;
+  vrid: number | null;
+  state: string | null;          // "MASTER" | "BACKUP" | "FAULT"
+  priority: number | null;
+  last_transition: string | null;
+}
+
+export interface VrrpStatusData {
+  groups: VrrpGroupData[];
+  total: number;
+}
+
 export interface DashboardSSEData {
   interfaceCounters: InterfaceCountersData | null;
   systemInfo: SystemInfoData | null;
   wireguardPeers: WireGuardPeersData | null;
   qosStats: QoSStatsResponse | null;
   openvpnStatus: OpenVpnStatus | null;
+  vrrpStatus: VrrpStatusData | null;
 }
 
 export interface DashboardSSEState {
@@ -109,7 +124,7 @@ export interface DashboardSSEState {
 
 export function useDashboardSSE(): DashboardSSEState {
   const [status, setStatus] = useState<SSEStatus>("disconnected");
-  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null });
+  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null, vrrpStatus: null });
   const [error, setError] = useState<string | null>(null);
   const esRef = useRef<EventSource | null>(null);
 
@@ -164,6 +179,15 @@ export function useDashboardSSE(): DashboardSSEState {
       try {
         const payload = JSON.parse(event.data) as OpenVpnStatus;
         setData((prev) => ({ ...prev, openvpnStatus: payload }));
+      } catch {
+        // Ignore malformed payloads
+      }
+    });
+
+    es.addEventListener("vrrp-status", (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as VrrpStatusData;
+        setData((prev) => ({ ...prev, vrrpStatus: payload }));
       } catch {
         // Ignore malformed payloads
       }


### PR DESCRIPTION
Fixes: #119 

Surface live VRRP group state on the dashboard via the VyOS GraphQL `Show` op (`show vrrp`), folded into the shared dashboard SSE broadcaster so all clients reuse one query loop.

Backend:
- vrrp_status.py: parse the `show vrrp` summary table (name, interface, vrid, state, priority, last transition) using the dashed header rule to tolerate right-aligned numeric columns; vrrp_configured() gate and vrrp_gql_fields() helper mirroring openvpn_status.py.
- show.py: include VRRP in the slow (5s) dashboard query when configured, broadcast a `vrrp-status` SSE event, and gate it on HIGH_AVAILABILITY read permission.

Frontend:
- useDashboardSSE: VrrpStatusData types + `vrrp-status` listener.
- VrrpStatusCard: MASTER/BACKUP/FAULT state badges, scrollable group list.
- Register the card in AddCardModal (HIGH_AVAILABILITY-gated) and page.tsx; widen the Add Card modal and make its grid 3-up and scrollable.