### PR TITLE
Add VPN connection logs to the monitoring page (closes #115)

### DIFF
--- a/backend/monitoring_commands.py
+++ b/backend/monitoring_commands.py
@@ -88,6 +88,24 @@ COMMANDS: Dict[str, MonitoringCommand] = {
         template="monitor conntrack",
         params={},
     ),
+    "show_log_vpn_ipsec": MonitoringCommand(
+        name="show_log_vpn_ipsec",
+        description="IPsec VPN connection logs",
+        template="monitor log vpn",
+        params={},
+    ),
+    "show_log_openvpn": MonitoringCommand(
+        name="show_log_openvpn",
+        description="OpenVPN connection logs",
+        template="monitor log openvpn",
+        params={},
+    ),
+    "show_log_l2tp": MonitoringCommand(
+        name="show_log_l2tp",
+        description="L2TP VPN connection logs",
+        template="monitor log l2tp",
+        params={},
+    ),
 }
 
 

--- a/frontend/src/app/monitoring/page.tsx
+++ b/frontend/src/app/monitoring/page.tsx
@@ -44,6 +44,9 @@ const TABLE_COMMANDS = {
   monitor_traffic: "traffic",
   monitor_log: "log",
   show_log_tail: "log",
+  show_log_vpn_ipsec: "log",
+  show_log_openvpn: "log",
+  show_log_l2tp: "log",
   monitor_conntrack: "conntrack",
 } as const;
 

--- a/frontend/src/lib/monitoring/parsers.ts
+++ b/frontend/src/lib/monitoring/parsers.ts
@@ -201,13 +201,20 @@ function detectSeverity(facilityLevel: string, message: string): LogSeverity {
   if (/\berror\b|\bfail(ed|ure)?\b/.test(lc)) return "error";
   if (/\bwarn(ing)?\b/.test(lc)) return "warning";
   if (/\bdebug\b/.test(lc)) return "debug";
-  return "unknown";
+
+  return "info";
 }
 
 // "Jan 15 14:22:19 hostname [facility.level] process[pid]: message"
 // "Jan 15 14:22:19 hostname process[pid]: message"
+// "Jun 14 15:47:56 process[pid]: message"  (journald w/o hostname — `show log openvpn|vpn|l2tp`)
+//
+// The hostname group is optional AND lazy so the no-hostname form is preferred:
+// this keeps messages that themselves contain a colon (e.g. "net_addr_v4_add: 10.8.0.1")
+// from being mis-split into hostname/process. The process token excludes "[" so a
+// "process[pid]:" prefix can never be swallowed as a hostname.
 const LOG_RE =
-  /^(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(\S+)\s+(?:(\w+\.\w+)\s+)?(\S+?)(?:\[(\d+)\])?:\s*(.*)/;
+  /^(\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?:(\S+)\s+)??(?:(\w+\.\w+)\s+)?([\w.\-/@]+?)(?:\[(\d+)\])?:\s*(.*)/;
 
 export function parseLogLine(line: string, id: number): LogEntry | null {
   const trimmed = clean(line);


### PR DESCRIPTION
Surface IPsec, OpenVPN, and L2TP connection logs through the existing SSH monitoring page, completing the last open item of the VPN feature set ("Connection logs and diagnostics").

- backend: allowlist three monitoring commands — `monitor log vpn` (IPsec), `monitor log openvpn`, and `monitor log l2tp` — so they stream as tail-style log views.
- frontend: route the three commands to the parsed LogTable view.
- parsers: fix LOG_RE to handle the journald format these logs use, which omits the hostname (`MMM DD HH:MM:SS process[pid]: message`). The hostname group is now optional and lazy so messages containing a colon (e.g. "net_addr_v4_add: 10.8.0.1") aren't mis-split; the process token excludes "[" so a "process[pid]:" prefix can't be swallowed as a hostname. Existing hostname-bearing syslog lines still parse unchanged.
- parsers: default lines with no facility tag or severity keyword to "info" instead of "unknown", matching journald/syslog convention so VPN log lines no longer all show as Unknown.