### PR TITLE
Add shared VrfSelect/VrfMultiSelect and convert VRF inputs to dropdowns

### DIFF
--- a/frontend/src/components/bfd/BfdPeerModal.tsx
+++ b/frontend/src/components/bfd/BfdPeerModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -504,11 +505,10 @@ export function BfdPeerModal({
                 {/* VRF */}
                 <div className="space-y-2">
                   <Label htmlFor="bfd-peer-vrf">VRF</Label>
-                  <Input
+                  <VrfSelect
                     id="bfd-peer-vrf"
                     value={vrf}
-                    onChange={(e) => setVrf(e.target.value)}
-                    placeholder="e.g. my-vrf"
+                    onValueChange={setVrf}
                   />
                   <p className="text-xs text-muted-foreground">
                     VRF instance for this BFD peer.

--- a/frontend/src/components/bonding/CreateBondingModal.tsx
+++ b/frontend/src/components/bonding/CreateBondingModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -572,7 +573,7 @@ export function CreateBondingModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="Optional VRF" />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="mac">MAC Override</Label>

--- a/frontend/src/components/bonding/EditBondingModal.tsx
+++ b/frontend/src/components/bonding/EditBondingModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -656,7 +657,7 @@ export function EditBondingModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-vrf">VRF</Label>
-                <Input id="edit-vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="Optional VRF" />
+                <VrfSelect id="edit-vrf" value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-mac">MAC Override</Label>

--- a/frontend/src/components/bridge/CreateBridgeModal.tsx
+++ b/frontend/src/components/bridge/CreateBridgeModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -601,7 +602,7 @@ export function CreateBridgeModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="Optional VRF" />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="mac">MAC Override</Label>

--- a/frontend/src/components/bridge/CreateBridgeVifModal.tsx
+++ b/frontend/src/components/bridge/CreateBridgeVifModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -157,11 +158,10 @@ export function CreateBridgeVifModal({
             </div>
             <div className="space-y-2">
               <Label htmlFor="vif-vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="vif-vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF"
+                onValueChange={setVrf}
               />
             </div>
           </div>

--- a/frontend/src/components/bridge/EditBridgeModal.tsx
+++ b/frontend/src/components/bridge/EditBridgeModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -569,7 +570,7 @@ export function EditBridgeModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-vrf">VRF</Label>
-                <Input id="edit-vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="Optional VRF" />
+                <VrfSelect id="edit-vrf" value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-mac">MAC Override</Label>

--- a/frontend/src/components/bridge/EditBridgeVifModal.tsx
+++ b/frontend/src/components/bridge/EditBridgeVifModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -131,11 +132,10 @@ export function EditBridgeVifModal({
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-vif-vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="edit-vif-vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF"
+                onValueChange={setVrf}
               />
             </div>
           </div>

--- a/frontend/src/components/container/NetworkModal.tsx
+++ b/frontend/src/components/container/NetworkModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -200,7 +201,7 @@ export function NetworkModal({ open, onOpenChange, network, capabilities, onSubm
 
             <div className="space-y-2">
               <Label htmlFor="net-vrf">VRF</Label>
-              <Input id="net-vrf" value={vrf} onChange={e => setVrf(e.target.value)} placeholder="VRF name (optional)" className="font-mono" />
+              <VrfSelect id="net-vrf" value={vrf} onValueChange={setVrf} className="font-mono" />
             </div>
 
             <div className="flex items-center gap-2">

--- a/frontend/src/components/dns-dynamic/DNSDynamicGlobalModal.tsx
+++ b/frontend/src/components/dns-dynamic/DNSDynamicGlobalModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -78,12 +79,12 @@ export function DNSDynamicGlobalModal({ open, onOpenChange, interval, vrf, onSub
           </div>
           <div className="space-y-2">
             <Label htmlFor="ddns-vrf">VRF (optional)</Label>
-            <Input
+            <VrfSelect
               id="ddns-vrf"
               value={vrfVal}
-              onChange={(e) => setVrfVal(e.target.value)}
-              placeholder="e.g. mgmt"
+              onValueChange={setVrfVal}
               className="font-mono"
+              extraOptions={[{ label: "Default", value: "default" }]}
             />
           </div>
         </div>

--- a/frontend/src/components/dummy/CreateDummyModal.tsx
+++ b/frontend/src/components/dummy/CreateDummyModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -230,11 +231,10 @@ export function CreateDummyModal({
 
             <div className="space-y-2">
               <Label htmlFor="vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF name"
+                onValueChange={setVrf}
               />
             </div>
 

--- a/frontend/src/components/dummy/EditDummyModal.tsx
+++ b/frontend/src/components/dummy/EditDummyModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -211,11 +212,10 @@ export function EditDummyModal({
 
             <div className="space-y-2">
               <Label htmlFor="edit-vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="edit-vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF name"
+                onValueChange={setVrf}
               />
             </div>
 

--- a/frontend/src/components/failover/FailoverRouteModal.tsx
+++ b/frontend/src/components/failover/FailoverRouteModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -563,11 +564,12 @@ export function FailoverRouteModal({
                     interfaces={availableInterfaces}
                     placeholder="Interface"
                   />
-                  <Input
+                  <VrfSelect
                     className="h-8 text-xs"
                     value={target.vrf}
-                    onChange={(e) => onUpdateTarget(tIndex, { vrf: e.target.value })}
+                    onValueChange={(v) => onUpdateTarget(tIndex, { vrf: v })}
                     placeholder="VRF"
+                    extraOptions={[{ label: "Default", value: "default" }]}
                   />
                 </>
               )}

--- a/frontend/src/components/firewall/zones/CreateZoneModal.tsx
+++ b/frontend/src/components/firewall/zones/CreateZoneModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -53,7 +54,6 @@ export function CreateZoneModal({
   const [defaultLog, setDefaultLog] = useState(false);
   const [interfaces, setInterfaces] = useState<string[]>([]);
   const [vrfs, setVrfs] = useState<string[]>([]);
-  const [vrfInput, setVrfInput] = useState("");
 
   const nonLocalPeers = existingZones.filter((z) => !z.local_zone);
   const isFirstZone = nonLocalPeers.length === 0;
@@ -79,7 +79,6 @@ export function CreateZoneModal({
     setDefaultLog(false);
     setInterfaces([]);
     setVrfs([]);
-    setVrfInput("");
     setError(null);
     setDone(false);
     setAvailableInterfaces([]);
@@ -95,14 +94,6 @@ export function CreateZoneModal({
     setInterfaces((prev) =>
       prev.includes(name) ? prev.filter((i) => i !== name) : [...prev, name]
     );
-  };
-
-  const addVrf = () => {
-    const val = vrfInput.trim();
-    if (val && !vrfs.includes(val)) {
-      setVrfs([...vrfs, val]);
-      setVrfInput("");
-    }
   };
 
   const handleSubmit = async () => {
@@ -368,24 +359,17 @@ export function CreateZoneModal({
             {supportsVrf && (
               <div className="space-y-2">
                 <Label>Member VRFs</Label>
-                <div className="flex gap-2">
-                  <Input
-                    value={vrfInput}
-                    onChange={(e) => setVrfInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        addVrf();
-                      }
-                    }}
-                    placeholder="e.g., mgmt"
-                    className="font-mono"
-                    disabled={loading}
-                  />
-                  <Button type="button" size="sm" onClick={addVrf} disabled={loading}>
-                    Add
-                  </Button>
-                </div>
+                <VrfSelect
+                  value=""
+                  onValueChange={(v) => {
+                    if (v && !vrfs.includes(v)) setVrfs([...vrfs, v]);
+                  }}
+                  filter={(v) => !vrfs.includes(v.name)}
+                  includeNone={false}
+                  placeholder="Add VRF"
+                  className="font-mono"
+                  disabled={loading}
+                />
                 {vrfs.length > 0 && (
                   <div className="flex flex-wrap gap-1">
                     {vrfs.map((vrf) => (

--- a/frontend/src/components/firewall/zones/EditZoneModal.tsx
+++ b/frontend/src/components/firewall/zones/EditZoneModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -67,7 +68,6 @@ export function EditZoneModal({
   const [defaultLog, setDefaultLog] = useState(zone.default_log);
   const [interfaces, setInterfaces] = useState<string[]>([...zone.interfaces]);
   const [vrfs, setVrfs] = useState<string[]>([...zone.vrfs]);
-  const [vrfInput, setVrfInput] = useState("");
   const [intraMode, setIntraMode] = useState<IntraMode>(getIntraMode(zone.intra_zone_filtering));
 
   // Sync when zone prop changes
@@ -78,7 +78,6 @@ export function EditZoneModal({
     setDefaultLog(zone.default_log);
     setInterfaces([...zone.interfaces]);
     setVrfs([...zone.vrfs]);
-    setVrfInput("");
     setIntraMode(getIntraMode(zone.intra_zone_filtering));
     setError(null);
     setConfirmDelete(false);
@@ -103,14 +102,6 @@ export function EditZoneModal({
     setInterfaces((prev) =>
       prev.includes(name) ? prev.filter((i) => i !== name) : [...prev, name]
     );
-  };
-
-  const addVrf = () => {
-    const val = vrfInput.trim();
-    if (val && !vrfs.includes(val)) {
-      setVrfs([...vrfs, val]);
-      setVrfInput("");
-    }
   };
 
   const handleSave = async () => {
@@ -296,23 +287,16 @@ export function EditZoneModal({
               {supportsVrf && (
                 <div className="space-y-2">
                   <Label>Member VRFs</Label>
-                  <div className="flex gap-2">
-                    <Input
-                      value={vrfInput}
-                      onChange={(e) => setVrfInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.preventDefault();
-                          addVrf();
-                        }
-                      }}
-                      placeholder="e.g., mgmt"
-                      className="font-mono"
-                    />
-                    <Button type="button" size="sm" onClick={addVrf}>
-                      Add
-                    </Button>
-                  </div>
+                  <VrfSelect
+                    value=""
+                    onValueChange={(v) => {
+                      if (v && !vrfs.includes(v)) setVrfs([...vrfs, v]);
+                    }}
+                    filter={(v) => !vrfs.includes(v.name)}
+                    includeNone={false}
+                    placeholder="Add VRF"
+                    className="font-mono"
+                  />
                   {vrfs.length > 0 && (
                     <div className="flex flex-wrap gap-1">
                       {vrfs.map((vrf) => (

--- a/frontend/src/components/geneve/CreateGeneveModal.tsx
+++ b/frontend/src/components/geneve/CreateGeneveModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -362,11 +363,10 @@ export function CreateGeneveModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="Optional VRF name"
+                  onValueChange={setVrf}
                 />
               </div>
             </div>

--- a/frontend/src/components/geneve/EditGeneveModal.tsx
+++ b/frontend/src/components/geneve/EditGeneveModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -336,11 +337,10 @@ export function EditGeneveModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="edit-vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="Optional VRF name"
+                  onValueChange={setVrf}
                 />
               </div>
             </div>

--- a/frontend/src/components/https/HTTPSModal.tsx
+++ b/frontend/src/components/https/HTTPSModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -452,11 +453,10 @@ export function HTTPSModal({ open, onClose, onSuccess, config }: HTTPSModalProps
                 {/* VRF */}
                 <div className="space-y-2">
                   <Label htmlFor="vrf">VRF</Label>
-                  <Input
+                  <VrfSelect
                     id="vrf"
-                    placeholder="VRF instance name (optional)"
                     value={vrf}
-                    onChange={(e) => setVrf(e.target.value)}
+                    onValueChange={setVrf}
                   />
                 </div>
               </div>

--- a/frontend/src/components/interfaces/InterfaceFormModal.tsx
+++ b/frontend/src/components/interfaces/InterfaceFormModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -244,26 +245,13 @@ export function InterfaceFormModal({
           {/* VRF */}
           <div className="space-y-2">
             <Label htmlFor="vrf">VRF</Label>
-            <Select
-              value={formData.vrf || "none"}
-              onValueChange={(value) =>
-                setFormData({ ...formData, vrf: value === "none" ? "" : value })
-              }
+            <VrfSelect
+              id="vrf"
+              value={formData.vrf || ""}
+              onValueChange={(value) => setFormData({ ...formData, vrf: value })}
+              vrfs={vrfs}
               disabled={isLoadingVrfs}
-            >
-              <SelectTrigger id="vrf">
-                <SelectValue placeholder={isLoadingVrfs ? "Loading VRFs..." : "Select VRF"} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">None</SelectItem>
-                {vrfs.map((vrf) => (
-                  <SelectItem key={vrf.name} value={vrf.name}>
-                    {vrf.name}
-                    {vrf.description && ` - ${vrf.description}`}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            />
           </div>
 
           {/* Hardware ID (for Ethernet) */}

--- a/frontend/src/components/l2tpv3/CreateL2TPv3Modal.tsx
+++ b/frontend/src/components/l2tpv3/CreateL2TPv3Modal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -436,11 +437,10 @@ export function CreateL2TPv3Modal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="Optional VRF name"
+                  onValueChange={setVrf}
                 />
               </div>
             </div>

--- a/frontend/src/components/l2tpv3/EditL2TPv3Modal.tsx
+++ b/frontend/src/components/l2tpv3/EditL2TPv3Modal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -366,7 +367,7 @@ export function EditL2TPv3Modal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="Optional VRF name" />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
 

--- a/frontend/src/components/macsec/CreateMacsecModal.tsx
+++ b/frontend/src/components/macsec/CreateMacsecModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -375,7 +376,7 @@ export function CreateMacsecModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="None" />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
 

--- a/frontend/src/components/macsec/EditMacsecModal.tsx
+++ b/frontend/src/components/macsec/EditMacsecModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { showService, type InterfaceName } from "@/lib/api/show";
 import { InterfaceSelect } from "@/components/ui/interface-select";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import {
   Dialog,
   DialogContent,
@@ -416,7 +417,7 @@ export function EditMacsecModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-vrf">VRF</Label>
-                <Input id="edit-vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="None" />
+                <VrfSelect id="edit-vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
 

--- a/frontend/src/components/network/ComprehensiveEthernetModal.tsx
+++ b/frontend/src/components/network/ComprehensiveEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -854,11 +855,10 @@ export function ComprehensiveEthernetModal({
                 {capabilities?.features.basic.vrf && (
                   <div className="space-y-2">
                     <Label htmlFor="vrf">VRF</Label>
-                    <Input
+                    <VrfSelect
                       id="vrf"
-                      placeholder="MGMT"
                       value={vrf}
-                      onChange={(e) => setVrf(e.target.value)}
+                      onValueChange={setVrf}
                     />
                   </div>
                 )}

--- a/frontend/src/components/network/ComprehensiveVIFCModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVIFCModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -543,7 +544,7 @@ export function ComprehensiveVIFCModal({
                 {feat?.vif_vrf && (
                   <div className="space-y-2">
                     <Label htmlFor="vrf">VRF</Label>
-                    <Input id="vrf" placeholder="MGMT" value={vrf} onChange={(e) => setVrf(e.target.value)} />
+                    <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
                   </div>
                 )}
                 {feat?.vif_redirect && (

--- a/frontend/src/components/network/ComprehensiveVIFSModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVIFSModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -523,7 +524,7 @@ export function ComprehensiveVIFSModal({
                 {feat?.vif_vrf && (
                   <div className="space-y-2">
                     <Label htmlFor="vrf">VRF</Label>
-                    <Input id="vrf" placeholder="MGMT" value={vrf} onChange={(e) => setVrf(e.target.value)} />
+                    <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
                   </div>
                 )}
                 {feat?.vif_redirect && (

--- a/frontend/src/components/network/ComprehensiveVLANModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVLANModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -678,11 +679,10 @@ export function ComprehensiveVLANModal({
                 {feat?.vif_vrf && (
                   <div className="space-y-2">
                     <Label htmlFor="vrf">VRF</Label>
-                    <Input
+                    <VrfSelect
                       id="vrf"
-                      placeholder="MGMT"
                       value={vrf}
-                      onChange={(e) => setVrf(e.target.value)}
+                      onValueChange={setVrf}
                     />
                   </div>
                 )}

--- a/frontend/src/components/network/CreateEthernetModal.tsx
+++ b/frontend/src/components/network/CreateEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -290,11 +291,10 @@ export function CreateEthernetModal({
             {capabilities?.features.basic.vrf && (
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="vrf"
-                  placeholder="MGMT"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
+                  onValueChange={setVrf}
                 />
               </div>
             )}

--- a/frontend/src/components/network/EditEthernetModal.tsx
+++ b/frontend/src/components/network/EditEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -300,11 +301,10 @@ export function EditEthernetModal({
             {capabilities?.features.basic.vrf && (
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="vrf"
-                  placeholder="MGMT"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
+                  onValueChange={setVrf}
                 />
               </div>
             )}

--- a/frontend/src/components/ntp/NTPGlobalSettingsModal.tsx
+++ b/frontend/src/components/ntp/NTPGlobalSettingsModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -284,11 +285,12 @@ export function NTPGlobalSettingsModal({
               <p className="text-xs text-muted-foreground">
                 Bind the NTP service to a specific VRF. Leave empty to use the default routing table.
               </p>
-              <Input
+              <VrfSelect
                 id="ntp-vrf"
-                placeholder="e.g. mgmt"
+                placeholder="Default routing table"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
+                onValueChange={setVrf}
+                extraOptions={[{ label: "Default", value: "default" }]}
               />
             </div>
           </div>

--- a/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/CreateOpenvpnModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -577,7 +578,7 @@ export function CreateOpenvpnModal({
               </div>
               <div>
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
             <div>

--- a/frontend/src/components/openvpn/EditOpenvpnModal.tsx
+++ b/frontend/src/components/openvpn/EditOpenvpnModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -537,7 +538,7 @@ export function EditOpenvpnModal({
               </div>
               <div>
                 <Label htmlFor="evrf">VRF</Label>
-                <Input id="evrf" value={vrf} onChange={(e) => setVrf(e.target.value)} />
+                <VrfSelect id="evrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
             <div>

--- a/frontend/src/components/policies/AddRouteMapRuleModal.tsx
+++ b/frontend/src/components/policies/AddRouteMapRuleModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1075,11 +1076,11 @@ export function AddRouteMapRuleModal({
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="matchSourceVrf">Source VRF</Label>
-                      <Input
+                      <VrfSelect
                         id="matchSourceVrf"
-                        placeholder="VRF name"
                         value={matchSourceVrf}
-                        onChange={(e) => setMatchSourceVrf(e.target.value)}
+                        onValueChange={setMatchSourceVrf}
+                        extraOptions={[{ label: "Default", value: "default" }]}
                       />
                     </div>
                     <div className="space-y-2">

--- a/frontend/src/components/policies/CreateLocalRouteModal.tsx
+++ b/frontend/src/components/policies/CreateLocalRouteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -370,12 +371,14 @@ export function CreateLocalRouteModal({
               </div>
             ) : (
               <div className="space-y-2">
-                <Input
+                <VrfSelect
                   id="vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="Enter VRF name or 'default'"
+                  onValueChange={setVrf}
                   disabled={loading}
+                  includeNone={false}
+                  placeholder="Select VRF"
+                  extraOptions={[{ label: "Default", value: "default" }]}
                 />
                 <p className="text-xs text-muted-foreground">
                   VRF instance to use for matched traffic (VyOS 1.5+)

--- a/frontend/src/components/policies/CreateRouteMapModal.tsx
+++ b/frontend/src/components/policies/CreateRouteMapModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -767,11 +768,11 @@ export function CreateRouteMapModal({ open, onOpenChange, onSuccess }: CreateRou
         </div>
         <div className="space-y-2">
         <Label htmlFor="matchSourceVrf">Source VRF</Label>
-        <Input
-        id="matchSourceVrf"
-        placeholder="VRF name"
-        value={matchSourceVrf}
-        onChange={(e) => setMatchSourceVrf(e.target.value)}
+        <VrfSelect
+          id="matchSourceVrf"
+          value={matchSourceVrf}
+          onValueChange={setMatchSourceVrf}
+          extraOptions={[{ label: "Default", value: "default" }]}
         />
         </div>
         <div className="space-y-2">

--- a/frontend/src/components/policies/CreateRouteRuleModal.tsx
+++ b/frontend/src/components/policies/CreateRouteRuleModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1525,12 +1526,12 @@ export function CreateRouteRuleModal({
                 {capabilities?.features.vrf_routing?.supported && (
                   <div className="space-y-2">
                     <Label htmlFor="actionVrf">VRF</Label>
-                    <Input
+                    <VrfSelect
                       id="actionVrf"
-                      placeholder="VRF name"
                       value={actionVrf}
-                      onChange={(e) => setActionVrf(e.target.value)}
+                      onValueChange={setActionVrf}
                       disabled={loading}
+                      extraOptions={[{ label: "Default", value: "default" }]}
                     />
                     <p className="text-xs text-muted-foreground">
                       VRF routing (VyOS 1.5+ only)

--- a/frontend/src/components/policies/EditLocalRouteModal.tsx
+++ b/frontend/src/components/policies/EditLocalRouteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -360,12 +361,14 @@ export function EditLocalRouteModal({
               </div>
             ) : (
               <div className="space-y-2">
-                <Input
+                <VrfSelect
                   id="vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="Enter VRF name or 'default'"
+                  onValueChange={setVrf}
                   disabled={loading}
+                  includeNone={false}
+                  placeholder="Select VRF"
+                  extraOptions={[{ label: "Default", value: "default" }]}
                 />
                 <p className="text-xs text-muted-foreground">
                   VRF instance to use for matched traffic (VyOS 1.5+)

--- a/frontend/src/components/policies/EditRouteMapRuleModal.tsx
+++ b/frontend/src/components/policies/EditRouteMapRuleModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1114,11 +1115,11 @@ export function EditRouteMapRuleModal({
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="matchSourceVrf">Source VRF</Label>
-                      <Input
+                      <VrfSelect
                         id="matchSourceVrf"
-                        placeholder="VRF name"
                         value={matchSourceVrf}
-                        onChange={(e) => setMatchSourceVrf(e.target.value)}
+                        onValueChange={setMatchSourceVrf}
+                        extraOptions={[{ label: "Default", value: "default" }]}
                       />
                     </div>
                     <div className="space-y-2">

--- a/frontend/src/components/policies/EditRouteRuleModal.tsx
+++ b/frontend/src/components/policies/EditRouteRuleModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1667,12 +1668,12 @@ export function EditRouteRuleModal({
                 {capabilities?.features.vrf_routing?.supported && (
                   <div className="space-y-2">
                     <Label htmlFor="actionVrf">VRF</Label>
-                    <Input
+                    <VrfSelect
                       id="actionVrf"
-                      placeholder="VRF name"
                       value={actionVrf}
-                      onChange={(e) => setActionVrf(e.target.value)}
+                      onValueChange={setActionVrf}
                       disabled={loading}
+                      extraOptions={[{ label: "Default", value: "default" }]}
                     />
                     <p className="text-xs text-muted-foreground">
                       VRF routing (VyOS 1.5+ only)

--- a/frontend/src/components/pppoe/CreatePppoeModal.tsx
+++ b/frontend/src/components/pppoe/CreatePppoeModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -487,10 +488,10 @@ export function CreatePppoeModal({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="pppoe-vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="pppoe-vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
+                  onValueChange={setVrf}
                 />
               </div>
               <div>

--- a/frontend/src/components/pppoe/EditPppoeModal.tsx
+++ b/frontend/src/components/pppoe/EditPppoeModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -448,10 +449,10 @@ export function EditPppoeModal({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="edit-pppoe-vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="edit-pppoe-vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
+                  onValueChange={setVrf}
                 />
               </div>
               <div>

--- a/frontend/src/components/pseudo-ethernet/CreatePseudoEthernetModal.tsx
+++ b/frontend/src/components/pseudo-ethernet/CreatePseudoEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -424,20 +425,18 @@ export function CreatePseudoEthernetModal({
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="VRF instance name"
+                  onValueChange={setVrf}
                 />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="redirect">Redirect</Label>
-                <Input
+                <VrfSelect
                   id="redirect"
                   value={redirect}
-                  onChange={(e) => setRedirect(e.target.value)}
-                  placeholder="Redirect destination"
+                  onValueChange={setRedirect}
                 />
               </div>
             </div>

--- a/frontend/src/components/pseudo-ethernet/EditPseudoEthernetModal.tsx
+++ b/frontend/src/components/pseudo-ethernet/EditPseudoEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -131,11 +132,11 @@ function VifForm({ form, onChange }: { form: VifFormState; onChange: (patch: Par
         </div>
         <div className="space-y-1">
           <Label className="text-xs">VRF</Label>
-          <Input value={form.vrf} onChange={(e) => onChange({ vrf: e.target.value })} />
+          <VrfSelect value={form.vrf} onValueChange={(v) => onChange({ vrf: v })} />
         </div>
         <div className="space-y-1">
           <Label className="text-xs">Redirect</Label>
-          <Input value={form.redirect} onChange={(e) => onChange({ redirect: e.target.value })} />
+          <VrfSelect value={form.redirect} onValueChange={(v) => onChange({ redirect: v })} />
         </div>
         <div className="space-y-1">
           <Label className="text-xs">Egress QoS</Label>
@@ -709,11 +710,11 @@ export function EditPseudoEthernetModal({
               </div>
               <div className="space-y-2">
                 <Label>VRF</Label>
-                <Input value={vrf} onChange={(e) => setVrf(e.target.value)} />
+                <VrfSelect value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label>Redirect</Label>
-                <Input value={redirect} onChange={(e) => setRedirect(e.target.value)} />
+                <VrfSelect value={redirect} onValueChange={setRedirect} />
               </div>
             </div>
 
@@ -1109,7 +1110,7 @@ export function EditPseudoEthernetModal({
                     </div>
                     <div className="space-y-1">
                       <Label className="text-xs">VRF</Label>
-                      <Input value={newVifS.vrf} onChange={(e) => setNewVifS((p) => ({ ...p, vrf: e.target.value }))} />
+                      <VrfSelect value={newVifS.vrf} onValueChange={(v) => setNewVifS((p) => ({ ...p, vrf: v }))} />
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
@@ -1161,7 +1162,7 @@ export function EditPseudoEthernetModal({
                             <div className="grid grid-cols-2 gap-2">
                               <div className="space-y-1">
                                 <Label className="text-xs">C-VLAN ID *</Label>
-                                <Input type="number" min={1} max={4094} value={newVifC.vlan_id} onChange={(e) => setNewVifC((p) => ({ ...p, vlan_id: e.target.value }))} />
+                                <VrfSelect value={newVifC.vlan_id} onValueChange={(v) => setNewVifC((p) => ({ ...p, vlan_id: v }))} />
                               </div>
                               <div className="space-y-1">
                                 <Label className="text-xs">Description</Label>

--- a/frontend/src/components/routing/CreateStaticRouteModal.tsx
+++ b/frontend/src/components/routing/CreateStaticRouteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -332,10 +333,10 @@ export function CreateStaticRouteModal({ open, onOpenChange, onSuccess, routeTyp
                     {capabilities?.features.next_hop_vrf.supported && (
                       <div className="space-y-2">
                         <Label>VRF</Label>
-                        <Input
-                          placeholder="VRF name (optional)"
+                        <VrfSelect
                           value={nh.vrf}
-                          onChange={(e) => updateNextHop(index, "vrf", e.target.value)}
+                          onValueChange={(v) => updateNextHop(index, "vrf", v)}
+                          extraOptions={[{ label: "Default", value: "default" }]}
                         />
                       </div>
                     )}

--- a/frontend/src/components/routing/EditStaticRouteModal.tsx
+++ b/frontend/src/components/routing/EditStaticRouteModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -360,10 +361,10 @@ export function EditStaticRouteModal({ open, onOpenChange, onSuccess, route }: E
                       {capabilities?.features.next_hop_vrf.supported && (
                         <div className="space-y-2">
                           <Label>VRF</Label>
-                          <Input
-                            placeholder="VRF name (optional)"
+                          <VrfSelect
                             value={nh.vrf}
-                            onChange={(e) => updateNextHop(index, "vrf", e.target.value)}
+                            onValueChange={(v) => updateNextHop(index, "vrf", v)}
+                            extraOptions={[{ label: "Default", value: "default" }]}
                           />
                         </div>
                       )}

--- a/frontend/src/components/service-monitoring/PrometheusExporterModal.tsx
+++ b/frontend/src/components/service-monitoring/PrometheusExporterModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -161,11 +162,11 @@ export function PrometheusExporterModal({
 
           <div className="space-y-2">
             <Label htmlFor="exp-vrf">VRF</Label>
-            <Input
+            <VrfSelect
               id="exp-vrf"
-              placeholder="e.g. mgmt"
               value={vrf}
-              onChange={(e) => setVrf(e.target.value)}
+              onValueChange={setVrf}
+              extraOptions={[{ label: "Default", value: "default" }]}
             />
           </div>
 

--- a/frontend/src/components/service-monitoring/TelegrafSourcesModal.tsx
+++ b/frontend/src/components/service-monitoring/TelegrafSourcesModal.tsx
@@ -8,8 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, Loader2 } from "lucide-react";
@@ -97,11 +97,11 @@ export function TelegrafSourcesModal({
 
           <div className="space-y-2">
             <Label htmlFor="telegraf-vrf">VRF</Label>
-            <Input
+            <VrfSelect
               id="telegraf-vrf"
-              placeholder="e.g. mgmt"
               value={vrf}
-              onChange={(e) => setVrf(e.target.value)}
+              onValueChange={setVrf}
+              extraOptions={[{ label: "Default", value: "default" }]}
             />
           </div>
         </div>

--- a/frontend/src/components/snmp/SNMPGeneralSettingsModal.tsx
+++ b/frontend/src/components/snmp/SNMPGeneralSettingsModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -179,11 +180,12 @@ export function SNMPGeneralSettingsModal({
               <p className="text-xs text-muted-foreground">
                 Bind the agent to a VRF. Leave empty for the default routing table.
               </p>
-              <Input
+              <VrfSelect
                 id="snmp-vrf"
-                placeholder="e.g. mgmt"
+                placeholder="Default routing table"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
+                onValueChange={setVrf}
+                extraOptions={[{ label: "Default", value: "default" }]}
               />
             </div>
 

--- a/frontend/src/components/ssh/SSHConnectionModal.tsx
+++ b/frontend/src/components/ssh/SSHConnectionModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AlertCircle, Loader2 } from "lucide-react";
 import { sshService, SSHConfig, SSHCapabilities } from "@/lib/api/ssh";
 import { SSHMultiValueField, isValidIP } from "./SSHMultiValueField";
+import { VrfMultiSelect } from "@/components/ui/vrf-multi-select";
 
 interface SSHConnectionModalProps {
   open: boolean;
@@ -115,13 +116,20 @@ export function SSHConnectionModal({
 
             <Separator />
 
-            <SSHMultiValueField
-              label="VRFs"
-              description='VRF instances to run the service in. Use "default" for the default VRF.'
-              placeholder="e.g. mgmt or default"
-              values={vrfs}
-              onChange={setVrfs}
-            />
+            <div className="space-y-2">
+              <div>
+                <Label className="text-sm font-medium">VRFs</Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {'VRF instances to run the service in. Use "default" for the default VRF.'}
+                </p>
+              </div>
+              <VrfMultiSelect
+                values={vrfs}
+                onChange={setVrfs}
+                placeholder="Select a VRF to add"
+                extraOptions={[{ label: "Default", value: "default" }]}
+              />
+            </div>
 
             <Separator />
 

--- a/frontend/src/components/sstpc/CreateSstpcModal.tsx
+++ b/frontend/src/components/sstpc/CreateSstpcModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -337,11 +338,10 @@ export function CreateSstpcModal({
 
             <div className="space-y-2">
               <Label htmlFor="vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="VRF instance name"
+                onValueChange={setVrf}
               />
             </div>
           </TabsContent>

--- a/frontend/src/components/sstpc/EditSstpcModal.tsx
+++ b/frontend/src/components/sstpc/EditSstpcModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -352,11 +353,10 @@ export function EditSstpcModal({
 
             <div className="space-y-2">
               <Label htmlFor="edit-vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="edit-vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="VRF instance name"
+                onValueChange={setVrf}
               />
             </div>
           </TabsContent>

--- a/frontend/src/components/tftp-server/TFTPServerListenAddressModal.tsx
+++ b/frontend/src/components/tftp-server/TFTPServerListenAddressModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -97,11 +98,10 @@ export function TFTPServerListenAddressModal({
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="tftp-listen-vrf">VRF</Label>
-            <Input
+            <VrfSelect
               id="tftp-listen-vrf"
-              placeholder="Optional VRF instance"
               value={vrf}
-              onChange={(e) => setVrf(e.target.value)}
+              onValueChange={setVrf}
               className="font-mono"
             />
             <p className="text-xs text-muted-foreground">

--- a/frontend/src/components/tunnel/CreateTunnelModal.tsx
+++ b/frontend/src/components/tunnel/CreateTunnelModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -387,7 +388,7 @@ export function CreateTunnelModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="VRF name" />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="source-interface">Source Interface</Label>

--- a/frontend/src/components/tunnel/EditTunnelModal.tsx
+++ b/frontend/src/components/tunnel/EditTunnelModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -419,7 +420,7 @@ export function EditTunnelModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-vrf">VRF</Label>
-                <Input id="edit-vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="VRF name" />
+                <VrfSelect id="edit-vrf" value={vrf} onValueChange={setVrf} />
               </div>
               <div className="space-y-2">
                 <Label>Source Interface</Label>

--- a/frontend/src/components/ui/vrf-multi-select.tsx
+++ b/frontend/src/components/ui/vrf-multi-select.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
+import { VrfSelect } from "@/components/ui/vrf-select";
+import { VrfInstance } from "@/lib/api/vrf";
+
+export interface VrfMultiSelectProps {
+  /** Currently selected VRF names. */
+  values: string[];
+  /** Called with the new list whenever a VRF is added or removed. */
+  onChange: (values: string[]) => void;
+  /**
+   * Pre-fetched list of VRF instances. When omitted, the underlying
+   * `VrfSelect` fetches the full list itself.
+   */
+  vrfs?: VrfInstance[];
+  /**
+   * Extra non-VRF options selectable from the dropdown (e.g. `default`).
+   * Already-selected values are hidden automatically.
+   */
+  extraOptions?: { label: string; value: string }[];
+  placeholder?: string;
+  disabled?: boolean;
+  id?: string;
+  /** Class applied to the dropdown trigger. */
+  className?: string;
+}
+
+/**
+ * Multi-value VRF picker: a dropdown that appends the chosen VRF to the list
+ * (hiding values already selected) plus removable badge chips for the current
+ * selection.
+ */
+export function VrfMultiSelect({
+  values,
+  onChange,
+  vrfs,
+  extraOptions,
+  placeholder = "Add VRF",
+  disabled,
+  id,
+  className,
+}: VrfMultiSelectProps) {
+  return (
+    <div className="space-y-2">
+      <VrfSelect
+        id={id}
+        value=""
+        onValueChange={(v) => {
+          if (v && !values.includes(v)) onChange([...values, v]);
+        }}
+        vrfs={vrfs}
+        filter={(vrf) => !values.includes(vrf.name)}
+        extraOptions={extraOptions?.filter((o) => !values.includes(o.value))}
+        includeNone={false}
+        placeholder={placeholder}
+        disabled={disabled}
+        className={className}
+      />
+      {values.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {values.map((val) => (
+            <Badge key={val} variant="secondary" className="font-mono gap-1 pr-1">
+              {val}
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => onChange(values.filter((v) => v !== val))}
+                className="ml-1 rounded-sm hover:bg-muted-foreground/20 p-0.5"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/vrf-select.tsx
+++ b/frontend/src/components/ui/vrf-select.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { vrfService, VrfInstance } from "@/lib/api/vrf";
+
+/**
+ * Radix Select cannot use an empty-string value, so the built-in "None" option
+ * is represented by this sentinel and mapped back to `""` for callers.
+ */
+const NONE_SENTINEL = "__none__";
+
+export interface VrfSelectProps {
+  /** Currently selected VRF name. An empty string means "None"/default. */
+  value: string;
+  /** Called with the newly selected VRF name (`""` when "None" is chosen). */
+  onValueChange: (value: string) => void;
+  /**
+   * Pre-fetched list of VRF instances to display. When provided, the component
+   * uses this list as-is and does NOT fetch. When omitted, it fetches the full
+   * VRF list itself.
+   */
+  vrfs?: VrfInstance[];
+  /** Optional predicate applied on top of the resolved list. */
+  filter?: (vrf: VrfInstance) => boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  id?: string;
+  /** Class applied to the trigger. */
+  className?: string;
+  /** Text for the disabled item shown when the list is empty. */
+  emptyText?: string;
+  /** Whether to render a "None" option at the top of the list. Defaults to true. */
+  includeNone?: boolean;
+  /** Label for the "None" option. Defaults to "None". */
+  noneLabel?: string;
+  /**
+   * Extra non-VRF options rendered above the VRF list (e.g. `default`). Values
+   * must be non-empty and are passed through to `onValueChange` unchanged.
+   */
+  extraOptions?: { label: string; value: string }[];
+}
+
+/**
+ * Shared VRF picker. Renders each VRF as its name followed by a muted
+ * description (nothing is shown when a VRF has no description). By default it
+ * fetches the full VRF list; pass `vrfs` to supply a pre-fetched list while
+ * keeping the same look.
+ */
+export function VrfSelect({
+  value,
+  onValueChange,
+  vrfs,
+  filter,
+  placeholder = "Select VRF",
+  disabled,
+  id,
+  className,
+  emptyText = "No VRFs available",
+  includeNone = true,
+  noneLabel = "None",
+  extraOptions,
+}: VrfSelectProps) {
+  const provided = vrfs !== undefined;
+  const [fetched, setFetched] = useState<VrfInstance[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (provided) return;
+    let active = true;
+    setLoading(true);
+    vrfService
+      .getConfig()
+      .then((res) => {
+        if (active) setFetched(res.instances);
+      })
+      .catch(() => {
+        if (active) setFetched([]);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [provided]);
+
+  let list = provided ? vrfs! : fetched;
+  if (filter) list = list.filter(filter);
+
+  // Radix shows the placeholder only for an empty-string value, and forbids
+  // "" as an item value. So map "" to the sentinel only when the "None" item
+  // actually exists; otherwise leave it "" so the placeholder renders.
+  const selected = value === "" && includeNone ? NONE_SENTINEL : value;
+
+  // Ensure a configured value that isn't in the resolved list (e.g. a VRF that
+  // was since removed) still displays instead of showing an empty trigger.
+  const knownValues = new Set([
+    ...(includeNone ? [NONE_SENTINEL] : []),
+    ...(extraOptions?.map((o) => o.value) ?? []),
+    ...list.map((v) => v.name),
+  ]);
+  const orphanValue = value !== "" && !knownValues.has(value) ? value : null;
+
+  return (
+    <Select
+      value={selected}
+      onValueChange={(v) => onValueChange(v === NONE_SENTINEL ? "" : v)}
+      disabled={disabled}
+    >
+      <SelectTrigger id={id} className={className}>
+        <SelectValue placeholder={loading ? "Loading VRFs..." : placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {includeNone && <SelectItem value={NONE_SENTINEL}>{noneLabel}</SelectItem>}
+        {extraOptions?.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+        {orphanValue && (
+          <SelectItem value={orphanValue}>
+            <span className="font-mono">{orphanValue}</span>
+          </SelectItem>
+        )}
+        {list.length === 0 && !includeNone && !extraOptions?.length ? (
+          <div className="px-2 py-1.5 text-sm text-muted-foreground">{emptyText}</div>
+        ) : (
+          list.map((vrf) => (
+            <SelectItem key={vrf.name} value={vrf.name}>
+              <span className="font-mono">{vrf.name}</span>
+              {vrf.description && (
+                <span className="text-muted-foreground ml-2 text-xs">{vrf.description}</span>
+              )}
+            </SelectItem>
+          ))
+        )}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/frontend/src/components/virtual-ethernet/CreateVirtualEthernetModal.tsx
+++ b/frontend/src/components/virtual-ethernet/CreateVirtualEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -268,11 +269,10 @@ export function CreateVirtualEthernetModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input
+                <VrfSelect
                   id="vrf"
                   value={vrf}
-                  onChange={(e) => setVrf(e.target.value)}
-                  placeholder="VRF instance name"
+                  onValueChange={setVrf}
                 />
               </div>
             </div>

--- a/frontend/src/components/virtual-ethernet/EditVirtualEthernetModal.tsx
+++ b/frontend/src/components/virtual-ethernet/EditVirtualEthernetModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -309,7 +310,7 @@ function VifForm({
         </div>
         <div className="space-y-1">
           <Label className="text-xs">VRF</Label>
-          <Input value={form.vrf} onChange={(e) => onChange({ vrf: e.target.value })} />
+          <VrfSelect value={form.vrf} onValueChange={(v) => onChange({ vrf: v })} />
         </div>
         <div className="space-y-1">
           <Label className="text-xs">Redirect</Label>
@@ -934,7 +935,7 @@ export function EditVirtualEthernetModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="e-vrf">VRF</Label>
-                <Input id="e-vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} />
+                <VrfSelect id="e-vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
 
@@ -1146,7 +1147,7 @@ export function EditVirtualEthernetModal({
                               <div className="space-y-1"><Label className="text-xs">Description</Label><Input value={newVifC.description} onChange={(e) => setNewVifC((p) => ({ ...p, description: e.target.value }))} /></div>
                               <div className="space-y-1"><Label className="text-xs">MTU</Label><Input type="number" value={newVifC.mtu} onChange={(e) => setNewVifC((p) => ({ ...p, mtu: e.target.value }))} /></div>
                               <div className="space-y-1"><Label className="text-xs">MAC</Label><Input value={newVifC.mac} onChange={(e) => setNewVifC((p) => ({ ...p, mac: e.target.value }))} placeholder="xx:xx:xx:xx:xx:xx" /></div>
-                              <div className="space-y-1"><Label className="text-xs">VRF</Label><Input value={newVifC.vrf} onChange={(e) => setNewVifC((p) => ({ ...p, vrf: e.target.value }))} /></div>
+                              <div className="space-y-1"><Label className="text-xs">VRF</Label><VrfSelect value={newVifC.vrf} onValueChange={(v) => setNewVifC((p) => ({ ...p, vrf: v }))} /></div>
                               <div className="space-y-1"><Label className="text-xs">Redirect</Label><Input value={newVifC.redirect} onChange={(e) => setNewVifC((p) => ({ ...p, redirect: e.target.value }))} /></div>
                             </div>
                             <div className="flex items-center gap-3">

--- a/frontend/src/components/vrf/FailoverRouteModal.tsx
+++ b/frontend/src/components/vrf/FailoverRouteModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -323,7 +324,7 @@ function TargetList({
         <div key={i} className="flex items-center gap-2">
           <Input className="h-7 font-mono" placeholder="Target address" value={t.address} disabled={disabled} onChange={(e) => update(i, { address: e.target.value })} />
           <Input className="h-7" placeholder="Interface" value={t.interface} disabled={disabled} onChange={(e) => update(i, { interface: e.target.value })} />
-          <Input className="h-7" placeholder="VRF" value={t.vrf} disabled={disabled} onChange={(e) => update(i, { vrf: e.target.value })} />
+          <VrfSelect className="h-7" placeholder="VRF" value={t.vrf} disabled={disabled} onValueChange={(v) => update(i, { vrf: v })} extraOptions={[{ label: "Default", value: "default" }]} />
           {!disabled && (
             <Button size="sm" variant="ghost" className="h-7 text-destructive" onClick={() => setTargets(targets.filter((_, idx) => idx !== i))}>
               <Trash2 className="h-3 w-3" />

--- a/frontend/src/components/vrf/VrfStaticRoutesTab.tsx
+++ b/frontend/src/components/vrf/VrfStaticRoutesTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -417,10 +418,11 @@ export function VrfStaticRoutesTab({
               {(newType === "next-hop" || newType === "interface") && (
                 <div className="space-y-2">
                   <Label>VRF (route leaking)</Label>
-                  <Input
-                    placeholder="Target VRF name"
+                  <VrfSelect
+                    placeholder="Target VRF"
                     value={newNhVrf}
-                    onChange={(e) => setNewNhVrf(e.target.value)}
+                    onValueChange={setNewNhVrf}
+                    extraOptions={[{ label: "Default", value: "default" }]}
                   />
                 </div>
               )}

--- a/frontend/src/components/vti/CreateVtiModal.tsx
+++ b/frontend/src/components/vti/CreateVtiModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -314,11 +315,10 @@ export function CreateVtiModal({
 
             <div className="space-y-2">
               <Label htmlFor="vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF name"
+                onValueChange={setVrf}
               />
             </div>
 

--- a/frontend/src/components/vti/EditVtiModal.tsx
+++ b/frontend/src/components/vti/EditVtiModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -319,11 +320,10 @@ export function EditVtiModal({
 
             <div className="space-y-2">
               <Label htmlFor="edit-vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="edit-vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF name"
+                onValueChange={setVrf}
               />
             </div>
 

--- a/frontend/src/components/vxlan/CreateVxlanModal.tsx
+++ b/frontend/src/components/vxlan/CreateVxlanModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -337,7 +338,7 @@ export function CreateVxlanModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="vrf">VRF</Label>
-                <Input id="vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="VRF name" />
+                <VrfSelect id="vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/vxlan/EditVxlanModal.tsx
+++ b/frontend/src/components/vxlan/EditVxlanModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -323,7 +324,7 @@ export function EditVxlanModal({
               </div>
               <div className="space-y-2">
                 <Label htmlFor="edit-vrf">VRF</Label>
-                <Input id="edit-vrf" value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="VRF name" />
+                <VrfSelect id="edit-vrf" value={vrf} onValueChange={setVrf} />
               </div>
             </div>
           </TabsContent>

--- a/frontend/src/components/wireless/CreateWirelessModal.tsx
+++ b/frontend/src/components/wireless/CreateWirelessModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -896,7 +897,7 @@ export function CreateWirelessModal({ open, onOpenChange, onSuccess, capabilitie
                 </div>
                 <div className="space-y-1.5">
                   <Label>VRF</Label>
-                  <Input value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="VRF name" className="font-mono" />
+                  <VrfSelect value={vrf} onValueChange={setVrf} className="font-mono" />
                 </div>
               </div>
             </TabsContent>

--- a/frontend/src/components/wireless/EditWirelessModal.tsx
+++ b/frontend/src/components/wireless/EditWirelessModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -921,7 +922,7 @@ export function EditWirelessModal({ open, onOpenChange, onSuccess, capabilities,
                 </div>
                 <div className="space-y-1.5">
                   <Label>VRF</Label>
-                  <Input value={vrf} onChange={(e) => setVrf(e.target.value)} placeholder="VRF name" className="font-mono" />
+                  <VrfSelect value={vrf} onValueChange={setVrf} className="font-mono" />
                 </div>
               </div>
             </TabsContent>

--- a/frontend/src/components/wwan/CreateWwanModal.tsx
+++ b/frontend/src/components/wwan/CreateWwanModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -408,11 +409,10 @@ export function CreateWwanModal({
 
             <div className="space-y-2">
               <Label htmlFor="vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF name"
+                onValueChange={setVrf}
               />
             </div>
           </TabsContent>

--- a/frontend/src/components/wwan/EditWwanModal.tsx
+++ b/frontend/src/components/wwan/EditWwanModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VrfSelect } from "@/components/ui/vrf-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -425,11 +426,10 @@ export function EditWwanModal({
 
             <div className="space-y-2">
               <Label htmlFor="edit-vrf">VRF</Label>
-              <Input
+              <VrfSelect
                 id="edit-vrf"
                 value={vrf}
-                onChange={(e) => setVrf(e.target.value)}
-                placeholder="Optional VRF name"
+                onValueChange={setVrf}
               />
             </div>
           </TabsContent>


### PR DESCRIPTION
Introduce reusable VrfSelect and VrfMultiSelect components (mirroring the shared InterfaceSelect) that render each VRF as its name plus a muted description, and migrate every modal/tab VRF setting from a free-text input to a dropdown.

- VrfSelect fetches the VRF list (or accepts a pre-filtered one), supports a built-in None option and extraOptions (e.g. Default).
- VrfMultiSelect adds dropdown-to-add plus removable chips; used for the SSH VRFs field.
- Add a Default option to service/routing VRF fields (NTP, SNMP, DNS-dynamic, monitoring, route-map/route-rule, static routes, failover, local-route, SSH) where VyOS treats 'default' as a real VRF; interface bindings keep None.