### PR TITLE
Add shared InterfaceSelect and apply themed scrollbars app-wide

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -133,6 +133,39 @@
     opacity: 0.35;
   }
 
+  /*
+   * Themed scrollbars applied app-wide. Every native scroll container — pages,
+   * panels, and modals — gets the thin, rounded, theme-colored scrollbar
+   * instead of the chunky default browser one. Radix ScrollArea viewports are
+   * excluded: they render their own custom scrollbar and already hide the
+   * native one, so styling them would re-show a duplicate.
+   */
+  *:not([data-radix-scroll-area-viewport]) {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+
+  *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 9999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  *:not([data-radix-scroll-area-viewport])::-webkit-scrollbar-thumb:hover {
+    background: var(--muted-foreground);
+    background-clip: padding-box;
+  }
+
   /* Glowing effects */
   .glow-primary {
     box-shadow: 0 0 20px var(--primary), 0 0 40px color-mix(in srgb, var(--primary) 30%, transparent);

--- a/frontend/src/components/babel/BabelInterfaceModal.tsx
+++ b/frontend/src/components/babel/BabelInterfaceModal.tsx
@@ -23,7 +23,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2 } from "lucide-react";
 import type { BabelInterface, BabelCapabilities } from "@/lib/api/babel";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface BabelInterfaceModalProps {
   open: boolean;
@@ -59,12 +60,12 @@ export function BabelInterfaceModal({
   // UI state
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -278,25 +279,14 @@ export function BabelInterfaceModal({
               {/* Interface Name */}
               <div className="space-y-2">
                 <Label htmlFor="babel-iface-name">Interface</Label>
-                <Select
+                <InterfaceSelect
                   value={name}
                   onValueChange={setName}
                   disabled={isEditMode}
-                >
-                  <SelectTrigger
-                    id="babel-iface-name"
-                    className={isEditMode ? "bg-muted" : ""}
-                  >
-                    <SelectValue placeholder="Select an interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface} value={iface}>
-                        {iface}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                  id="babel-iface-name"
+                  className={isEditMode ? "bg-muted" : ""}
+                  interfaces={availableInterfaces}
+                />
                 <p className="text-xs text-muted-foreground">
                   The VyOS interface to enable Babel on.
                 </p>

--- a/frontend/src/components/bonding/CreateBondingModal.tsx
+++ b/frontend/src/components/bonding/CreateBondingModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Loader2, Link2, X, Plus } from "lucide-react";
 import { bondingService, type BondingCapabilities } from "@/lib/api/bonding";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 const BONDING_MODES = [
@@ -517,14 +518,13 @@ export function CreateBondingModal({
             </div>
 
             <div className="flex gap-2">
-              <Select value={memberToAdd} onValueChange={setMemberToAdd}>
-                <SelectTrigger className="flex-1"><SelectValue placeholder="Select an interface to add" /></SelectTrigger>
-                <SelectContent>
-                  {ethernetInterfaces.map((i) => (
-                    <SelectItem key={i.name} value={i.name}>{i.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={memberToAdd}
+                onValueChange={setMemberToAdd}
+                interfaces={ethernetInterfaces}
+                className="flex-1"
+                placeholder="Select an interface to add"
+              />
               <Button
                 variant="outline"
                 onClick={() => {

--- a/frontend/src/components/bonding/EditBondingModal.tsx
+++ b/frontend/src/components/bonding/EditBondingModal.tsx
@@ -28,6 +28,7 @@ import {
   type BondingInterface,
 } from "@/lib/api/bonding";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 const BONDING_MODES = [
@@ -601,14 +602,13 @@ export function EditBondingModal({
             </div>
 
             <div className="flex gap-2">
-              <Select value={memberToAdd} onValueChange={setMemberToAdd}>
-                <SelectTrigger className="flex-1"><SelectValue placeholder="Select an interface to add" /></SelectTrigger>
-                <SelectContent>
-                  {ethernetInterfaces.map((i) => (
-                    <SelectItem key={i.name} value={i.name}>{i.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={memberToAdd}
+                onValueChange={setMemberToAdd}
+                interfaces={ethernetInterfaces}
+                className="flex-1"
+                placeholder="Select an interface to add"
+              />
               <Button
                 variant="outline"
                 onClick={() => {

--- a/frontend/src/components/bridge/CreateBridgeModal.tsx
+++ b/frontend/src/components/bridge/CreateBridgeModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Loader2, Network, X, Plus } from "lucide-react";
 import { bridgeService, type BridgeCapabilities } from "@/lib/api/bridge";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface MemberFormState {
@@ -513,14 +514,13 @@ export function CreateBridgeModal({
             </div>
 
             <div className="flex gap-2">
-              <Select value={memberToAdd} onValueChange={setMemberToAdd}>
-                <SelectTrigger className="flex-1"><SelectValue placeholder="Select an interface to add" /></SelectTrigger>
-                <SelectContent>
-                  {selectableInterfaces.map((i) => (
-                    <SelectItem key={i.name} value={i.name}>{i.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={memberToAdd}
+                onValueChange={setMemberToAdd}
+                interfaces={selectableInterfaces}
+                className="flex-1"
+                placeholder="Select an interface to add"
+              />
               <Button variant="outline" onClick={addMember} disabled={!memberToAdd}>
                 <Plus className="h-4 w-4 mr-1" /> Add
               </Button>

--- a/frontend/src/components/bridge/EditBridgeModal.tsx
+++ b/frontend/src/components/bridge/EditBridgeModal.tsx
@@ -28,6 +28,7 @@ import {
   type BridgeInterface,
 } from "@/lib/api/bridge";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface MemberFormState {
@@ -481,14 +482,13 @@ export function EditBridgeModal({
             </div>
 
             <div className="flex gap-2">
-              <Select value={memberToAdd} onValueChange={setMemberToAdd}>
-                <SelectTrigger className="flex-1"><SelectValue placeholder="Select an interface to add" /></SelectTrigger>
-                <SelectContent>
-                  {selectableInterfaces.map((i) => (
-                    <SelectItem key={i.name} value={i.name}>{i.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={memberToAdd}
+                onValueChange={setMemberToAdd}
+                interfaces={selectableInterfaces}
+                className="flex-1"
+                placeholder="Select an interface to add"
+              />
               <Button variant="outline" onClick={addMember} disabled={!memberToAdd}>
                 <Plus className="h-4 w-4 mr-1" /> Add
               </Button>

--- a/frontend/src/components/broadcast-relay/BroadcastRelayInstanceModal.tsx
+++ b/frontend/src/components/broadcast-relay/BroadcastRelayInstanceModal.tsx
@@ -15,16 +15,10 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import type { BroadcastRelayInstance } from "@/lib/api/broadcast-relay";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface Props {
   open: boolean;
@@ -242,27 +236,14 @@ export function BroadcastRelayInstanceModal({ open, onOpenChange, instance, onSu
               )}
 
               <div className="flex items-center gap-2">
-                <Select value={selectedInterface} onValueChange={setSelectedInterface}>
-                  <SelectTrigger className="flex-1">
-                    <SelectValue
-                      placeholder={
-                        interfacesLoading
-                          ? "Loading interfaces..."
-                          : availableToAdd.length === 0
-                          ? "No more interfaces available"
-                          : "Select interface to add"
-                      }
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableToAdd.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        <span className="font-mono">{iface.name}</span>
-                        <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={selectedInterface}
+                  onValueChange={setSelectedInterface}
+                  interfaces={availableToAdd}
+                  className="flex-1"
+                  placeholder="Select interface to add"
+                  emptyText="No more interfaces available"
+                />
                 <Button
                   variant="outline"
                   size="icon"

--- a/frontend/src/components/conntrack-sync/ConntrackSyncModal.tsx
+++ b/frontend/src/components/conntrack-sync/ConntrackSyncModal.tsx
@@ -17,13 +17,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   Loader2,
   Plus,
   Trash2,
@@ -33,7 +26,8 @@ import {
   Settings2,
 } from "lucide-react";
 import { ConntrackSyncConfig, ConntrackSyncInterface } from "@/lib/api/conntrack-sync";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface ConntrackSyncModalProps {
   open: boolean;
@@ -54,7 +48,7 @@ export function ConntrackSyncModal({ open, config, onClose, onSubmit }: Conntrac
   const [error, setError] = useState<string | null>(null);
 
   // Available interfaces from VyOS
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState(false);
 
   // Tab 1 — Interfaces
@@ -85,7 +79,7 @@ export function ConntrackSyncModal({ open, config, onClose, onSubmit }: Conntrac
     // Load available interfaces (non-critical)
     setInterfacesLoading(true);
     showService.getAllInterfaces()
-      .then((res) => setAvailableInterfaces(res.interfaces.map((i) => i.name).sort()))
+      .then((res) => setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name))))
       .catch(() => {/* non-critical */})
       .finally(() => setInterfacesLoading(false));
 
@@ -250,35 +244,18 @@ export function ConntrackSyncModal({ open, config, onClose, onSubmit }: Conntrac
                   <div key={row.key} className="grid grid-cols-[1fr_1fr_100px_32px] gap-2 items-end">
                     <div className="space-y-1">
                       <Label className="text-xs">Interface</Label>
-                      <Select
-                        value={row.name || undefined}
+                      <InterfaceSelect
+                        value={row.name}
                         onValueChange={(val) => updateIfaceRow(row.key, "name", val)}
                         disabled={interfacesLoading}
-                      >
-                        <SelectTrigger>
-                          <SelectValue
-                            placeholder={interfacesLoading ? "Loading..." : "Select interface"}
-                          />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {availableInterfaces
-                            .filter(
-                              (iface) =>
-                                iface === row.name ||
-                                !ifaceRows.some((r) => r.key !== row.key && r.name === iface)
-                            )
-                            .map((iface) => (
-                              <SelectItem key={iface} value={iface}>
-                                {iface}
-                              </SelectItem>
-                            ))}
-                          {availableInterfaces.length === 0 && !interfacesLoading && (
-                            <SelectItem value="" disabled>
-                              No interfaces found
-                            </SelectItem>
-                          )}
-                        </SelectContent>
-                      </Select>
+                        interfaces={availableInterfaces.filter(
+                          (iface) =>
+                            iface.name === row.name ||
+                            !ifaceRows.some((r) => r.key !== row.key && r.name === iface.name)
+                        )}
+                        placeholder="Select interface"
+                        emptyText="No interfaces found"
+                      />
                     </div>
                     <div className="space-y-1">
                       <Label className="text-xs">Peer IP (optional)</Label>

--- a/frontend/src/components/dhcp-relay/DHCPRelayModal.tsx
+++ b/frontend/src/components/dhcp-relay/DHCPRelayModal.tsx
@@ -26,6 +26,7 @@ import {
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import { dhcpRelayService, DHCPRelayConfig } from "@/lib/api/dhcp-relay";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface DHCPRelayModalProps {
   open: boolean;
@@ -526,27 +527,15 @@ function InterfaceSection({
       )}
 
       <div className="flex items-center gap-2">
-        <Select value={selected} onValueChange={onSelectedChange}>
-          <SelectTrigger className="flex-1">
-            <SelectValue
-              placeholder={
-                loading
-                  ? "Loading interfaces..."
-                  : available.length === 0
-                  ? "No additional interfaces available"
-                  : "Select interface to add"
-              }
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {available.map((iface) => (
-              <SelectItem key={iface.name} value={iface.name}>
-                <span className="font-mono">{iface.name}</span>
-                <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <InterfaceSelect
+          value={selected}
+          onValueChange={onSelectedChange}
+          interfaces={available}
+          disabled={loading}
+          className="flex-1"
+          placeholder="Select interface to add"
+          emptyText="No additional interfaces available"
+        />
         <Button
           variant="outline"
           size="icon"

--- a/frontend/src/components/dhcpv6-relay/DHCPv6RelayModal.tsx
+++ b/frontend/src/components/dhcpv6-relay/DHCPv6RelayModal.tsx
@@ -16,16 +16,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import { dhcpv6RelayService, DHCPv6RelayConfig } from "@/lib/api/dhcpv6-relay";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface DHCPv6RelayModalProps {
   open: boolean;
@@ -357,27 +351,12 @@ export function DHCPv6RelayModal({ open, onClose, onSuccess, config }: DHCPv6Rel
               )}
 
               <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
-                <Select value={listenSelectedIface} onValueChange={setListenSelectedIface}>
-                  <SelectTrigger>
-                    <SelectValue
-                      placeholder={
-                        interfacesLoading
-                          ? "Loading..."
-                          : availableForListen.length === 0
-                          ? "No interfaces available"
-                          : "Select interface"
-                      }
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableForListen.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        <span className="font-mono">{iface.name}</span>
-                        <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={listenSelectedIface}
+                  onValueChange={setListenSelectedIface}
+                  interfaces={availableForListen}
+                  placeholder="Select interface"
+                />
                 <Input
                   value={listenAddressInput}
                   onChange={(e) => setListenAddressInput(e.target.value)}
@@ -481,27 +460,13 @@ export function DHCPv6RelayModal({ open, onClose, onSuccess, config }: DHCPv6Rel
 
               {/* Add upstream interface */}
               <div className="flex items-center gap-2">
-                <Select value={upstreamSelectedIface} onValueChange={setUpstreamSelectedIface}>
-                  <SelectTrigger className="flex-1">
-                    <SelectValue
-                      placeholder={
-                        interfacesLoading
-                          ? "Loading..."
-                          : availableForUpstream.length === 0
-                          ? "No interfaces available"
-                          : "Select upstream interface to add"
-                      }
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableForUpstream.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        <span className="font-mono">{iface.name}</span>
-                        <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={upstreamSelectedIface}
+                  onValueChange={setUpstreamSelectedIface}
+                  interfaces={availableForUpstream}
+                  className="flex-1"
+                  placeholder="Select upstream interface to add"
+                />
                 <Button
                   variant="outline"
                   size="icon"

--- a/frontend/src/components/dns-dynamic/DNSDynamicEntryModal.tsx
+++ b/frontend/src/components/dns-dynamic/DNSDynamicEntryModal.tsx
@@ -25,6 +25,7 @@ import {
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import type { DynamicNameEntry } from "@/lib/api/dns-dynamic";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface Props {
   open: boolean;
@@ -298,29 +299,14 @@ export function DNSDynamicEntryModal({ open, onOpenChange, entry, onSubmit }: Pr
                 {addressSource === "interface" ? (
                   <div className="space-y-2">
                     <Label>Interface</Label>
-                    <Select
+                    <InterfaceSelect
                       value={addressInterface || "none"}
                       onValueChange={(v) => setAddressInterface(v === "none" ? "" : v)}
-                    >
-                      <SelectTrigger className="font-mono">
-                        <SelectValue
-                          placeholder={
-                            interfacesLoading ? "Loading interfaces..." : "Select interface"
-                          }
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="none">
-                          <span className="text-muted-foreground">None</span>
-                        </SelectItem>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name}>
-                            <span className="font-mono">{iface.name}</span>
-                            <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      interfaces={availableInterfaces}
+                      noneOption={{ label: "None", value: "none" }}
+                      className="font-mono"
+                      placeholder="Select interface"
+                    />
                   </div>
                 ) : (
                   <>

--- a/frontend/src/components/dummy/CreateDummyModal.tsx
+++ b/frontend/src/components/dummy/CreateDummyModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Box, Loader2 } from "lucide-react";
 import { dummyService, type DummyCapabilities } from "@/lib/api/dummy";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateDummyModalProps {
@@ -318,39 +319,33 @@ export function CreateDummyModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress →</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress →</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
 

--- a/frontend/src/components/dummy/EditDummyModal.tsx
+++ b/frontend/src/components/dummy/EditDummyModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Box, Loader2 } from "lucide-react";
 import { dummyService, type DummyInterface, type DummyCapabilities } from "@/lib/api/dummy";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditDummyModalProps {
@@ -299,39 +300,33 @@ export function EditDummyModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress →</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress →</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
 

--- a/frontend/src/components/failover/FailoverRouteModal.tsx
+++ b/frontend/src/components/failover/FailoverRouteModal.tsx
@@ -206,7 +206,10 @@ function InterfaceSelect({
         <SelectItem value="__none__">None</SelectItem>
         {interfaces.map((iface) => (
           <SelectItem key={iface.name} value={iface.name}>
-            {iface.name}
+            <span className="font-mono">{iface.name}</span>
+            {iface.description && (
+              <span className="text-muted-foreground ml-2 text-xs">{iface.description}</span>
+            )}
           </SelectItem>
         ))}
       </SelectContent>

--- a/frontend/src/components/firewall/CreateBridgeRuleModal.tsx
+++ b/frontend/src/components/firewall/CreateBridgeRuleModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RefreshCw, AlertCircle, Loader2 } from "lucide-react";
 import {
@@ -488,55 +489,23 @@ export function CreateBridgeRuleModal({
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="inboundInterface">Inbound Interface</Label>
-                    <Select
+                    <InterfaceSelect
                       value={inboundInterface || "_none_"}
                       onValueChange={(v) => setInboundInterface(v === "_none_" ? "" : v)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="None" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="_none_" textValue="None">None</SelectItem>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name} textValue={iface.name}>
-                            <div className="flex flex-col">
-                              <span>{iface.name}</span>
-                              {iface.description && (
-                                <span className="text-xs text-muted-foreground">
-                                  {iface.description}
-                                </span>
-                              )}
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      interfaces={availableInterfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      noneOption={{ label: "None", value: "_none_" }}
+                      placeholder="None"
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="outboundInterface">Outbound Interface</Label>
-                    <Select
+                    <InterfaceSelect
                       value={outboundInterface || "_none_"}
                       onValueChange={(v) => setOutboundInterface(v === "_none_" ? "" : v)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="None" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="_none_" textValue="None">None</SelectItem>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name} textValue={iface.name}>
-                            <div className="flex flex-col">
-                              <span>{iface.name}</span>
-                              {iface.description && (
-                                <span className="text-xs text-muted-foreground">
-                                  {iface.description}
-                                </span>
-                              )}
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      interfaces={availableInterfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      noneOption={{ label: "None", value: "_none_" }}
+                      placeholder="None"
+                    />
                   </div>
                 </div>
               )}

--- a/frontend/src/components/firewall/CreateFirewallRuleModal.tsx
+++ b/frontend/src/components/firewall/CreateFirewallRuleModal.tsx
@@ -35,6 +35,7 @@ import { firewallIPv6Service } from "@/lib/api/firewall-ipv6";
 import { firewallGroupsService, type FirewallGroup } from "@/lib/api/firewall-groups";
 import { flowtablesService, type Flowtable } from "@/lib/api/firewall-flowtables";
 import { showService } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { NetworkInterface } from "@/lib/api/interfaces";
 import { CountryMultiSelect } from "./CountryMultiSelect";
 import {
@@ -273,7 +274,7 @@ export function CreateFirewallRuleModal({
           name: i.name,
           type: "ethernet" as const,
           addresses: [],
-          description: null,
+          description: i.description ?? null,
           vrf: null,
           "hw-id": null,
           "source-interface": null,
@@ -2099,36 +2100,26 @@ export function CreateFirewallRuleModal({
 
             <div className="space-y-2">
               <Label htmlFor="inboundInterface">Inbound Interface</Label>
-              <Select value={inboundInterface} onValueChange={setInboundInterface}>
-                <SelectTrigger id="inboundInterface">
-                  <SelectValue placeholder="Any interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="any">Any</SelectItem>
-                  {interfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={inboundInterface}
+                onValueChange={setInboundInterface}
+                id="inboundInterface"
+                interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                noneOption={{ label: "Any", value: "any" }}
+                placeholder="Any interface"
+              />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="outboundInterface">Outbound Interface</Label>
-              <Select value={outboundInterface} onValueChange={setOutboundInterface}>
-                <SelectTrigger id="outboundInterface">
-                  <SelectValue placeholder="Any interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="any">Any</SelectItem>
-                  {interfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={outboundInterface}
+                onValueChange={setOutboundInterface}
+                id="outboundInterface"
+                interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                noneOption={{ label: "Any", value: "any" }}
+                placeholder="Any interface"
+              />
             </div>
 
             {/* IPsec Matching */}

--- a/frontend/src/components/firewall/CreateFlowtableModal.tsx
+++ b/frontend/src/components/firewall/CreateFlowtableModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Badge } from "@/components/ui/badge";
 import { AlertCircle, X, Plus } from "lucide-react";
 import { flowtablesService, type Flowtable } from "@/lib/api/firewall-flowtables";
@@ -186,25 +187,15 @@ export function CreateFlowtableModal({
               Interfaces <span className="text-destructive">*</span>
             </Label>
             <div className="flex gap-2">
-              <Select value={selectedInterface} onValueChange={setSelectedInterface}>
-                <SelectTrigger className="flex-1">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces
-                    .filter((iface) => !interfaces.includes(iface.name))
-                    .map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        {iface.name}
-                        {iface.description && (
-                          <span className="text-muted-foreground ml-2">
-                            - {iface.description}
-                          </span>
-                        )}
-                      </SelectItem>
-                    ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={selectedInterface}
+                onValueChange={setSelectedInterface}
+                interfaces={availableInterfaces
+                  .filter((iface) => !interfaces.includes(iface.name))
+                  .map((i) => ({ name: i.name, type: i.type, description: i.description ?? null }))}
+                className="flex-1"
+                placeholder="Select interface"
+              />
               <Button
                 type="button"
                 variant="outline"

--- a/frontend/src/components/firewall/EditBridgeRuleModal.tsx
+++ b/frontend/src/components/firewall/EditBridgeRuleModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RefreshCw, AlertCircle, Loader2 } from "lucide-react";
 import {
@@ -517,55 +518,23 @@ export function EditBridgeRuleModal({
                 <div className="grid grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="inboundInterface">Inbound Interface</Label>
-                    <Select
+                    <InterfaceSelect
                       value={inboundInterface || "_none_"}
                       onValueChange={(v) => setInboundInterface(v === "_none_" ? "" : v)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="None" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="_none_" textValue="None">None</SelectItem>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name} textValue={iface.name}>
-                            <div className="flex flex-col">
-                              <span>{iface.name}</span>
-                              {iface.description && (
-                                <span className="text-xs text-muted-foreground">
-                                  {iface.description}
-                                </span>
-                              )}
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      interfaces={availableInterfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      noneOption={{ label: "None", value: "_none_" }}
+                      placeholder="None"
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="outboundInterface">Outbound Interface</Label>
-                    <Select
+                    <InterfaceSelect
                       value={outboundInterface || "_none_"}
                       onValueChange={(v) => setOutboundInterface(v === "_none_" ? "" : v)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="None" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="_none_" textValue="None">None</SelectItem>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name} textValue={iface.name}>
-                            <div className="flex flex-col">
-                              <span>{iface.name}</span>
-                              {iface.description && (
-                                <span className="text-xs text-muted-foreground">
-                                  {iface.description}
-                                </span>
-                              )}
-                            </div>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      interfaces={availableInterfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      noneOption={{ label: "None", value: "_none_" }}
+                      placeholder="None"
+                    />
                   </div>
                 </div>
               )}

--- a/frontend/src/components/firewall/EditFirewallRuleModal.tsx
+++ b/frontend/src/components/firewall/EditFirewallRuleModal.tsx
@@ -35,6 +35,7 @@ import { firewallIPv6Service } from "@/lib/api/firewall-ipv6";
 import { firewallGroupsService, type FirewallGroup } from "@/lib/api/firewall-groups";
 import { flowtablesService, type Flowtable } from "@/lib/api/firewall-flowtables";
 import { showService } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { NetworkInterface } from "@/lib/api/interfaces";
 import { CountryMultiSelect } from "./CountryMultiSelect";
 import {
@@ -255,7 +256,7 @@ export function EditFirewallRuleModal({
           name: i.name,
           type: "ethernet" as const,
           addresses: [],
-          description: null,
+          description: i.description ?? null,
           vrf: null,
           "hw-id": null,
           "source-interface": null,
@@ -2134,36 +2135,26 @@ export function EditFirewallRuleModal({
 
             <div className="space-y-2">
               <Label htmlFor="inboundInterface">Inbound Interface</Label>
-              <Select value={inboundInterface} onValueChange={setInboundInterface}>
-                <SelectTrigger id="inboundInterface">
-                  <SelectValue placeholder="Any interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="any">Any</SelectItem>
-                  {interfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={inboundInterface}
+                onValueChange={setInboundInterface}
+                id="inboundInterface"
+                interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                noneOption={{ label: "Any", value: "any" }}
+                placeholder="Any interface"
+              />
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="outboundInterface">Outbound Interface</Label>
-              <Select value={outboundInterface} onValueChange={setOutboundInterface}>
-                <SelectTrigger id="outboundInterface">
-                  <SelectValue placeholder="Any interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="any">Any</SelectItem>
-                  {interfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={outboundInterface}
+                onValueChange={setOutboundInterface}
+                id="outboundInterface"
+                interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                noneOption={{ label: "Any", value: "any" }}
+                placeholder="Any interface"
+              />
             </div>
 
             {/* IPsec Matching */}

--- a/frontend/src/components/firewall/EditFlowtableModal.tsx
+++ b/frontend/src/components/firewall/EditFlowtableModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Badge } from "@/components/ui/badge";
 import { AlertCircle, X, Plus } from "lucide-react";
 import { flowtablesService, type Flowtable } from "@/lib/api/firewall-flowtables";
@@ -177,25 +178,15 @@ export function EditFlowtableModal({
               Interfaces <span className="text-destructive">*</span>
             </Label>
             <div className="flex gap-2">
-              <Select value={selectedInterface} onValueChange={setSelectedInterface}>
-                <SelectTrigger className="flex-1">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces
-                    .filter((iface) => !interfaces.includes(iface.name))
-                    .map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        {iface.name}
-                        {iface.description && (
-                          <span className="text-muted-foreground ml-2">
-                            - {iface.description}
-                          </span>
-                        )}
-                      </SelectItem>
-                    ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={selectedInterface}
+                onValueChange={setSelectedInterface}
+                interfaces={availableInterfaces
+                  .filter((iface) => !interfaces.includes(iface.name))
+                  .map((i) => ({ name: i.name, type: i.type, description: i.description ?? null }))}
+                className="flex-1"
+                placeholder="Select interface"
+              />
               <Button
                 type="button"
                 variant="outline"

--- a/frontend/src/components/firewall/zones/CreateZoneModal.tsx
+++ b/frontend/src/components/firewall/zones/CreateZoneModal.tsx
@@ -335,8 +335,8 @@ export function CreateZoneModal({
                         className="text-sm font-mono cursor-pointer flex-1"
                       >
                         {iface.name}
-                        {iface.type && (
-                          <span className="text-xs text-muted-foreground ml-2 font-sans">{iface.type}</span>
+                        {iface.description && (
+                          <span className="text-xs text-muted-foreground ml-2 font-sans">{iface.description}</span>
                         )}
                       </label>
                     </div>

--- a/frontend/src/components/firewall/zones/EditZoneModal.tsx
+++ b/frontend/src/components/firewall/zones/EditZoneModal.tsx
@@ -267,8 +267,8 @@ export function EditZoneModal({
                           className="text-sm font-mono cursor-pointer flex-1"
                         >
                           {iface.name}
-                          {iface.type && (
-                            <span className="text-xs text-muted-foreground ml-2 font-sans">{iface.type}</span>
+                          {iface.description && (
+                            <span className="text-xs text-muted-foreground ml-2 font-sans">{iface.description}</span>
                           )}
                         </label>
                       </div>

--- a/frontend/src/components/geneve/CreateGeneveModal.tsx
+++ b/frontend/src/components/geneve/CreateGeneveModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Layers, Loader2 } from "lucide-react";
 import { geneveService, type GeneveCapabilities } from "@/lib/api/geneve";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateGeneveModalProps {
@@ -650,39 +651,33 @@ export function CreateGeneveModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress &rarr;</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress &rarr;</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/geneve/EditGeneveModal.tsx
+++ b/frontend/src/components/geneve/EditGeneveModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Layers, Loader2 } from "lucide-react";
 import { geneveService, type GeneveInterface, type GeneveCapabilities } from "@/lib/api/geneve";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditGeneveModalProps {
@@ -624,39 +625,33 @@ export function EditGeneveModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress &rarr;</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress &rarr;</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/high-availability/VrrpGroupModal.tsx
+++ b/frontend/src/components/high-availability/VrrpGroupModal.tsx
@@ -30,6 +30,7 @@ import {
 import { AlertCircle, ChevronDown, Loader2, Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/lib/api/client";
+import type { InterfaceName } from "@/lib/api/show";
 import type { VrrpGroup, VrrpGroupAddress } from "@/lib/api/high-availability";
 
 // ============================================================================
@@ -167,7 +168,7 @@ function InterfaceSelect({
 }: {
   value: string;
   onChange: (v: string) => void;
-  interfaces: string[];
+  interfaces: InterfaceName[];
   placeholder?: string;
   className?: string;
 }) {
@@ -196,8 +197,11 @@ function InterfaceSelect({
           <span className="text-muted-foreground">{placeholder}</span>
         </SelectItem>
         {interfaces.map((iface) => (
-          <SelectItem key={iface} value={iface}>
-            <span className="font-mono">{iface}</span>
+          <SelectItem key={iface.name} value={iface.name}>
+            <span className="font-mono">{iface.name}</span>
+            {iface.description && (
+              <span className="text-muted-foreground ml-2 text-xs">{iface.description}</span>
+            )}
           </SelectItem>
         ))}
       </SelectContent>
@@ -230,7 +234,7 @@ export function VrrpGroupModal({
   const [newPeer, setNewPeer] = useState("");
 
   // Interfaces fetched from the router
-  const [interfaces, setInterfaces] = useState<string[]>([]);
+  const [interfaces, setInterfaces] = useState<InterfaceName[]>([]);
   const [trackIfaceSelection, setTrackIfaceSelection] = useState("");
 
   useEffect(() => {
@@ -243,8 +247,8 @@ export function VrrpGroupModal({
 
       // Fetch interfaces
       apiClient
-        .get<{ interfaces: { name: string; type: string }[] }>("/vyos/show/all-interfaces")
-        .then((r) => setInterfaces(r.interfaces.map((i) => i.name).sort()))
+        .get<{ interfaces: InterfaceName[] }>("/vyos/show/all-interfaces")
+        .then((r) => setInterfaces([...r.interfaces].sort((a, b) => a.name.localeCompare(b.name))))
         .catch(() => setInterfaces([]));
     }
   }, [open, existingGroup]);
@@ -290,7 +294,7 @@ export function VrrpGroupModal({
   const removeTrackIface = (iface: string) =>
     setForm((prev) => ({ ...prev, track_interfaces: prev.track_interfaces.filter((i) => i !== iface) }));
 
-  const availableTrackInterfaces = interfaces.filter((i) => !form.track_interfaces.includes(i));
+  const availableTrackInterfaces = interfaces.filter((i) => !form.track_interfaces.includes(i.name));
 
   const handleSubmit = async () => {
     setError(null);

--- a/frontend/src/components/igmp-proxy/IgmpProxyInterfaceModal.tsx
+++ b/frontend/src/components/igmp-proxy/IgmpProxyInterfaceModal.tsx
@@ -23,6 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import type { IgmpProxyInterface } from "@/lib/api/igmp-proxy";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface IgmpProxyInterfaceModalProps {
   open: boolean;
@@ -221,19 +222,12 @@ export function IgmpProxyInterfaceModal({
                   className="bg-muted font-mono"
                 />
               ) : (
-                <Select value={name} onValueChange={setName}>
-                  <SelectTrigger>
-                    <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        <span className="font-mono">{iface.name}</span>
-                        <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={name}
+                  onValueChange={setName}
+                  interfaces={availableInterfaces}
+                  placeholder="Select interface"
+                />
               )}
               <p className="text-xs text-muted-foreground">
                 Network interface to participate in IGMP proxy.

--- a/frontend/src/components/igmp-proxy/IgmpProxySetupModal.tsx
+++ b/frontend/src/components/igmp-proxy/IgmpProxySetupModal.tsx
@@ -12,13 +12,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -31,6 +24,7 @@ import {
 } from "lucide-react";
 import type { IgmpProxyInterface } from "@/lib/api/igmp-proxy";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface IgmpProxySetupModalProps {
   open: boolean;
@@ -238,19 +232,12 @@ export function IgmpProxySetupModal({
 
               <div className="space-y-2">
                 <Label>Interface</Label>
-                <Select value={upstreamName} onValueChange={setUpstreamName}>
-                  <SelectTrigger>
-                    <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        <span className="font-mono">{iface.name}</span>
-                        <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={upstreamName}
+                  onValueChange={setUpstreamName}
+                  interfaces={availableInterfaces}
+                  placeholder="Select interface"
+                />
               </div>
 
               <div className="space-y-2">
@@ -379,19 +366,12 @@ export function IgmpProxySetupModal({
 
               <div className="space-y-2">
                 <Label>Interface</Label>
-                <Select value={downstreamName} onValueChange={setDownstreamName}>
-                  <SelectTrigger>
-                    <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        <span className="font-mono">{iface.name}</span>
-                        <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={downstreamName}
+                  onValueChange={setDownstreamName}
+                  interfaces={availableInterfaces}
+                  placeholder="Select interface"
+                />
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/components/input/CreateInputModal.tsx
+++ b/frontend/src/components/input/CreateInputModal.tsx
@@ -12,17 +12,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ArrowDownToLine, Loader2 } from "lucide-react";
 import { inputService, type InputCapabilities } from "@/lib/api/input";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateInputModalProps {
@@ -153,15 +147,13 @@ export function CreateInputModal({
 
           <div className="space-y-2">
             <Label>Redirect To</Label>
-            <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-              <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">None</SelectItem>
-                {availableInterfaces.map((iface) => (
-                  <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={redirect || "none"}
+              onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+              interfaces={availableInterfaces}
+              noneOption={{ label: "None", value: "none" }}
+              placeholder="None"
+            />
             <p className="text-xs text-muted-foreground">Redirect incoming packets to a destination interface</p>
           </div>
 

--- a/frontend/src/components/input/EditInputModal.tsx
+++ b/frontend/src/components/input/EditInputModal.tsx
@@ -12,17 +12,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ArrowDownToLine, Loader2 } from "lucide-react";
 import { inputService, type InputInterface, type InputCapabilities } from "@/lib/api/input";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditInputModalProps {
@@ -124,15 +118,13 @@ export function EditInputModal({
 
           <div className="space-y-2">
             <Label>Redirect To</Label>
-            <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-              <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">None</SelectItem>
-                {availableInterfaces.map((iface) => (
-                  <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={redirect || "none"}
+              onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+              interfaces={availableInterfaces}
+              noneOption={{ label: "None", value: "none" }}
+              placeholder="None"
+            />
             <p className="text-xs text-muted-foreground">Redirect incoming packets to a destination interface</p>
           </div>
 

--- a/frontend/src/components/isis/IsisInterfaceModal.tsx
+++ b/frontend/src/components/isis/IsisInterfaceModal.tsx
@@ -30,7 +30,8 @@ import {
   IsisInterfaceRemoteLfa,
   IsisCapabilities,
 } from "@/lib/api/isis";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface IsisInterfaceModalProps {
   open: boolean;
@@ -78,7 +79,7 @@ export function IsisInterfaceModal({
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [interfaceNames, setInterfaceNames] = useState<string[]>([]);
+  const [interfaceNames, setInterfaceNames] = useState<InterfaceName[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState(false);
 
   // Basic fields
@@ -132,7 +133,7 @@ export function IsisInterfaceModal({
     setInterfacesLoading(true);
     showService
       .getAllInterfaces()
-      .then((res) => setInterfaceNames(res.interfaces.map((i) => i.name).sort()))
+      .then((res) => setInterfaceNames([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name))))
       .catch(() => setInterfaceNames([]))
       .finally(() => setInterfacesLoading(false));
 
@@ -299,18 +300,13 @@ export function IsisInterfaceModal({
                   {name}
                 </div>
               ) : (
-                <Select value={name} onValueChange={setName} disabled={interfacesLoading}>
-                  <SelectTrigger>
-                    <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {interfaceNames.map((iface) => (
-                      <SelectItem key={iface} value={iface} className="font-mono">
-                        {iface}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={name}
+                  onValueChange={setName}
+                  disabled={interfacesLoading}
+                  interfaces={interfaceNames}
+                  placeholder="Select interface"
+                />
               )}
             </div>
 

--- a/frontend/src/components/l2tpv3/CreateL2TPv3Modal.tsx
+++ b/frontend/src/components/l2tpv3/CreateL2TPv3Modal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Cable, Loader2 } from "lucide-react";
 import { l2tpv3Service, type L2TPv3Capabilities } from "@/lib/api/l2tpv3";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateL2TPv3ModalProps {
@@ -656,27 +657,23 @@ export function CreateL2TPv3Modal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress &rarr;</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress &rarr;</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/l2tpv3/EditL2TPv3Modal.tsx
+++ b/frontend/src/components/l2tpv3/EditL2TPv3Modal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Cable, Loader2 } from "lucide-react";
 import { l2tpv3Service, type L2TPv3Interface, type L2TPv3Capabilities } from "@/lib/api/l2tpv3";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditL2TPv3ModalProps {
@@ -501,27 +502,23 @@ export function EditL2TPv3Modal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress &rarr;</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress &rarr;</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/lldp/LLDPInterfaceModal.tsx
+++ b/frontend/src/components/lldp/LLDPInterfaceModal.tsx
@@ -24,7 +24,8 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { lldpService, LLDPInterface, LLDPCapabilities } from "@/lib/api/lldp";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface LLDPInterfaceModalProps {
   open: boolean;
@@ -78,15 +79,14 @@ export function LLDPInterfaceModal({
   );
   const [elin, setElin] = useState(existing?.location?.elin ?? "");
 
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
     showService.getAllInterfaces().then((res) => {
-      const names = res.interfaces.map((i) => i.name).sort();
-      setAvailableInterfaces(names);
+      setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name)));
     });
   }, [open]);
 
@@ -140,9 +140,10 @@ export function LLDPInterfaceModal({
   const use15Mode = capabilities.features.interface_mode.supported;
   const use14Disable = capabilities.features.interface_disable_flag.supported;
 
-  const selectableInterfaces = ["all", ...availableInterfaces].filter(
-    (name) => !existingNames.includes(name) || name === existing?.name
-  );
+  const selectableInterfaces: InterfaceName[] = [
+    { name: "all", type: "", description: "Apply to all interfaces" },
+    ...availableInterfaces,
+  ].filter((i) => !existingNames.includes(i.name) || i.name === existing?.name);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -164,27 +165,12 @@ export function LLDPInterfaceModal({
               {isEdit ? (
                 <Input value={interfaceName} disabled />
               ) : (
-                <Select value={interfaceName} onValueChange={setInterfaceName}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {selectableInterfaces.map((name) => (
-                      <SelectItem key={name} value={name}>
-                        {name === "all" ? (
-                          <span>
-                            all{" "}
-                            <span className="text-muted-foreground text-xs">
-                              — Apply to all interfaces
-                            </span>
-                          </span>
-                        ) : (
-                          name
-                        )}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={interfaceName}
+                  onValueChange={setInterfaceName}
+                  interfaces={selectableInterfaces}
+                  placeholder="Select interface"
+                />
               )}
             </div>
 

--- a/frontend/src/components/loopback/CreateLoopbackModal.tsx
+++ b/frontend/src/components/loopback/CreateLoopbackModal.tsx
@@ -24,6 +24,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Repeat, Loader2 } from "lucide-react";
 import { loopbackService, type LoopbackCapabilities } from "@/lib/api/loopback";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateLoopbackModalProps {
@@ -178,39 +179,33 @@ export function CreateLoopbackModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/loopback/EditLoopbackModal.tsx
+++ b/frontend/src/components/loopback/EditLoopbackModal.tsx
@@ -24,6 +24,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Repeat, Loader2 } from "lucide-react";
 import { loopbackService, type LoopbackInterface, type LoopbackCapabilities } from "@/lib/api/loopback";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditLoopbackModalProps {
@@ -178,39 +179,33 @@ export function EditLoopbackModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/macsec/CreateMacsecModal.tsx
+++ b/frontend/src/components/macsec/CreateMacsecModal.tsx
@@ -25,6 +25,7 @@ import { Separator } from "@/components/ui/separator";
 import { Lock, Loader2, AlertCircle, Plus, Trash2 } from "lucide-react";
 import { macsecService, type MacsecCapabilities } from "@/lib/api/macsec";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface StaticPeerEntry {
@@ -352,16 +353,12 @@ export function CreateMacsecModal({
               </div>
               <div className="space-y-2">
                 <Label>Source Interface <span className="text-destructive">*</span></Label>
-                <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select source interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {allInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface}
+                  onValueChange={setSourceInterface}
+                  interfaces={allInterfaces}
+                  placeholder="Select source interface"
+                />
                 <p className="text-xs text-muted-foreground">Physical ethernet interface for MACsec traffic</p>
               </div>
             </div>

--- a/frontend/src/components/macsec/EditMacsecModal.tsx
+++ b/frontend/src/components/macsec/EditMacsecModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import {
   Dialog,
   DialogContent,
@@ -394,16 +395,12 @@ export function EditMacsecModal({
               </div>
               <div className="space-y-2">
                 <Label>Source Interface <span className="text-destructive">*</span></Label>
-                <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select source interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {allInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface}
+                  onValueChange={setSourceInterface}
+                  interfaces={allInterfaces}
+                  placeholder="Select source interface"
+                />
               </div>
             </div>
 

--- a/frontend/src/components/mpls/MplsContent.tsx
+++ b/frontend/src/components/mpls/MplsContent.tsx
@@ -41,19 +41,13 @@ import {
   MplsLdpConfig,
   MplsParameters,
 } from "@/lib/api/mpls";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { MplsLdpInterfaceModal } from "./MplsLdpInterfaceModal";
 import { MplsLdpNeighborModal } from "./MplsLdpNeighborModal";
 import { MplsLdpTargetedModal } from "./MplsLdpTargetedModal";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 // ============================================================================
 // Default empty LDP config used when ldp is null
@@ -117,7 +111,7 @@ export function MplsContent() {
   const [targetedModalOpen, setTargetedModalOpen] = useState(false);
 
   // Overview — global interface inline add
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [globalIfaceError, setGlobalIfaceError] = useState<string | null>(null);
 
   // Overview — parameters inline edit
@@ -166,7 +160,7 @@ export function MplsContent() {
   // Load available system interfaces once on mount
   useEffect(() => {
     showService.getAllInterfaces().then((res) => {
-      setAvailableInterfaces(res.interfaces.map((i) => i.name).sort());
+      setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name)));
     }).catch(() => {
       // Non-fatal — dropdown will just be empty
     });
@@ -505,21 +499,16 @@ export function MplsContent() {
 
                   {hasWritePermission && (() => {
                     const unenabledInterfaces = availableInterfaces.filter(
-                      (i) => !config?.interfaces.includes(i)
+                      (i) => !config?.interfaces.includes(i.name)
                     );
                     return unenabledInterfaces.length > 0 ? (
-                      <Select onValueChange={handleAddGlobalIface}>
-                        <SelectTrigger className="max-w-xs">
-                          <SelectValue placeholder="Add interface..." />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {unenabledInterfaces.map((iface) => (
-                            <SelectItem key={iface} value={iface}>
-                              {iface}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <InterfaceSelect
+                        value=""
+                        onValueChange={handleAddGlobalIface}
+                        interfaces={unenabledInterfaces}
+                        className="max-w-xs"
+                        placeholder="Add interface..."
+                      />
                     ) : availableInterfaces.length > 0 ? (
                       <p className="text-xs text-muted-foreground">All available interfaces are already enabled</p>
                     ) : null;

--- a/frontend/src/components/mpls/MplsLdpInterfaceModal.tsx
+++ b/frontend/src/components/mpls/MplsLdpInterfaceModal.tsx
@@ -11,16 +11,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { MplsLdpInterface } from "@/lib/api/mpls";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface MplsLdpInterfaceModalProps {
   open: boolean;
@@ -39,7 +33,7 @@ export function MplsLdpInterfaceModal({
 
   const [interfaceName, setInterfaceName] = useState("");
   const [disableHello, setDisableHello] = useState(false);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,7 +41,7 @@ export function MplsLdpInterfaceModal({
   useEffect(() => {
     if (open && !isEditMode) {
       showService.getAllInterfaces().then((res) => {
-        setAvailableInterfaces(res.interfaces.map((i) => i.name));
+        setAvailableInterfaces(res.interfaces);
       }).catch(() => {
         // Silently ignore — user can type manually via fallback
       });
@@ -108,18 +102,13 @@ export function MplsLdpInterfaceModal({
                 {existingInterface?.name}
               </p>
             ) : availableInterfaces.length > 0 ? (
-              <Select value={interfaceName} onValueChange={setInterfaceName}>
-                <SelectTrigger id="ldp-iface-name">
-                  <SelectValue placeholder="Select interface..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={interfaceName}
+                onValueChange={setInterfaceName}
+                interfaces={availableInterfaces}
+                id="ldp-iface-name"
+                placeholder="Select interface..."
+              />
             ) : (
               <input
                 id="ldp-iface-name"

--- a/frontend/src/components/ndp-proxy/NdpProxyInterfaceModal.tsx
+++ b/frontend/src/components/ndp-proxy/NdpProxyInterfaceModal.tsx
@@ -29,7 +29,8 @@ import {
   NdpProxyInterface,
   NdpProxyPrefix,
 } from "@/lib/api/ndp-proxy";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface NdpProxyInterfaceModalProps {
   open: boolean;
@@ -105,7 +106,7 @@ export function NdpProxyInterfaceModal({
   const [addingPrefix, setAddingPrefix] = useState(false);
   const [newPrefix, setNewPrefix] = useState<PrefixForm>({ ...emptyPrefixForm });
 
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [prefixError, setPrefixError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -113,8 +114,7 @@ export function NdpProxyInterfaceModal({
   useEffect(() => {
     if (!open) return;
     showService.getAllInterfaces().then((res) => {
-      const names = res.interfaces.map((i) => i.name).sort();
-      setAvailableInterfaces(names);
+      setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name)));
     });
   }, [open]);
 
@@ -264,20 +264,13 @@ export function NdpProxyInterfaceModal({
               {isEdit ? (
                 <Input id="iface-name" value={interfaceName} disabled />
               ) : (
-                <Select value={interfaceName} onValueChange={setInterfaceName}>
-                  <SelectTrigger id="iface-name">
-                    <SelectValue placeholder="Select interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces
-                      .filter((name) => !existingNames.includes(name))
-                      .map((name) => (
-                        <SelectItem key={name} value={name}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={interfaceName}
+                  onValueChange={setInterfaceName}
+                  id="iface-name"
+                  interfaces={availableInterfaces.filter((i) => !existingNames.includes(i.name))}
+                  placeholder="Select interface"
+                />
               )}
             </div>
 

--- a/frontend/src/components/network/ComprehensiveEthernetModal.tsx
+++ b/frontend/src/components/network/ComprehensiveEthernetModal.tsx
@@ -23,6 +23,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ethernetService } from "@/lib/api/ethernet";
 import { showService } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { EthernetInterface, EthernetCapabilities, BatchOperation } from "@/lib/api/types/ethernet";
 import { Loader2, X, AlertCircle } from "lucide-react";
 
@@ -740,18 +741,13 @@ export function ComprehensiveEthernetModal({
                       All ethernet interfaces are already configured.
                     </p>
                   ) : (
-                    <Select value={interfaceName} onValueChange={setInterfaceName}>
-                      <SelectTrigger id="interface-name">
-                        <SelectValue placeholder="Select an interface" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface} value={iface}>
-                            {iface}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={interfaceName}
+                      onValueChange={setInterfaceName}
+                      id="interface-name"
+                      interfaces={availableInterfaces.map((n) => ({ name: n, type: "ethernet", description: null }))}
+                      placeholder="Select an interface"
+                    />
                   )}
                 </div>
               )}

--- a/frontend/src/components/network/ComprehensiveVIFCModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVIFCModal.tsx
@@ -24,6 +24,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetCapabilities, VIFConfig, BatchOperation, VlanBatchService, VlanParentInterface } from "@/lib/api/types/ethernet";
 import { Loader2, X } from "lucide-react";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface VIFCWithParent extends VIFConfig {
   parentInterface: string;
@@ -458,16 +459,13 @@ export function ComprehensiveVIFCModal({
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="parent-interface">Parent Interface <span className="text-destructive">*</span></Label>
-                    <Select value={parentInterface || undefined} onValueChange={(v) => { setParentInterface(v); setSVlanId(""); }}>
-                      <SelectTrigger id="parent-interface"><SelectValue placeholder="Select parent interface" /></SelectTrigger>
-                      <SelectContent>
-                        {interfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name}>
-                            {iface.name}{iface.description && ` - ${iface.description}`}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={parentInterface}
+                      onValueChange={(v) => { setParentInterface(v); setSVlanId(""); }}
+                      id="parent-interface"
+                      interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      placeholder="Select parent interface"
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="s-vlan">Parent S-VLAN <span className="text-destructive">*</span></Label>

--- a/frontend/src/components/network/ComprehensiveVIFSModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVIFSModal.tsx
@@ -24,6 +24,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetCapabilities, VIFSConfig, BatchOperation, VlanBatchService, VlanParentInterface } from "@/lib/api/types/ethernet";
 import { Loader2, X } from "lucide-react";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface VIFSWithParent extends VIFSConfig {
   parentInterface: string;
@@ -454,16 +455,13 @@ export function ComprehensiveVIFSModal({
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="parent-interface">Parent Interface <span className="text-destructive">*</span></Label>
-                    <Select value={parentInterface || undefined} onValueChange={setParentInterface}>
-                      <SelectTrigger id="parent-interface"><SelectValue placeholder="Select parent interface" /></SelectTrigger>
-                      <SelectContent>
-                        {interfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name}>
-                            {iface.name}{iface.description && ` - ${iface.description}`}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={parentInterface}
+                      onValueChange={setParentInterface}
+                      id="parent-interface"
+                      interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      placeholder="Select parent interface"
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="vlan-id">S-VLAN ID <span className="text-destructive">*</span></Label>

--- a/frontend/src/components/network/ComprehensiveVLANModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVLANModal.tsx
@@ -24,6 +24,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ethernetService } from "@/lib/api/ethernet";
 import type { EthernetCapabilities, VIFConfig, BatchOperation, VlanBatchService, VlanParentInterface } from "@/lib/api/types/ethernet";
 import { Loader2, X } from "lucide-react";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface VLANWithParent extends VIFConfig {
   parentInterface: string;
@@ -547,19 +548,13 @@ export function ComprehensiveVLANModal({
                     <Label htmlFor="parent-interface">
                       Parent Interface <span className="text-destructive">*</span>
                     </Label>
-                    <Select value={parentInterface || undefined} onValueChange={setParentInterface}>
-                      <SelectTrigger id="parent-interface">
-                        <SelectValue placeholder="Select parent interface" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {interfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name}>
-                            {iface.name}
-                            {iface.description && ` - ${iface.description}`}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={parentInterface}
+                      onValueChange={setParentInterface}
+                      id="parent-interface"
+                      interfaces={interfaces.map((i) => ({ name: i.name, type: "", description: i.description ?? null }))}
+                      placeholder="Select parent interface"
+                    />
                   </div>
 
                   <div className="space-y-2">

--- a/frontend/src/components/network/CreateDestinationNATModal.tsx
+++ b/frontend/src/components/network/CreateDestinationNATModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -433,18 +434,13 @@ export function CreateDestinationNATModal({ open, onOpenChange, onSuccess }: Cre
               {inboundInterfaceType === "name" ? (
                 <div className="space-y-2">
                   <Label htmlFor="inbound-interface-name">Inbound Interface Name</Label>
-                  <Select value={inboundInterfaceName} onValueChange={setInboundInterfaceName}>
-                    <SelectTrigger id="inbound-interface-name">
-                      <SelectValue placeholder="Select interface" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {interfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>
-                          {iface.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={inboundInterfaceName}
+                    onValueChange={setInboundInterfaceName}
+                    id="inbound-interface-name"
+                    interfaces={interfaces.map((i) => ({ name: i.name, type: i.type, description: null }))}
+                    placeholder="Select interface"
+                  />
                 </div>
               ) : (
                 <div className="space-y-2">

--- a/frontend/src/components/network/CreateEthernetModal.tsx
+++ b/frontend/src/components/network/CreateEthernetModal.tsx
@@ -22,6 +22,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { ethernetService } from "@/lib/api/ethernet";
 import { showService } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { EthernetCapabilities } from "@/lib/api/types/ethernet";
 import { Loader2 } from "lucide-react";
 
@@ -171,18 +172,13 @@ export function CreateEthernetModal({
                 No unconfigured ethernet interfaces found.
               </div>
             ) : (
-              <Select value={interfaceName} onValueChange={setInterfaceName}>
-                <SelectTrigger id="interface-name">
-                  <SelectValue placeholder="Select an interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={interfaceName}
+                onValueChange={setInterfaceName}
+                id="interface-name"
+                interfaces={availableInterfaces.map((n) => ({ name: n, type: "ethernet", description: null }))}
+                placeholder="Select an interface"
+              />
             )}
           </div>
 

--- a/frontend/src/components/network/CreateSourceNATModal.tsx
+++ b/frontend/src/components/network/CreateSourceNATModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -441,18 +442,13 @@ export function CreateSourceNATModal({ open, onOpenChange, onSuccess }: CreateSo
               {outboundInterfaceType === "name" ? (
                 <div className="space-y-2">
                   <Label htmlFor="outbound-interface-name">Outbound Interface Name</Label>
-                  <Select value={outboundInterfaceName} onValueChange={setOutboundInterfaceName}>
-                    <SelectTrigger id="outbound-interface-name">
-                      <SelectValue placeholder="Select interface" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {interfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>
-                          {iface.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={outboundInterfaceName}
+                    onValueChange={setOutboundInterfaceName}
+                    id="outbound-interface-name"
+                    interfaces={interfaces.map((i) => ({ name: i.name, type: i.type, description: null }))}
+                    placeholder="Select interface"
+                  />
                 </div>
               ) : (
                 <div className="space-y-2">

--- a/frontend/src/components/network/CreateStaticNATModal.tsx
+++ b/frontend/src/components/network/CreateStaticNATModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Textarea } from "@/components/ui/textarea";
 import { AlertCircle } from "lucide-react";
 import { natService } from "@/lib/api/nat";
@@ -242,18 +242,13 @@ export function CreateStaticNATModal({ open, onOpenChange, onSuccess }: CreateSt
           {/* Inbound Interface */}
           <div className="space-y-2">
             <Label htmlFor="inbound-interface">Inbound Interface</Label>
-            <Select value={inboundInterface} onValueChange={setInboundInterface}>
-              <SelectTrigger id="inbound-interface">
-                <SelectValue placeholder="Select interface" />
-              </SelectTrigger>
-              <SelectContent>
-                {interfaces.map((iface) => (
-                  <SelectItem key={iface.name} value={iface.name}>
-                    {iface.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={inboundInterface}
+              onValueChange={setInboundInterface}
+              id="inbound-interface"
+              interfaces={interfaces.map((i) => ({ name: i.name, type: i.type, description: null }))}
+              placeholder="Select interface"
+            />
             <p className="text-xs text-muted-foreground">
               The interface on which the traffic arrives
             </p>

--- a/frontend/src/components/network/EditDestinationNATModal.tsx
+++ b/frontend/src/components/network/EditDestinationNATModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -684,18 +685,13 @@ export function EditDestinationNATModal({ open, onOpenChange, rule, onSuccess }:
               {inboundInterfaceType === "name" ? (
                 <div className="space-y-2">
                   <Label htmlFor="inbound-interface-name">Inbound Interface Name</Label>
-                  <Select value={inboundInterfaceName} onValueChange={setInboundInterfaceName}>
-                    <SelectTrigger id="inbound-interface-name">
-                      <SelectValue placeholder="Select interface" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {interfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>
-                          {iface.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={inboundInterfaceName}
+                    onValueChange={setInboundInterfaceName}
+                    id="inbound-interface-name"
+                    interfaces={interfaces.map((i) => ({ name: i.name, type: i.type, description: null }))}
+                    placeholder="Select interface"
+                  />
                 </div>
               ) : (
                 <div className="space-y-2">

--- a/frontend/src/components/network/EditSourceNATModal.tsx
+++ b/frontend/src/components/network/EditSourceNATModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -730,18 +731,13 @@ export function EditSourceNATModal({ open, onOpenChange, rule, onSuccess }: Edit
               {outboundInterfaceType === "name" ? (
                 <div className="space-y-2">
                   <Label htmlFor="outbound-interface-name">Outbound Interface Name</Label>
-                  <Select value={outboundInterfaceName} onValueChange={setOutboundInterfaceName}>
-                    <SelectTrigger id="outbound-interface-name">
-                      <SelectValue placeholder="Select interface" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {interfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>
-                          {iface.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={outboundInterfaceName}
+                    onValueChange={setOutboundInterfaceName}
+                    id="outbound-interface-name"
+                    interfaces={interfaces.map((i) => ({ name: i.name, type: i.type, description: null }))}
+                    placeholder="Select interface"
+                  />
                 </div>
               ) : (
                 <div className="space-y-2">

--- a/frontend/src/components/network/EditStaticNATModal.tsx
+++ b/frontend/src/components/network/EditStaticNATModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Textarea } from "@/components/ui/textarea";
 import { AlertCircle } from "lucide-react";
 import { natService } from "@/lib/api/nat";
@@ -240,18 +240,13 @@ export function EditStaticNATModal({ open, onOpenChange, rule, onSuccess }: Edit
           {/* Inbound Interface */}
           <div className="space-y-2">
             <Label htmlFor="inbound-interface">Inbound Interface (Optional)</Label>
-            <Select value={inboundInterfaceName || undefined} onValueChange={setInboundInterfaceName}>
-              <SelectTrigger id="inbound-interface">
-                <SelectValue placeholder="Select interface (optional)" />
-              </SelectTrigger>
-              <SelectContent>
-                {interfaces.map((iface) => (
-                  <SelectItem key={iface.name} value={iface.name}>
-                    {iface.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={inboundInterfaceName}
+              onValueChange={setInboundInterfaceName}
+              id="inbound-interface"
+              interfaces={interfaces.map((i) => ({ name: i.name, type: i.type, description: null }))}
+              placeholder="Select interface (optional)"
+            />
             {inboundInterfaceName && (
               <Button
                 variant="ghost"

--- a/frontend/src/components/network/NAT66RuleDialog.tsx
+++ b/frontend/src/components/network/NAT66RuleDialog.tsx
@@ -23,6 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { AlertCircle } from "lucide-react";
 import {
   nat66Service,
@@ -562,18 +563,13 @@ export function NAT66RuleDialog({
                 <Label htmlFor="nat66-iface">
                   {isSource ? "Outbound Interface" : "Inbound Interface"}
                 </Label>
-                <Select value={interfaceName} onValueChange={setInterfaceName}>
-                  <SelectTrigger id="nat66-iface">
-                    <SelectValue placeholder="Select interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {interfaces.map((iface) => (
-                      <SelectItem key={iface} value={iface}>
-                        {iface}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={interfaceName}
+                  onValueChange={setInterfaceName}
+                  id="nat66-iface"
+                  interfaces={interfaces.map((n) => ({ name: n, type: "", description: null }))}
+                  placeholder="Select interface"
+                />
               </div>
 
               {/* Translation */}

--- a/frontend/src/components/openfabric/OpenfabricInterfaceModal.tsx
+++ b/frontend/src/components/openfabric/OpenfabricInterfaceModal.tsx
@@ -26,7 +26,8 @@ import {
   OpenfabricInterfaceConfig,
   OpenfabricCapabilities,
 } from "@/lib/api/openfabric";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface OpenfabricInterfaceModalProps {
   open: boolean;
@@ -47,7 +48,7 @@ export function OpenfabricInterfaceModal({
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [interfaceNames, setInterfaceNames] = useState<string[]>([]);
+  const [interfaceNames, setInterfaceNames] = useState<InterfaceName[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState(false);
 
   // General
@@ -74,7 +75,7 @@ export function OpenfabricInterfaceModal({
     setInterfacesLoading(true);
     showService
       .getAllInterfaces()
-      .then((res) => setInterfaceNames(res.interfaces.map((i) => i.name).sort()))
+      .then((res) => setInterfaceNames([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name))))
       .catch(() => setInterfaceNames([]))
       .finally(() => setInterfacesLoading(false));
 
@@ -171,18 +172,13 @@ export function OpenfabricInterfaceModal({
                   {name}
                 </div>
               ) : (
-                <Select value={name} onValueChange={setName} disabled={interfacesLoading}>
-                  <SelectTrigger>
-                    <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {interfaceNames.map((iface) => (
-                      <SelectItem key={iface} value={iface} className="font-mono">
-                        {iface}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={name}
+                  onValueChange={setName}
+                  disabled={interfacesLoading}
+                  interfaces={interfaceNames}
+                  placeholder="Select interface"
+                />
               )}
             </div>
 

--- a/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/api/openvpn";
 import { pkiService, type PKIConfigResponse } from "@/lib/api/pki";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 import {
   LEGACY_CIPHERS,
@@ -581,21 +582,13 @@ export function CreateOpenvpnModal({
             </div>
             <div>
               <Label htmlFor="redirect">Redirect</Label>
-              <Select value={redirect} onValueChange={setRedirect}>
-                <SelectTrigger id="redirect">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        ({iface.type})
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={redirect}
+                onValueChange={setRedirect}
+                id="redirect"
+                interfaces={availableInterfaces}
+                placeholder="Select interface"
+              />
             </div>
             <Separator />
             <div className="space-y-2">
@@ -1525,39 +1518,23 @@ export function CreateOpenvpnModal({
           <TabsContent value="mirror" className="space-y-4">
             <div>
               <Label htmlFor="mirrorIn">Ingress Mirror Interface</Label>
-              <Select value={mirrorIngress} onValueChange={setMirrorIngress}>
-                <SelectTrigger id="mirrorIn">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        ({iface.type})
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorIngress}
+                onValueChange={setMirrorIngress}
+                id="mirrorIn"
+                interfaces={availableInterfaces}
+                placeholder="Select interface"
+              />
             </div>
             <div>
               <Label htmlFor="mirrorOut">Egress Mirror Interface</Label>
-              <Select value={mirrorEgress} onValueChange={setMirrorEgress}>
-                <SelectTrigger id="mirrorOut">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        ({iface.type})
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorEgress}
+                onValueChange={setMirrorEgress}
+                id="mirrorOut"
+                interfaces={availableInterfaces}
+                placeholder="Select interface"
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/openvpn/EditOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/EditOpenvpnModal.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/api/openvpn";
 import { pkiService, type PKIConfigResponse } from "@/lib/api/pki";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 import {
   LEGACY_CIPHERS,
@@ -541,21 +542,13 @@ export function EditOpenvpnModal({
             </div>
             <div>
               <Label htmlFor="eredirect">Redirect</Label>
-              <Select value={redirect} onValueChange={setRedirect}>
-                <SelectTrigger id="eredirect">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        ({iface.type})
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={redirect}
+                onValueChange={setRedirect}
+                id="eredirect"
+                interfaces={availableInterfaces}
+                placeholder="Select interface"
+              />
             </div>
             <Separator />
             <div className="space-y-2">
@@ -1468,39 +1461,23 @@ export function EditOpenvpnModal({
           <TabsContent value="mirror" className="space-y-4">
             <div>
               <Label htmlFor="emirror">Ingress Mirror Interface</Label>
-              <Select value={mirrorIngress} onValueChange={setMirrorIngress}>
-                <SelectTrigger id="emirror">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        ({iface.type})
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorIngress}
+                onValueChange={setMirrorIngress}
+                id="emirror"
+                interfaces={availableInterfaces}
+                placeholder="Select interface"
+              />
             </div>
             <div>
               <Label htmlFor="emirrorE">Egress Mirror Interface</Label>
-              <Select value={mirrorEgress} onValueChange={setMirrorEgress}>
-                <SelectTrigger id="emirrorE">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      {iface.name}
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        ({iface.type})
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorEgress}
+                onValueChange={setMirrorEgress}
+                id="emirrorE"
+                interfaces={availableInterfaces}
+                placeholder="Select interface"
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/ospf/OspfInterfaceModal.tsx
+++ b/frontend/src/components/ospf/OspfInterfaceModal.tsx
@@ -23,7 +23,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2, Plus, Trash2 } from "lucide-react";
 import type { OspfInterface, OspfCapabilities } from "@/lib/api/ospf";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface OspfInterfaceModalProps {
   open: boolean;
@@ -63,12 +64,12 @@ export function OspfInterfaceModal({
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -234,16 +235,14 @@ export function OspfInterfaceModal({
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="ospf-iface-name">Interface</Label>
-                <Select value={name} onValueChange={setName} disabled={isEditMode}>
-                  <SelectTrigger id="ospf-iface-name" className={isEditMode ? "bg-muted" : ""}>
-                    <SelectValue placeholder="Select an interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={name}
+                  onValueChange={setName}
+                  disabled={isEditMode}
+                  id="ospf-iface-name"
+                  className={isEditMode ? "bg-muted" : ""}
+                  interfaces={availableInterfaces}
+                />
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/components/ospfv3/Ospfv3InterfaceModal.tsx
+++ b/frontend/src/components/ospfv3/Ospfv3InterfaceModal.tsx
@@ -23,7 +23,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2 } from "lucide-react";
 import type { Ospfv3Interface, Ospfv3Capabilities } from "@/lib/api/ospfv3";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface Ospfv3InterfaceModalProps {
   open: boolean;
@@ -60,12 +61,12 @@ export function Ospfv3InterfaceModal({
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -198,16 +199,14 @@ export function Ospfv3InterfaceModal({
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="ospfv3-iface-name">Interface</Label>
-                <Select value={name} onValueChange={setName} disabled={isEditMode}>
-                  <SelectTrigger id="ospfv3-iface-name" className={isEditMode ? "bg-muted" : ""}>
-                    <SelectValue placeholder="Select an interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={name}
+                  onValueChange={setName}
+                  disabled={isEditMode}
+                  id="ospfv3-iface-name"
+                  className={isEditMode ? "bg-muted" : ""}
+                  interfaces={availableInterfaces}
+                />
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/components/pim/PimInterfaceModal.tsx
+++ b/frontend/src/components/pim/PimInterfaceModal.tsx
@@ -25,6 +25,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import type { PimInterface, PimIgmpJoin } from "@/lib/api/pim";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface PimInterfaceModalProps {
   open: boolean;
@@ -287,19 +288,12 @@ export function PimInterfaceModal({
                   {isEditMode ? (
                     <Input value={name} disabled className="bg-muted font-mono" />
                   ) : (
-                    <Select value={name} onValueChange={setName}>
-                      <SelectTrigger>
-                        <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name}>
-                            <span className="font-mono">{iface.name}</span>
-                            <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={name}
+                      onValueChange={setName}
+                      interfaces={availableInterfaces}
+                      placeholder="Select interface"
+                    />
                   )}
                 </div>
 

--- a/frontend/src/components/pim6/Pim6InterfaceModal.tsx
+++ b/frontend/src/components/pim6/Pim6InterfaceModal.tsx
@@ -25,6 +25,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import type { Pim6Interface, Pim6MldJoin } from "@/lib/api/pim6";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { isValidIPv6 } from "@/lib/validators/firewall";
 
 interface Pim6InterfaceModalProps {
@@ -299,19 +300,12 @@ export function Pim6InterfaceModal({
                   {isEditMode ? (
                     <Input value={name} disabled className="bg-muted font-mono" />
                   ) : (
-                    <Select value={name} onValueChange={setName}>
-                      <SelectTrigger>
-                        <SelectValue placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {availableInterfaces.map((iface) => (
-                          <SelectItem key={iface.name} value={iface.name}>
-                            <span className="font-mono">{iface.name}</span>
-                            <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={name}
+                      onValueChange={setName}
+                      interfaces={availableInterfaces}
+                      placeholder="Select interface"
+                    />
                   )}
                 </div>
 

--- a/frontend/src/components/policies/CreateLocalRouteModal.tsx
+++ b/frontend/src/components/policies/CreateLocalRouteModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { AlertCircle } from "lucide-react";
 import { localRouteService, type LocalRouteCapabilitiesResponse } from "@/lib/api/local-route";
 import { apiClient } from "@/lib/api/client";
@@ -303,19 +303,15 @@ export function CreateLocalRouteModal({
           {/* Inbound Interface */}
           <div className="space-y-2">
             <Label htmlFor="inbound-interface">Inbound Interface</Label>
-            <Select value={inboundInterface} onValueChange={setInboundInterface} disabled={loading}>
-              <SelectTrigger id="inbound-interface">
-                <SelectValue placeholder="Select interface (optional)" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__none__">None</SelectItem>
-                {interfaces.map((iface) => (
-                  <SelectItem key={iface} value={iface}>
-                    {iface}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={inboundInterface}
+              onValueChange={setInboundInterface}
+              disabled={loading}
+              id="inbound-interface"
+              interfaces={interfaces.map((n) => ({ name: n, type: "", description: null }))}
+              noneOption={{ label: "None", value: "__none__" }}
+              placeholder="Select interface (optional)"
+            />
             <p className="text-xs text-muted-foreground">
               Match traffic arriving on this interface (optional)
             </p>

--- a/frontend/src/components/policies/EditLocalRouteModal.tsx
+++ b/frontend/src/components/policies/EditLocalRouteModal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { AlertCircle } from "lucide-react";
 import { localRouteService, type LocalRouteRule, type LocalRouteCapabilitiesResponse } from "@/lib/api/local-route";
 import { apiClient } from "@/lib/api/client";
@@ -293,19 +293,15 @@ export function EditLocalRouteModal({
           {/* Inbound Interface */}
           <div className="space-y-2">
             <Label htmlFor="inbound-interface">Inbound Interface</Label>
-            <Select value={inboundInterface || "__none__"} onValueChange={setInboundInterface} disabled={loading}>
-              <SelectTrigger id="inbound-interface">
-                <SelectValue placeholder="Select interface" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__none__">None</SelectItem>
-                {interfaces.map((iface) => (
-                  <SelectItem key={iface} value={iface}>
-                    {iface}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={inboundInterface || "__none__"}
+              onValueChange={setInboundInterface}
+              disabled={loading}
+              id="inbound-interface"
+              interfaces={interfaces.map((n) => ({ name: n, type: "", description: null }))}
+              noneOption={{ label: "None", value: "__none__" }}
+              placeholder="Select interface"
+            />
             <p className="text-xs text-muted-foreground">
               Match traffic arriving on this interface
             </p>

--- a/frontend/src/components/pppoe-server/InterfaceModal.tsx
+++ b/frontend/src/components/pppoe-server/InterfaceModal.tsx
@@ -9,13 +9,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,6 +17,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, Loader2, Network, X } from "lucide-react";
 import { pppoeServerService, PPPoEInterface, PPPoECapabilities } from "@/lib/api/pppoe-server";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface InterfaceModalProps {
@@ -127,27 +121,12 @@ export function InterfaceModal({ open, onOpenChange, onSuccess, existingInterfac
             {isEdit ? (
               <Input value={ifaceName} disabled />
             ) : (
-              <Select value={ifaceName} onValueChange={setIfaceName}>
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={
-                      ifacesLoading
-                        ? "Loading interfaces..."
-                        : availableInterfaces.length === 0
-                        ? "No interfaces available"
-                        : "Select an interface"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      <span className="font-mono">{iface.name}</span>
-                      <span className="text-muted-foreground ml-2 text-xs">({iface.type})</span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={ifaceName}
+                onValueChange={setIfaceName}
+                interfaces={availableInterfaces}
+                placeholder="Select an interface"
+              />
             )}
           </div>
 

--- a/frontend/src/components/pppoe/CreatePppoeModal.tsx
+++ b/frontend/src/components/pppoe/CreatePppoeModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { Loader2, Plus, Trash2 } from "lucide-react";
@@ -450,23 +451,13 @@ export function CreatePppoeModal({
 
             <div>
               <Label htmlFor="pppoe-source">Source Interface *</Label>
-              <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                <SelectTrigger id="pppoe-source">
-                  <SelectValue placeholder="Select ethernet or VLAN" />
-                </SelectTrigger>
-                <SelectContent>
-                  {sourceOptions.length === 0 && (
-                    <SelectItem value="__none__" disabled>
-                      No interfaces available
-                    </SelectItem>
-                  )}
-                  {sourceOptions.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={sourceInterface}
+                onValueChange={setSourceInterface}
+                id="pppoe-source"
+                interfaces={sourceOptions.map((n) => ({ name: n, type: "", description: null }))}
+                placeholder="Select ethernet or VLAN"
+              />
               <p className="text-xs text-muted-foreground mt-1">
                 Underlying interface used to establish the session.
               </p>
@@ -963,45 +954,25 @@ export function CreatePppoeModal({
           <TabsContent value="mirror" className="space-y-4">
             <div>
               <Label htmlFor="pppoe-mirror-in">Ingress Mirror Interface</Label>
-              <Select
+              <InterfaceSelect
                 value={mirrorIngress || "__none__"}
-                onValueChange={(v) =>
-                  setMirrorIngress(v === "__none__" ? "" : v)
-                }
-              >
-                <SelectTrigger id="pppoe-mirror-in">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {sourceOptions.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                id="pppoe-mirror-in"
+                interfaces={sourceOptions.map((n) => ({ name: n, type: "", description: null }))}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select interface"
+              />
             </div>
             <div>
               <Label htmlFor="pppoe-mirror-out">Egress Mirror Interface</Label>
-              <Select
+              <InterfaceSelect
                 value={mirrorEgress || "__none__"}
-                onValueChange={(v) =>
-                  setMirrorEgress(v === "__none__" ? "" : v)
-                }
-              >
-                <SelectTrigger id="pppoe-mirror-out">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {sourceOptions.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                id="pppoe-mirror-out"
+                interfaces={sourceOptions.map((n) => ({ name: n, type: "", description: null }))}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select interface"
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/pppoe/EditPppoeModal.tsx
+++ b/frontend/src/components/pppoe/EditPppoeModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { Loader2, Plus, Trash2 } from "lucide-react";
@@ -415,24 +416,14 @@ export function EditPppoeModal({
 
             <div>
               <Label htmlFor="edit-pppoe-source">Source Interface</Label>
-              <Select
+              <InterfaceSelect
                 value={sourceInterface || "__none__"}
-                onValueChange={(v) =>
-                  setSourceInterface(v === "__none__" ? "" : v)
-                }
-              >
-                <SelectTrigger id="edit-pppoe-source">
-                  <SelectValue placeholder="Select ethernet or VLAN" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {sourceOptions.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}
+                id="edit-pppoe-source"
+                interfaces={sourceOptions.map((n) => ({ name: n, type: "", description: null }))}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select ethernet or VLAN"
+              />
             </div>
 
             <div className="grid grid-cols-2 gap-4">
@@ -912,45 +903,25 @@ export function EditPppoeModal({
           <TabsContent value="mirror" className="space-y-4">
             <div>
               <Label htmlFor="edit-pppoe-mirror-in">Ingress Mirror Interface</Label>
-              <Select
+              <InterfaceSelect
                 value={mirrorIngress || "__none__"}
-                onValueChange={(v) =>
-                  setMirrorIngress(v === "__none__" ? "" : v)
-                }
-              >
-                <SelectTrigger id="edit-pppoe-mirror-in">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {sourceOptions.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                id="edit-pppoe-mirror-in"
+                interfaces={sourceOptions.map((n) => ({ name: n, type: "", description: null }))}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select interface"
+              />
             </div>
             <div>
               <Label htmlFor="edit-pppoe-mirror-out">Egress Mirror Interface</Label>
-              <Select
+              <InterfaceSelect
                 value={mirrorEgress || "__none__"}
-                onValueChange={(v) =>
-                  setMirrorEgress(v === "__none__" ? "" : v)
-                }
-              >
-                <SelectTrigger id="edit-pppoe-mirror-out">
-                  <SelectValue placeholder="Select interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {sourceOptions.map((iface) => (
-                    <SelectItem key={iface} value={iface}>
-                      {iface}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                id="edit-pppoe-mirror-out"
+                interfaces={sourceOptions.map((n) => ({ name: n, type: "", description: null }))}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select interface"
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/pseudo-ethernet/CreatePseudoEthernetModal.tsx
+++ b/frontend/src/components/pseudo-ethernet/CreatePseudoEthernetModal.tsx
@@ -31,7 +31,8 @@ import {
   type PseudoEthernetDhcpv6PdInstanceInput,
   type PseudoEthernetDhcpv6PdInterfaceInput,
 } from "@/lib/api/pseudo-ethernet";
-import { showService } from "@/lib/api/show";
+import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { EthernetInterface } from "@/lib/api/types/ethernet";
 import { ApiError } from "@/lib/types/api";
 
@@ -145,13 +146,13 @@ export function CreatePseudoEthernetModal({
   const [mirrorIngress, setMirrorIngress] = useState("");
   const [mirrorEgress, setMirrorEgress] = useState("");
 
-  const [allInterfaces, setAllInterfaces] = useState<string[]>([]);
+  const [allInterfaces, setAllInterfaces] = useState<InterfaceName[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
-    showService.getAllInterfaces().then((r) => setAllInterfaces(r.interfaces.map((i) => i.name))).catch(() => {});
+    showService.getAllInterfaces().then((r) => setAllInterfaces(r.interfaces)).catch(() => {});
     setName("peth0");
     setSourceInterface("");
     setMode("private");
@@ -359,18 +360,13 @@ export function CreatePseudoEthernetModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="sourceInterface">Source Interface *</Label>
-                <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                  <SelectTrigger id="sourceInterface">
-                    <SelectValue placeholder="Select ethernet interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        {iface.name}{iface.description ? ` — ${iface.description}` : ""}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface}
+                  onValueChange={setSourceInterface}
+                  id="sourceInterface"
+                  interfaces={availableInterfaces.map((i) => ({ name: i.name, type: i.type, description: i.description ?? null }))}
+                  placeholder="Select ethernet interface"
+                />
               </div>
             </div>
 
@@ -824,31 +820,23 @@ export function CreatePseudoEthernetModal({
           <TabsContent value="mirror" className="space-y-4 mt-4">
             <div className="space-y-2">
               <Label>Mirror Ingress</Label>
-              <Select value={mirrorIngress || "__none__"} onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select destination interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {allInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorIngress || "__none__"}
+                onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                interfaces={allInterfaces}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select destination interface"
+              />
             </div>
             <div className="space-y-2">
               <Label>Mirror Egress</Label>
-              <Select value={mirrorEgress || "__none__"} onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select destination interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {allInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorEgress || "__none__"}
+                onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                interfaces={allInterfaces}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select destination interface"
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/pseudo-ethernet/EditPseudoEthernetModal.tsx
+++ b/frontend/src/components/pseudo-ethernet/EditPseudoEthernetModal.tsx
@@ -41,7 +41,8 @@ import {
   type PseudoEthernetVifSInput,
   type PseudoEthernetVifCInput,
 } from "@/lib/api/pseudo-ethernet";
-import { showService } from "@/lib/api/show";
+import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { EthernetInterface } from "@/lib/api/types/ethernet";
 import { ApiError } from "@/lib/types/api";
 
@@ -353,13 +354,13 @@ export function EditPseudoEthernetModal({
   const [showVifCFormForS, setShowVifCFormForS] = useState<number | null>(null);
   const [newVifC, setNewVifC] = useState<VifCFormState>(emptyVifC());
 
-  const [allInterfaces, setAllInterfaces] = useState<string[]>([]);
+  const [allInterfaces, setAllInterfaces] = useState<InterfaceName[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open || !interfaceData) return;
-    showService.getAllInterfaces().then((r) => setAllInterfaces(r.interfaces.map((i) => i.name))).catch(() => {});
+    showService.getAllInterfaces().then((r) => setAllInterfaces(r.interfaces)).catch(() => {});
     const d = interfaceData;
     setSourceInterface(d.source_interface ?? "");
     setMode(d.mode ?? "private");
@@ -669,18 +670,12 @@ export function EditPseudoEthernetModal({
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label>Source Interface</Label>
-                <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select ethernet interface" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>
-                        {iface.name}{iface.description ? ` — ${iface.description}` : ""}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface}
+                  onValueChange={setSourceInterface}
+                  interfaces={availableInterfaces.map((i) => ({ name: i.name, type: i.type, description: i.description ?? null }))}
+                  placeholder="Select ethernet interface"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mode</Label>
@@ -1000,31 +995,23 @@ export function EditPseudoEthernetModal({
           <TabsContent value="mirror" className="space-y-4 mt-4">
             <div className="space-y-2">
               <Label>Mirror Ingress</Label>
-              <Select value={mirrorIngress || "__none__"} onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select destination interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {allInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorIngress || "__none__"}
+                onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                interfaces={allInterfaces}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select destination interface"
+              />
             </div>
             <div className="space-y-2">
               <Label>Mirror Egress</Label>
-              <Select value={mirrorEgress || "__none__"} onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select destination interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {allInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorEgress || "__none__"}
+                onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                interfaces={allInterfaces}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select destination interface"
+              />
             </div>
           </TabsContent>
 

--- a/frontend/src/components/qos/QoSInterfaceModal.tsx
+++ b/frontend/src/components/qos/QoSInterfaceModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -21,7 +21,7 @@ import {
 } from "@/components/ui/select";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { qosService, QoSInterface, QoSPolicy } from "@/lib/api/qos";
-import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface QoSInterfaceModalProps {
   open: boolean;
@@ -47,27 +47,12 @@ export function QoSInterfaceModal({
   const [ingress, setIngress] = useState(existing?.ingress ?? "");
   const [egress, setEgress] = useState(existing?.egress ?? "");
 
-  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
-  const [ifacesLoading, setIfacesLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Ingress accepts only limiter policies; egress accepts all others.
   const ingressPolicies = policies.filter((p) => p.type === "limiter").map((p) => p.name);
   const egressPolicies = policies.filter((p) => p.type !== "limiter").map((p) => p.name);
-
-  useEffect(() => {
-    if (!open || isEdit) return;
-    setIfacesLoading(true);
-    showService
-      .getAllInterfaces()
-      .then((res) => setAvailableInterfaces(res.interfaces))
-      .catch(() => setAvailableInterfaces([]))
-      .finally(() => setIfacesLoading(false));
-  }, [open, isEdit]);
-
-  // Interfaces that already have a QoS binding can't be added again.
-  const selectableInterfaces = availableInterfaces.filter((i) => !existingNames.includes(i.name));
 
   const handleSubmit = async () => {
     const ifname = name.trim();
@@ -106,29 +91,11 @@ export function QoSInterfaceModal({
             {isEdit ? (
               <Input value={name} disabled className="font-mono bg-muted" />
             ) : (
-              <Select value={name} onValueChange={setName}>
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={
-                      ifacesLoading
-                        ? "Loading interfaces..."
-                        : selectableInterfaces.length === 0
-                          ? "No interfaces available"
-                          : "Select an interface"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {selectableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      <span className="font-mono">{iface.name}</span>
-                      <span className="text-muted-foreground ml-2 text-xs">
-                        {iface.description ? iface.description : iface.type}
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={name}
+                onValueChange={setName}
+                filter={(i) => !existingNames.includes(i.name)}
+              />
             )}
           </div>
 

--- a/frontend/src/components/rip/RipInterfaceModal.tsx
+++ b/frontend/src/components/rip/RipInterfaceModal.tsx
@@ -22,7 +22,8 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2, Plus, Trash2 } from "lucide-react";
 import type { RipInterface, RipMd5Key } from "@/lib/api/rip";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface RipInterfaceModalProps {
   open: boolean;
@@ -49,12 +50,12 @@ export function RipInterfaceModal({
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   useEffect(() => {
     if (!open) return;
     showService.getAllInterfaces()
-      .then((res) => setAvailableInterfaces(res.interfaces.map((i) => i.name)))
+      .then((res) => setAvailableInterfaces(res.interfaces))
       .catch(() => {});
 
     if (existingInterface) {
@@ -165,16 +166,14 @@ export function RipInterfaceModal({
             {/* Interface */}
             <div className="space-y-2">
               <Label htmlFor="rip-iface-name">Interface</Label>
-              <Select value={name} onValueChange={setName} disabled={isEditMode}>
-                <SelectTrigger id="rip-iface-name" className={isEditMode ? "bg-muted" : ""}>
-                  <SelectValue placeholder="Select an interface" />
-                </SelectTrigger>
-                <SelectContent>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={name}
+                onValueChange={setName}
+                disabled={isEditMode}
+                id="rip-iface-name"
+                className={isEditMode ? "bg-muted" : ""}
+                interfaces={availableInterfaces}
+              />
             </div>
 
             {/* Authentication */}

--- a/frontend/src/components/ripng/RipngInterfaceModal.tsx
+++ b/frontend/src/components/ripng/RipngInterfaceModal.tsx
@@ -20,7 +20,8 @@ import {
 } from "@/components/ui/select";
 import { AlertCircle, Loader2 } from "lucide-react";
 import type { RipNgInterface } from "@/lib/api/ripng";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface RipngInterfaceModalProps {
   open: boolean;
@@ -42,12 +43,12 @@ export function RipngInterfaceModal({
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   useEffect(() => {
     if (!open) return;
     showService.getAllInterfaces()
-      .then((res) => setAvailableInterfaces(res.interfaces.map((i) => i.name)))
+      .then((res) => setAvailableInterfaces(res.interfaces))
       .catch(() => {});
 
     if (existingInterface) {
@@ -116,16 +117,14 @@ export function RipngInterfaceModal({
           {/* Interface */}
           <div className="space-y-2">
             <Label htmlFor="ripng-iface-name">Interface</Label>
-            <Select value={name} onValueChange={setName} disabled={isEditMode}>
-              <SelectTrigger id="ripng-iface-name" className={isEditMode ? "bg-muted" : ""}>
-                <SelectValue placeholder="Select an interface" />
-              </SelectTrigger>
-              <SelectContent>
-                {availableInterfaces.map((iface) => (
-                  <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={name}
+              onValueChange={setName}
+              disabled={isEditMode}
+              id="ripng-iface-name"
+              className={isEditMode ? "bg-muted" : ""}
+              interfaces={availableInterfaces}
+            />
           </div>
 
           {/* Split Horizon */}

--- a/frontend/src/components/router-advert/RouterAdvertInterfaceModal.tsx
+++ b/frontend/src/components/router-advert/RouterAdvertInterfaceModal.tsx
@@ -32,7 +32,8 @@ import {
   RAPrefix,
   RARoute,
 } from "@/lib/api/router-advert";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface RouterAdvertInterfaceModalProps {
   open: boolean;
@@ -193,13 +194,12 @@ export function RouterAdvertInterfaceModal({
   const captivePortalSupported = capabilities?.features.captive_portal.supported ?? false;
   const baseIfaceSupported = capabilities?.features.prefix_base_interface.supported ?? false;
 
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   useEffect(() => {
     if (!open || isEdit) return;
     showService.getAllInterfaces().then((res) => {
-      const names = res.interfaces.map((i) => i.name).sort();
-      setAvailableInterfaces(names);
+      setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name)));
     });
   }, [open, isEdit]);
 
@@ -497,20 +497,13 @@ export function RouterAdvertInterfaceModal({
                   {isEdit ? (
                     <Input id="iface-name" value={interfaceName} disabled className="font-mono" />
                   ) : (
-                    <Select value={interfaceName} onValueChange={setInterfaceName}>
-                      <SelectTrigger id="iface-name">
-                        <SelectValue placeholder="Select interface" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {availableInterfaces
-                          .filter((name) => !existingNames.includes(name))
-                          .map((name) => (
-                            <SelectItem key={name} value={name}>
-                              {name}
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
+                    <InterfaceSelect
+                      value={interfaceName}
+                      onValueChange={setInterfaceName}
+                      id="iface-name"
+                      interfaces={availableInterfaces.filter((i) => !existingNames.includes(i.name))}
+                      placeholder="Select interface"
+                    />
                   )}
                 </div>
 

--- a/frontend/src/components/routing/CreateArpEntryModal.tsx
+++ b/frontend/src/components/routing/CreateArpEntryModal.tsx
@@ -12,16 +12,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { staticRoutesService } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface CreateArpEntryModalProps {
   open: boolean;
@@ -36,7 +30,7 @@ export function CreateArpEntryModal({
 }: CreateArpEntryModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   // Form fields
   const [interfaceName, setInterfaceName] = useState("");
@@ -54,7 +48,7 @@ export function CreateArpEntryModal({
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -137,18 +131,12 @@ export function CreateArpEntryModal({
 
           <div className="space-y-2">
             <Label htmlFor="interface">Interface</Label>
-            <Select value={interfaceName} onValueChange={setInterfaceName}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select interface..." />
-              </SelectTrigger>
-              <SelectContent>
-                {availableInterfaces.map((iface) => (
-                  <SelectItem key={iface} value={iface}>
-                    {iface}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={interfaceName}
+              onValueChange={setInterfaceName}
+              interfaces={availableInterfaces}
+              placeholder="Select interface..."
+            />
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/components/routing/CreateMrouteModal.tsx
+++ b/frontend/src/components/routing/CreateMrouteModal.tsx
@@ -12,17 +12,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, Loader2, Plus, Trash2 } from "lucide-react";
 import { staticRoutesService, type MrouteNextHop, type MrouteInterface } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface CreateMrouteModalProps {
   open: boolean;
@@ -49,7 +43,7 @@ export function CreateMrouteModal({
 }: CreateMrouteModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   // Form fields
   const [prefix, setPrefix] = useState("");
@@ -66,7 +60,7 @@ export function CreateMrouteModal({
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -248,21 +242,13 @@ export function CreateMrouteModal({
             {interfaces.map((iface, index) => (
               <div key={index} className="border rounded-lg p-3 space-y-2">
                 <div className="flex items-center gap-2">
-                  <Select
+                  <InterfaceSelect
                     value={iface.interface}
                     onValueChange={(value) => updateInterface(index, "interface", value)}
-                  >
-                    <SelectTrigger className="flex-1">
-                      <SelectValue placeholder="Select interface..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableInterfaces.map((name) => (
-                        <SelectItem key={name} value={name}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    interfaces={availableInterfaces}
+                    className="flex-1"
+                    placeholder="Select interface..."
+                  />
                   <Input
                     placeholder="Distance"
                     type="number"

--- a/frontend/src/components/routing/CreateNeighborProxyModal.tsx
+++ b/frontend/src/components/routing/CreateNeighborProxyModal.tsx
@@ -12,17 +12,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AlertCircle, Loader2 } from "lucide-react";
 import { staticRoutesService } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface CreateNeighborProxyModalProps {
   open: boolean;
@@ -37,7 +31,7 @@ export function CreateNeighborProxyModal({
 }: CreateNeighborProxyModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [proxyType, setProxyType] = useState<"arp" | "nd">("arp");
 
   // Form fields
@@ -54,7 +48,7 @@ export function CreateNeighborProxyModal({
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -164,18 +158,12 @@ export function CreateNeighborProxyModal({
 
           <div className="space-y-2">
             <Label htmlFor="interface">Interface</Label>
-            <Select value={interfaceName} onValueChange={setInterfaceName}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select interface..." />
-              </SelectTrigger>
-              <SelectContent>
-                {availableInterfaces.map((iface) => (
-                  <SelectItem key={iface} value={iface}>
-                    {iface}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <InterfaceSelect
+              value={interfaceName}
+              onValueChange={setInterfaceName}
+              interfaces={availableInterfaces}
+              placeholder="Select interface..."
+            />
           </div>
         </div>
 

--- a/frontend/src/components/routing/CreateStaticRouteModal.tsx
+++ b/frontend/src/components/routing/CreateStaticRouteModal.tsx
@@ -5,13 +5,13 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AlertCircle, Plus, Trash2 } from "lucide-react";
 import { staticRoutesService } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { StaticRoutesCapabilities } from "@/lib/api/static-routes";
 
 interface CreateStaticRouteModalProps {
@@ -40,7 +40,7 @@ export function CreateStaticRouteModal({ open, onOpenChange, onSuccess, routeTyp
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [capabilities, setCapabilities] = useState<StaticRoutesCapabilities | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   // Form fields
   const [destination, setDestination] = useState("");
@@ -85,7 +85,7 @@ export function CreateStaticRouteModal({ open, onOpenChange, onSuccess, routeTyp
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -416,21 +416,12 @@ export function CreateStaticRouteModal({ open, onOpenChange, onSuccess, routeTyp
                         <Label>
                           Interface <span className="text-destructive">*</span>
                         </Label>
-                        <Select
+                        <InterfaceSelect
                           value={iface.interface}
                           onValueChange={(value) => updateInterface(index, "interface", value)}
-                        >
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select interface" />
-                          </SelectTrigger>
-                          <SelectContent className="max-h-60 overflow-y-auto">
-                            {availableInterfaces.map((interfaceName) => (
-                              <SelectItem key={interfaceName} value={interfaceName}>
-                                {interfaceName}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          interfaces={availableInterfaces}
+                          placeholder="Select interface"
+                        />
                       </div>
 
                       <div className="space-y-2">

--- a/frontend/src/components/routing/CreateTableRouteModal.tsx
+++ b/frontend/src/components/routing/CreateTableRouteModal.tsx
@@ -22,7 +22,8 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, Loader2, Plus, Trash2 } from "lucide-react";
 import { staticRoutesService, type RoutingTable } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface CreateTableRouteModalProps {
   open: boolean;
@@ -51,7 +52,7 @@ export function CreateTableRouteModal({
 }: CreateTableRouteModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   // Form fields
   const [routeType, setRouteType] = useState<"ipv4" | "ipv6">("ipv4");
@@ -74,7 +75,7 @@ export function CreateTableRouteModal({
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -299,21 +300,13 @@ export function CreateTableRouteModal({
             {interfaces.map((iface, index) => (
               <div key={index} className="border rounded-lg p-3 space-y-2">
                 <div className="flex items-center gap-2">
-                  <Select
+                  <InterfaceSelect
                     value={iface.interface}
                     onValueChange={(value) => updateInterface(index, "interface", value)}
-                  >
-                    <SelectTrigger className="flex-1">
-                      <SelectValue placeholder="Select interface..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableInterfaces.map((name) => (
-                        <SelectItem key={name} value={name}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    interfaces={availableInterfaces}
+                    className="flex-1"
+                    placeholder="Select interface..."
+                  />
                   <Input
                     placeholder="Distance"
                     type="number"

--- a/frontend/src/components/routing/EditStaticRouteModal.tsx
+++ b/frontend/src/components/routing/EditStaticRouteModal.tsx
@@ -5,13 +5,13 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AlertCircle, Plus, Trash2 } from "lucide-react";
 import { staticRoutesService } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import type { StaticRoute, StaticRoutesCapabilities } from "@/lib/api/static-routes";
 
 interface EditStaticRouteModalProps {
@@ -40,7 +40,7 @@ export function EditStaticRouteModal({ open, onOpenChange, onSuccess, route }: E
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [capabilities, setCapabilities] = useState<StaticRoutesCapabilities | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   // Form fields
   const [description, setDescription] = useState("");
@@ -85,7 +85,7 @@ export function EditStaticRouteModal({ open, onOpenChange, onSuccess, route }: E
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -446,21 +446,12 @@ export function EditStaticRouteModal({ open, onOpenChange, onSuccess, route }: E
                       <div className="grid grid-cols-2 gap-3">
                         <div className="space-y-2">
                           <Label>Interface</Label>
-                          <Select
+                          <InterfaceSelect
                             value={iface.interface}
                             onValueChange={(value) => updateInterface(index, "interface", value)}
-                          >
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select interface" />
-                            </SelectTrigger>
-                            <SelectContent className="max-h-60 overflow-y-auto">
-                              {availableInterfaces.map((interfaceName) => (
-                                <SelectItem key={interfaceName} value={interfaceName}>
-                                  {interfaceName}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
+                            interfaces={availableInterfaces}
+                            placeholder="Select interface"
+                          />
                         </div>
 
                         <div className="space-y-2">

--- a/frontend/src/components/routing/EditTableRouteModal.tsx
+++ b/frontend/src/components/routing/EditTableRouteModal.tsx
@@ -12,17 +12,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, Loader2, Plus, Trash2 } from "lucide-react";
 import { staticRoutesService, type RoutingTable, type StaticRoute } from "@/lib/api/static-routes";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface EditTableRouteModalProps {
   open: boolean;
@@ -53,7 +47,7 @@ export function EditTableRouteModal({
 }: EditTableRouteModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
 
   const [description, setDescription] = useState("");
   const [nextHops, setNextHops] = useState<NextHopEntry[]>([]);
@@ -73,7 +67,7 @@ export function EditTableRouteModal({
   const loadInterfaces = async () => {
     try {
       const response = await showService.getAllInterfaces();
-      setAvailableInterfaces(response.interfaces.map((i) => i.name));
+      setAvailableInterfaces(response.interfaces);
     } catch (err) {
       console.error("Failed to load interfaces:", err);
     }
@@ -263,21 +257,13 @@ export function EditTableRouteModal({
             {interfaces.map((iface, index) => (
               <div key={index} className="border rounded-lg p-3 space-y-2">
                 <div className="flex items-center gap-2">
-                  <Select
+                  <InterfaceSelect
                     value={iface.interface}
                     onValueChange={(value) => updateInterface(index, "interface", value)}
-                  >
-                    <SelectTrigger className="flex-1">
-                      <SelectValue placeholder="Select interface..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableInterfaces.map((name) => (
-                        <SelectItem key={name} value={name}>
-                          {name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    interfaces={availableInterfaces}
+                    className="flex-1"
+                    placeholder="Select interface..."
+                  />
                   <Input
                     placeholder="Distance"
                     type="number"

--- a/frontend/src/components/salt-minion/SaltMinionSettingsModal.tsx
+++ b/frontend/src/components/salt-minion/SaltMinionSettingsModal.tsx
@@ -25,6 +25,7 @@ import {
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import { saltMinionService, SaltMinionConfig, SaltMinionSettingsUpdate } from "@/lib/api/salt-minion";
 import { showService } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface SaltMinionSettingsModalProps {
   open: boolean;
@@ -42,35 +43,6 @@ const HASH_OPTIONS: { value: string; label: string; description: string }[] = [
   { value: "sha1",     label: "SHA-1",              description: "Legacy — not recommended for new deployments" },
   { value: "md5",      label: "MD5",               description: "Legacy — not recommended for new deployments" },
 ];
-
-function formatIfaceType(type: string): string {
-  const map: Record<string, string> = {
-    ethernet:         "Ethernet",
-    bonding:          "Bonding",
-    bridge:           "Bridge",
-    dummy:            "Dummy",
-    geneve:           "GENEVE",
-    input:            "IFB Input",
-    l2tpv3:           "L2TPv3",
-    loopback:         "Loopback",
-    macsec:           "MACsec",
-    openvpn:          "OpenVPN",
-    pppoe:            "PPPoE",
-    "pseudo-ethernet":"Pseudo-Ethernet",
-    sstpc:            "SSTPC",
-    tunnel:           "Tunnel",
-    vif:              "VLAN",
-    "vif-s":          "QinQ Service VLAN",
-    "vif-c":          "QinQ Customer VLAN",
-    "virtual-ethernet":"Virtual Ethernet",
-    vti:              "VTI",
-    vxlan:            "VXLAN",
-    wireguard:        "WireGuard",
-    wireless:         "Wireless",
-    wwan:             "WWAN",
-  };
-  return map[type] ?? type;
-}
 
 interface IfaceOption {
   name: string;
@@ -326,27 +298,12 @@ export function SaltMinionSettingsModal({
               <p className="text-xs text-muted-foreground">
                 Network interface used to establish the connection to the master. Leave unset to use the default route.
               </p>
-              <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">
-                    <span className="font-medium">None</span>
-                    <span className="block text-xs text-muted-foreground">
-                      Use the default routing table
-                    </span>
-                  </SelectItem>
-                  {ifaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>
-                      <span className="font-mono font-medium">{iface.name}</span>
-                      <span className="block text-xs text-muted-foreground">
-                        {iface.description ?? formatIfaceType(iface.type)}
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={sourceInterface}
+                onValueChange={setSourceInterface}
+                interfaces={ifaces.map((i) => ({ name: i.name, type: i.type, description: i.description ?? null }))}
+                noneOption={{ label: "None", value: "none" }}
+              />
             </div>
           </div>
         </ScrollArea>

--- a/frontend/src/components/system/settings/ConntrackPanel.tsx
+++ b/frontend/src/components/system/settings/ConntrackPanel.tsx
@@ -54,7 +54,8 @@ import {
   type ConntrackIgnoreRule,
   type ConntrackTimeoutCustomRule,
 } from "@/lib/api/system-settings";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { useToast } from "@/hooks/useToast";
 import {
   DndContext,
@@ -224,7 +225,7 @@ export function ConntrackPanel({ config, capabilities, isReadOnly, onRefresh }: 
   const [gtError, setGtError] = useState<string | null>(null);
 
   // Interface list for inbound interface dropdown
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [loadingInterfaces, setLoadingInterfaces] = useState(false);
 
   // Ignore rules
@@ -292,7 +293,7 @@ export function ConntrackPanel({ config, capabilities, isReadOnly, onRefresh }: 
     setLoadingInterfaces(true);
     try {
       const res = await showService.getAllInterfaces();
-      setAvailableInterfaces(res.interfaces.map((i) => i.name).sort());
+      setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name)));
     } catch {
       setAvailableInterfaces([]);
     } finally {
@@ -1140,21 +1141,14 @@ export function ConntrackPanel({ config, capabilities, isReadOnly, onRefresh }: 
             </div>
             <div className="space-y-1">
               <Label className="text-xs">Inbound Interface</Label>
-              <Select
+              <InterfaceSelect
                 value={ignInboundIface || "_any"}
                 onValueChange={(v) => setIgnInboundIface(v === "_any" ? "" : v)}
                 disabled={loadingInterfaces}
-              >
-                <SelectTrigger className="font-mono text-sm">
-                  <SelectValue placeholder={loadingInterfaces ? "Loading…" : "Any"} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_any">Any</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface} value={iface}>{iface}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                interfaces={availableInterfaces}
+                noneOption={{ label: "Any", value: "_any" }}
+                className="font-mono text-sm"
+              />
             </div>
           </div>
           <DialogFooter>

--- a/frontend/src/components/traffic-engineering/TeInterfaceModal.tsx
+++ b/frontend/src/components/traffic-engineering/TeInterfaceModal.tsx
@@ -9,13 +9,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,7 +16,8 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { AlertCircle, Loader2 } from "lucide-react";
 import type { AdminGroup, TeInterface } from "@/lib/api/traffic-engineering";
-import { showService } from "@/lib/api/show";
+import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 
 interface TeInterfaceModalProps {
   open: boolean;
@@ -43,7 +37,7 @@ export function TeInterfaceModal({
   const isEditMode = !!existingInterface;
 
   const [name, setName] = useState("");
-  const [availableInterfaces, setAvailableInterfaces] = useState<string[]>([]);
+  const [availableInterfaces, setAvailableInterfaces] = useState<InterfaceName[]>([]);
   const [interfacesLoading, setInterfacesLoading] = useState(false);
   const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
   const [maxBandwidth, setMaxBandwidth] = useState("");
@@ -76,7 +70,7 @@ export function TeInterfaceModal({
       setInterfacesLoading(true);
       showService
         .getAllInterfaces()
-        .then((res) => setAvailableInterfaces(res.interfaces.map((i) => i.name).sort()))
+        .then((res) => setAvailableInterfaces([...res.interfaces].sort((a, b) => a.name.localeCompare(b.name))))
         .catch(() => setAvailableInterfaces([]))
         .finally(() => setInterfacesLoading(false));
     }
@@ -159,20 +153,13 @@ export function TeInterfaceModal({
               {isEditMode ? (
                 <Input value={name} disabled className="bg-muted" />
               ) : (
-                <Select value={name} onValueChange={setName} disabled={interfacesLoading}>
-                  <SelectTrigger>
-                    <SelectValue
-                      placeholder={interfacesLoading ? "Loading interfaces..." : "Select interface"}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface} value={iface}>
-                        {iface}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={name}
+                  onValueChange={setName}
+                  disabled={interfacesLoading}
+                  interfaces={availableInterfaces}
+                  placeholder="Select interface"
+                />
               )}
             </div>
 

--- a/frontend/src/components/tunnel/CreateTunnelModal.tsx
+++ b/frontend/src/components/tunnel/CreateTunnelModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Loader2, Waypoints } from "lucide-react";
 import { tunnelService, type TunnelCapabilities } from "@/lib/api/tunnel";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 const ENCAPSULATION_TYPES = [
@@ -390,17 +391,13 @@ export function CreateTunnelModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="source-interface">Source Interface</Label>
-                <Select value={sourceInterface} onValueChange={setSourceInterface}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="None" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface || "__none__"}
+                  onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "__none__" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>
@@ -533,45 +530,33 @@ export function CreateTunnelModal({
               <div className="grid grid-cols-3 gap-4">
                 <div className="space-y-2">
                   <Label>Mirror Ingress</Label>
-                  <Select value={mirrorIngress || "__none__"} onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="None" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorIngress || "__none__"}
+                    onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="None"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label>Mirror Egress</Label>
-                  <Select value={mirrorEgress || "__none__"} onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="None" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorEgress || "__none__"}
+                    onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="None"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label>Redirect</Label>
-                  <Select value={redirect || "__none__"} onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="None" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={redirect || "__none__"}
+                    onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="None"
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/components/tunnel/EditTunnelModal.tsx
+++ b/frontend/src/components/tunnel/EditTunnelModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Loader2, Waypoints } from "lucide-react";
 import { tunnelService, type TunnelCapabilities, type TunnelInterface } from "@/lib/api/tunnel";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 const IPV4_ENCAPS = ["gre", "gretap", "ipip", "erspan"];
@@ -422,17 +423,13 @@ export function EditTunnelModal({
               </div>
               <div className="space-y-2">
                 <Label>Source Interface</Label>
-                <Select value={sourceInterface || "__none__"} onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="None" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface || "__none__"}
+                  onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "__none__" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>
@@ -561,45 +558,33 @@ export function EditTunnelModal({
               <div className="grid grid-cols-3 gap-4">
                 <div className="space-y-2">
                   <Label>Mirror Ingress</Label>
-                  <Select value={mirrorIngress || "__none__"} onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="None" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorIngress || "__none__"}
+                    onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="None"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label>Mirror Egress</Label>
-                  <Select value={mirrorEgress || "__none__"} onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="None" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorEgress || "__none__"}
+                    onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="None"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label>Redirect</Label>
-                  <Select value={redirect || "__none__"} onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="None" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={redirect || "__none__"}
+                    onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="None"
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ui/interface-select.tsx
+++ b/frontend/src/components/ui/interface-select.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { showService, InterfaceName } from "@/lib/api/show";
+
+export interface InterfaceSelectProps {
+  /** Currently selected interface name (or sentinel `noneOption.value`). */
+  value: string;
+  /** Called with the newly selected value. */
+  onValueChange: (value: string) => void;
+  /**
+   * Pre-filtered list of interfaces to display. When provided, the component
+   * uses this list as-is and does NOT fetch — callers that need to filter
+   * (e.g. ethernet-only, exclude already-used) pass their narrowed list here.
+   * When omitted, the component fetches the full interface list itself.
+   */
+  interfaces?: InterfaceName[];
+  /** Optional predicate applied on top of the resolved list. */
+  filter?: (iface: InterfaceName) => boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  id?: string;
+  /** Class applied to the trigger. */
+  className?: string;
+  /** Text for the disabled item shown when the list is empty. */
+  emptyText?: string;
+  /**
+   * Optional sentinel option rendered at the top of the list (e.g. "None",
+   * "Any", "All"). Radix Select cannot use an empty-string value, so the
+   * value must be a non-empty sentinel such as "__none__".
+   */
+  noneOption?: { label: string; value: string };
+}
+
+/**
+ * Shared interface picker. Renders each interface as its name followed by a
+ * muted description (nothing is shown when an interface has no description).
+ * By default it fetches the full interface list; pass `interfaces` to supply a
+ * pre-filtered list while keeping the same look.
+ */
+export function InterfaceSelect({
+  value,
+  onValueChange,
+  interfaces,
+  filter,
+  placeholder = "Select an interface",
+  disabled,
+  id,
+  className,
+  emptyText = "No interfaces available",
+  noneOption,
+}: InterfaceSelectProps) {
+  const provided = interfaces !== undefined;
+  const [fetched, setFetched] = useState<InterfaceName[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (provided) return;
+    let active = true;
+    setLoading(true);
+    showService
+      .getAllInterfaces()
+      .then((res) => {
+        if (active) setFetched(res.interfaces);
+      })
+      .catch(() => {
+        if (active) setFetched([]);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [provided]);
+
+  let list = provided ? interfaces! : fetched;
+  if (filter) list = list.filter(filter);
+
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger id={id} className={className}>
+        <SelectValue placeholder={loading ? "Loading interfaces..." : placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {noneOption && <SelectItem value={noneOption.value}>{noneOption.label}</SelectItem>}
+        {list.length === 0 && !noneOption ? (
+          <div className="px-2 py-1.5 text-sm text-muted-foreground">{emptyText}</div>
+        ) : (
+          list.map((iface) => (
+            <SelectItem key={iface.name} value={iface.name}>
+              <span className="font-mono">{iface.name}</span>
+              {iface.description && (
+                <span className="text-muted-foreground ml-2 text-xs">{iface.description}</span>
+              )}
+            </SelectItem>
+          ))
+        )}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/frontend/src/components/vpn/ipsec/AuthPSKModal.tsx
+++ b/frontend/src/components/vpn/ipsec/AuthPSKModal.tsx
@@ -23,6 +23,7 @@ import {
 import { AlertCircle, Loader2, Key, Eye, EyeOff, RefreshCw } from "lucide-react";
 import { ipsecService, AuthPSK } from "@/lib/api/ipsec";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface AuthPSKModalProps {
@@ -173,13 +174,13 @@ export function AuthPSKModal({
             </div>
             <div className="space-y-2">
               <Label>DHCP Interface (optional)</Label>
-              <Select value={dhcpInterface || "_none"} onValueChange={(v) => setDhcpInterface(v === "_none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_none">None</SelectItem>
-                  {allInterfaces.map((iface) => <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>)}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={dhcpInterface || "_none"}
+                onValueChange={(v) => setDhcpInterface(v === "_none" ? "" : v)}
+                interfaces={allInterfaces}
+                noneOption={{ label: "None", value: "_none" }}
+                placeholder="None"
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/components/vpn/ipsec/SiteToSiteModal.tsx
+++ b/frontend/src/components/vpn/ipsec/SiteToSiteModal.tsx
@@ -30,6 +30,7 @@ import {
   IPSecCapabilities,
 } from "@/lib/api/ipsec";
 import { showService, InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface SiteToSiteModalProps {
@@ -323,13 +324,13 @@ export function SiteToSiteModal({
               </div>
               <div className="space-y-2">
                 <Label>DHCP Interface (optional)</Label>
-                <Select value={dhcpInterface || "_none"} onValueChange={(v) => setDhcpInterface(v === "_none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="_none">None</SelectItem>
-                    {allInterfaces.map((iface) => <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>)}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={dhcpInterface || "_none"}
+                  onValueChange={(v) => setDhcpInterface(v === "_none" ? "" : v)}
+                  interfaces={allInterfaces}
+                  noneOption={{ label: "None", value: "_none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -466,15 +467,13 @@ export function SiteToSiteModal({
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label>Bound Interface</Label>
-                <Select value={vtiBind || "_none"} onValueChange={(v) => setVtiBind(v === "_none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="_none">None</SelectItem>
-                    {allInterfaces
-                      .filter((iface) => iface.name.startsWith("vti"))
-                      .map((iface) => <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>)}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={vtiBind || "_none"}
+                  onValueChange={(v) => setVtiBind(v === "_none" ? "" : v)}
+                  interfaces={allInterfaces.filter((iface) => iface.name.startsWith("vti"))}
+                  noneOption={{ label: "None", value: "_none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>ESP Group</Label>

--- a/frontend/src/components/vti/CreateVtiModal.tsx
+++ b/frontend/src/components/vti/CreateVtiModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Lock, Loader2 } from "lucide-react";
 import { vtiService, type VtiCapabilities } from "@/lib/api/vti";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateVtiModalProps {
@@ -606,39 +607,33 @@ export function CreateVtiModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring &amp; Redirect</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress →</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress →</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/vti/EditVtiModal.tsx
+++ b/frontend/src/components/vti/EditVtiModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Lock, Loader2 } from "lucide-react";
 import { vtiService, type VtiInterface, type VtiCapabilities } from "@/lib/api/vti";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditVtiModalProps {
@@ -621,39 +622,33 @@ export function EditVtiModal({
               <h4 className="text-sm font-medium text-foreground">Traffic Mirroring &amp; Redirect</h4>
               <div className="space-y-2">
                 <Label>Mirror Ingress →</Label>
-                <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorIngress || "none"}
+                  onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Mirror Egress →</Label>
-                <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={mirrorEgress || "none"}
+                  onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
               <div className="space-y-2">
                 <Label>Redirect To</Label>
-                <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={redirect || "none"}
+                  onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "none" }}
+                  placeholder="None"
+                />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/vxlan/CreateVxlanModal.tsx
+++ b/frontend/src/components/vxlan/CreateVxlanModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Boxes, Loader2, Plus, Trash2 } from "lucide-react";
 import { vxlanService, type VxlanCapabilities } from "@/lib/api/vxlan";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateVxlanModalProps {
@@ -292,15 +293,13 @@ export function CreateVxlanModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="sourceInterface">Source Interface</Label>
-                <Select value={sourceInterface || "__none__"} onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface || "__none__"}
+                  onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "__none__" }}
+                  placeholder="Select interface"
+                />
               </div>
             </div>
 
@@ -431,42 +430,36 @@ export function CreateVxlanModal({
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="mirrorIngress" className="text-xs">Ingress Interface</Label>
-                  <Select value={mirrorIngress || "__none__"} onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorIngress || "__none__"}
+                    onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="Select interface"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="mirrorEgress" className="text-xs">Egress Interface</Label>
-                  <Select value={mirrorEgress || "__none__"} onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorEgress || "__none__"}
+                    onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="Select interface"
+                  />
                 </div>
               </div>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="redirect">Redirect Interface</Label>
-              <Select value={redirect || "__none__"} onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={redirect || "__none__"}
+                onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select interface"
+              />
               <p className="text-xs text-muted-foreground">Redirect received packets to another interface</p>
             </div>
           </TabsContent>

--- a/frontend/src/components/vxlan/EditVxlanModal.tsx
+++ b/frontend/src/components/vxlan/EditVxlanModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Boxes, Loader2, Plus, Trash2 } from "lucide-react";
 import { vxlanService, type VxlanInterface, type VxlanCapabilities } from "@/lib/api/vxlan";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditVxlanModalProps {
@@ -278,15 +279,13 @@ export function EditVxlanModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-sourceInterface">Source Interface</Label>
-                <Select value={sourceInterface || "__none__"} onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}>
-                  <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="__none__">None</SelectItem>
-                    {availableInterfaces.map((iface) => (
-                      <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <InterfaceSelect
+                  value={sourceInterface || "__none__"}
+                  onValueChange={(v) => setSourceInterface(v === "__none__" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "__none__" }}
+                  placeholder="Select interface"
+                />
               </div>
             </div>
 
@@ -417,42 +416,36 @@ export function EditVxlanModal({
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="edit-mirrorIngress" className="text-xs">Ingress Interface</Label>
-                  <Select value={mirrorIngress || "__none__"} onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorIngress || "__none__"}
+                    onValueChange={(v) => setMirrorIngress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="Select interface"
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="edit-mirrorEgress" className="text-xs">Egress Interface</Label>
-                  <Select value={mirrorEgress || "__none__"} onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}>
-                    <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">None</SelectItem>
-                      {availableInterfaces.map((iface) => (
-                        <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <InterfaceSelect
+                    value={mirrorEgress || "__none__"}
+                    onValueChange={(v) => setMirrorEgress(v === "__none__" ? "" : v)}
+                    interfaces={availableInterfaces}
+                    noneOption={{ label: "None", value: "__none__" }}
+                    placeholder="Select interface"
+                  />
                 </div>
               </div>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="edit-redirect">Redirect Interface</Label>
-              <Select value={redirect || "__none__"} onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="Select interface" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={redirect || "__none__"}
+                onValueChange={(v) => setRedirect(v === "__none__" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "__none__" }}
+                placeholder="Select interface"
+              />
             </div>
           </TabsContent>
 

--- a/frontend/src/components/wwan/CreateWwanModal.tsx
+++ b/frontend/src/components/wwan/CreateWwanModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Signal, Loader2, Eye, EyeOff, X, Plus } from "lucide-react";
 import { wwanService, type WwanCapabilities } from "@/lib/api/wwan";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface CreateWwanModalProps {
@@ -803,39 +804,33 @@ export function CreateWwanModal({
             <h4 className="text-sm font-medium text-foreground">Traffic Mirroring &amp; Redirect</h4>
             <div className="space-y-2">
               <Label>Mirror Ingress →</Label>
-              <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorIngress || "none"}
+                onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "none" }}
+                placeholder="None"
+              />
             </div>
             <div className="space-y-2">
               <Label>Mirror Egress →</Label>
-              <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorEgress || "none"}
+                onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "none" }}
+                placeholder="None"
+              />
             </div>
             <div className="space-y-2">
               <Label>Redirect To</Label>
-              <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={redirect || "none"}
+                onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "none" }}
+                placeholder="None"
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/wwan/EditWwanModal.tsx
+++ b/frontend/src/components/wwan/EditWwanModal.tsx
@@ -25,6 +25,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Signal, Loader2, Eye, EyeOff, X, Plus } from "lucide-react";
 import { wwanService, type WwanInterface, type WwanCapabilities } from "@/lib/api/wwan";
 import { showService, type InterfaceName } from "@/lib/api/show";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { ApiError } from "@/lib/types/api";
 
 interface EditWwanModalProps {
@@ -820,39 +821,33 @@ export function EditWwanModal({
             <h4 className="text-sm font-medium text-foreground">Traffic Mirroring &amp; Redirect</h4>
             <div className="space-y-2">
               <Label>Mirror Ingress →</Label>
-              <Select value={mirrorIngress || "none"} onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorIngress || "none"}
+                onValueChange={(v) => setMirrorIngress(v === "none" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "none" }}
+                placeholder="None"
+              />
             </div>
             <div className="space-y-2">
               <Label>Mirror Egress →</Label>
-              <Select value={mirrorEgress || "none"} onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={mirrorEgress || "none"}
+                onValueChange={(v) => setMirrorEgress(v === "none" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "none" }}
+                placeholder="None"
+              />
             </div>
             <div className="space-y-2">
               <Label>Redirect To</Label>
-              <Select value={redirect || "none"} onValueChange={(v) => setRedirect(v === "none" ? "" : v)}>
-                <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {availableInterfaces.map((iface) => (
-                    <SelectItem key={iface.name} value={iface.name}>{iface.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <InterfaceSelect
+                value={redirect || "none"}
+                onValueChange={(v) => setRedirect(v === "none" ? "" : v)}
+                interfaces={availableInterfaces}
+                noneOption={{ label: "None", value: "none" }}
+                placeholder="None"
+              />
             </div>
           </TabsContent>
         </Tabs>


### PR DESCRIPTION
Introduce a reusable InterfaceSelect component that renders each interface as its name plus a muted description, and migrate every interface dropdown across the app (~89 files) to use it. Modals keep their own filtering by passing a pre-filtered list; sentinel "None"/"Any" options are preserved via noneOption.

Also apply the thin, theme-colored scrollbar globally in globals.css so all pages, panels, and modals match — excluding Radix ScrollArea viewports to avoid duplicate scrollbars.