### PR TITLE
Add real-time BGP session status dashboard card (#114)

### DIFF
--- a/backend/bgp_status.py
+++ b/backend/bgp_status.py
@@ -1,0 +1,163 @@
+"""BGP live session status for the dashboard stream.
+
+Parses the structured ``ShowSummaryBgp`` GraphQL op (FRR ``show bgp summary json``)
+into per-address-family session state, and builds the GraphQL alias field the
+dashboard broadcaster folds into its shared query.
+
+This surfaces the *running* BGP sessions — their live ``Established`` / ``Active``
+/ ``Connect`` / ``Idle`` state, uptime and prefix counts — which never appear in
+the configuration and so are invisible to the config-driven BGP page.
+
+The op returns a JSON object keyed by address family, e.g.::
+
+    {
+      "ipv4_unicast": {
+        "router_id": "10.0.0.1", "as": 65001, "vrf_name": "default",
+        "peer_count": 1, "rib_count": 0,
+        "peers": {
+          "192_168_9_1": {
+            "remote_as": 65002, "state": "Established", "peer_uptime": "01:23:45",
+            "msg_rcvd": 10, "msg_sent": 12, "pfx_rcd": 3, "pfx_snt": 5,
+            "id_type": "ipv4"
+          }
+        }
+      }
+    }
+
+The VyOS GraphQL serializer replaces dots/colons in dict keys with underscores,
+so the neighbor address only survives in the peer key (``192_168_9_1``); it is
+reconstructed from that key using the peer's ``id_type``.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class BgpPeerStatus(BaseModel):
+    """A single live BGP neighbor as reported by ``show bgp summary``."""
+    neighbor: str
+    remote_as: Optional[int] = None
+    state: Optional[str] = None            # "Established" / "Active" / "Connect" / "Idle" / ...
+    established: bool = False
+    uptime: Optional[str] = None           # e.g. "01:23:45" or "never"
+    msg_rcvd: Optional[int] = None
+    msg_sent: Optional[int] = None
+    pfx_rcd: Optional[int] = None
+    pfx_snt: Optional[int] = None
+
+
+class BgpAddressFamilyStatus(BaseModel):
+    """Live state for one BGP address family (one summary section)."""
+    afi: str                               # raw key, e.g. "ipv4_unicast"
+    label: str                             # display label, e.g. "IPv4 Unicast"
+    router_id: Optional[str] = None
+    local_as: Optional[int] = None
+    vrf_name: Optional[str] = None
+    rib_count: Optional[int] = None
+    peers: List[BgpPeerStatus] = []
+
+
+def bgp_configured(full_config) -> bool:
+    """True when BGP is configured in the default VRF (gates the dashboard fetch)."""
+    protocols = (full_config or {}).get("protocols", {}) or {}
+    return bool(protocols.get("bgp"))
+
+
+def bgp_gql_fields(key_literal: str) -> List[str]:
+    """GraphQL alias field fetching ``show bgp summary`` via ``ShowSummaryBgp``.
+
+    ``key_literal`` must be a JSON-encoded API key (``json.dumps(key)``).
+    """
+    return [
+        f"Bgp: ShowSummaryBgp(data: {{key: {key_literal}}}) {{ success data {{ result }} }}"
+    ]
+
+
+def _int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _decode_peer_addr(key: str, id_type: Optional[str]) -> str:
+    """Reconstruct a neighbor address from its underscore-encoded summary key.
+
+    VyOS replaces ``.`` (IPv4) and ``:`` (IPv6) in JSON keys with ``_``; the
+    peer's ``id_type`` tells us which separator to restore. Interface / hostname
+    peers (no separators) round-trip unchanged.
+    """
+    if id_type == "ipv4":
+        return key.replace("_", ".")
+    if id_type == "ipv6":
+        return key.replace("_", ":")
+    return key
+
+
+# Pretty labels for the address-family key fragments.
+_AFI_WORDS = {
+    "ipv4": "IPv4",
+    "ipv6": "IPv6",
+    "l2vpn": "L2VPN",
+    "evpn": "EVPN",
+    "vpn": "VPN",
+    "unicast": "Unicast",
+    "multicast": "Multicast",
+    "labeled": "Labeled",
+    "flowspec": "Flowspec",
+}
+
+
+def _afi_label(afi: str) -> str:
+    return " ".join(_AFI_WORDS.get(part, part.title()) for part in afi.split("_"))
+
+
+def _parse_address_family(afi: str, section: dict) -> BgpAddressFamilyStatus:
+    peers: List[BgpPeerStatus] = []
+    for key, peer in (section.get("peers") or {}).items():
+        if not isinstance(peer, dict):
+            continue
+        state = peer.get("state")
+        peers.append(BgpPeerStatus(
+            neighbor=_decode_peer_addr(key, peer.get("id_type")),
+            remote_as=_int(peer.get("remote_as")),
+            state=state,
+            established=(isinstance(state, str) and state.lower() == "established"),
+            uptime=peer.get("peer_uptime"),
+            msg_rcvd=_int(peer.get("msg_rcvd")),
+            msg_sent=_int(peer.get("msg_sent")),
+            pfx_rcd=_int(peer.get("pfx_rcd")),
+            pfx_snt=_int(peer.get("pfx_snt")),
+        ))
+    # Stable ordering: established first, then by neighbor address.
+    peers.sort(key=lambda p: (not p.established, p.neighbor))
+    return BgpAddressFamilyStatus(
+        afi=afi,
+        label=_afi_label(afi),
+        router_id=section.get("router_id"),
+        local_as=_int(section.get("as")),
+        vrf_name=section.get("vrf_name"),
+        rib_count=_int(section.get("rib_count")),
+        peers=peers,
+    )
+
+
+def build_bgp_status(gql: dict) -> dict:
+    """Build the ``bgp-status`` SSE payload from the shared GraphQL result."""
+    node = (gql or {}).get("Bgp") or {}
+    result = (node.get("data") or {}).get("result") if node.get("success") else None
+
+    families: List[BgpAddressFamilyStatus] = []
+    if isinstance(result, dict):
+        for afi, section in result.items():
+            if isinstance(section, dict):
+                families.append(_parse_address_family(afi, section))
+
+    total_peers = sum(len(f.peers) for f in families)
+    established_peers = sum(1 for f in families for p in f.peers if p.established)
+    return {
+        "address_families": [f.dict() for f in families],
+        "total_peers": total_peers,
+        "established_peers": established_peers,
+    }

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -31,6 +31,7 @@ from routers.qos.qos import (
 )
 from openvpn_status import openvpn_configured, openvpn_gql_fields, build_openvpn_status
 from vrrp_status import vrrp_configured, vrrp_gql_fields, build_vrrp_status
+from bgp_status import bgp_configured, bgp_gql_fields, build_bgp_status
 import logging
 logger = logging.getLogger(__name__)
 
@@ -116,7 +117,7 @@ def _wg_alias(iface_name: str) -> str:
     return f"WGStatus_{safe}"
 
 
-def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False) -> dict:
+def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False, include_bgp: bool = False) -> dict:
     """
     Build the JSON body for the slow dashboard GraphQL query.
 
@@ -138,6 +139,8 @@ def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Opti
         fields += openvpn_gql_fields(k)
     if include_vrrp:
         fields += vrrp_gql_fields(k)
+    if include_bgp:
+        fields += bgp_gql_fields(k)
     if include_wireguard:
         fields.append(
             f'WireGuardConfig: ShowConfig(data: {{key: {k}, path: ["interfaces", "wireguard"]}}) {{ data {{ result }} }}'
@@ -156,7 +159,7 @@ def _build_gql_wg_status_payload(api_key: str, iface_names: List[str]) -> dict:
     return {"query": "{ " + " ".join(fields) + " }"}
 
 
-async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False) -> Optional[dict]:
+async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False, include_bgp: bool = False) -> Optional[dict]:
     """
     Fire a single GraphQL POST for the full dashboard data.
 
@@ -165,7 +168,7 @@ async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_target
     api_key = str(service.config.apikey)
     url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
     verify = service.config.verify
-    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_openvpn, include_vrrp)
+    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_openvpn, include_vrrp, include_bgp)
 
     try:
         async with httpx.AsyncClient(verify=verify, timeout=15.0) as client:
@@ -916,6 +919,8 @@ class DeviceDataBroadcaster:
         self._openvpn_configured: bool = False
         # Whether any VRRP group is configured (gates the show vrrp fetch).
         self._vrrp_configured: bool = False
+        # Whether BGP is configured (gates the show bgp summary fetch).
+        self._bgp_configured: bool = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -1056,6 +1061,7 @@ class DeviceDataBroadcaster:
             self._cached_cake_targets = find_cake_targets(cfg)
             self._openvpn_configured = openvpn_configured(cfg)
             self._vrrp_configured = vrrp_configured(cfg)
+            self._bgp_configured = bgp_configured(cfg)
         except Exception:
             logger.exception("Broadcaster: config-state refresh error")
 
@@ -1074,6 +1080,14 @@ class DeviceDataBroadcaster:
         except Exception:
             logger.exception("Broadcaster: vrrp-status parse error")
             self._push_to_all({"type": "error", "data": {"channel": "vrrp-status", "message": "Parse failed"}})
+
+    def _broadcast_bgp(self, gql: dict) -> None:
+        """Parse live BGP session state from the shared GraphQL result and push an event."""
+        try:
+            self._push_to_all({"type": "bgp-status", "data": build_bgp_status(gql)})
+        except Exception:
+            logger.exception("Broadcaster: bgp-status parse error")
+            self._push_to_all({"type": "error", "data": {"channel": "bgp-status", "message": "Parse failed"}})
 
     def _on_task_done(self, fut: asyncio.Future) -> None:
         """Clean up if _run() exits unexpectedly."""
@@ -1100,8 +1114,9 @@ class DeviceDataBroadcaster:
                     targets = self._cached_cake_targets
                     ovpn = self._openvpn_configured
                     vrrp = self._vrrp_configured
-                    # Full query: counters + system info + QoS + OpenVPN + VRRP + WireGuard
-                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_openvpn=ovpn, include_vrrp=vrrp)
+                    bgp = self._bgp_configured
+                    # Full query: counters + system info + QoS + OpenVPN + VRRP + BGP + WireGuard
+                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_openvpn=ovpn, include_vrrp=vrrp, include_bgp=bgp)
                     if gql is not None:
                         self._broadcast_interface_counters(gql)
                         self._broadcast_system_info(gql)
@@ -1111,6 +1126,8 @@ class DeviceDataBroadcaster:
                             self._broadcast_openvpn(gql)
                         if vrrp:
                             self._broadcast_vrrp(gql)
+                        if bgp:
+                            self._broadcast_bgp(gql)
                     else:
                         self._push_to_all({"type": "error", "data": {"channel": "all", "message": "GraphQL fetch failed"}})
                 else:
@@ -1168,6 +1185,7 @@ async def dashboard_stream(request: Request):
     service = get_session_vyos_service(request)
     include_wireguard = await has_permission(request, FeatureGroup.WIREGUARD, PermissionLevel.READ)
     include_vrrp = await has_permission(request, FeatureGroup.HIGH_AVAILABILITY, PermissionLevel.READ)
+    include_bgp = await has_permission(request, FeatureGroup.BGP, PermissionLevel.READ)
     broadcaster = _get_broadcaster(service)
 
     instance_id: str = service.config.instance_id
@@ -1193,6 +1211,8 @@ async def dashboard_stream(request: Request):
                 if event["type"] == "wireguard-peers" and not include_wireguard:
                     continue
                 if event["type"] == "vrrp-status" and not include_vrrp:
+                    continue
+                if event["type"] == "bgp-status" and not include_bgp:
                     continue
                 yield f'event: {event["type"]}\ndata: {json.dumps(event["data"])}\n\n'
         finally:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -17,6 +17,7 @@ import { NetworkSpeedCard } from "@/components/dashboard/NetworkSpeedCard";
 import { QoSStatsCard } from "@/components/dashboard/QoSStatsCard";
 import { OpenVpnCard } from "@/components/dashboard/OpenVpnCard";
 import { VrrpStatusCard } from "@/components/dashboard/VrrpStatusCard";
+import { BgpStatusCard } from "@/components/dashboard/BgpStatusCard";
 import { AddCardModal } from "@/components/dashboard/AddCardModal";
 import {
   DndContext,
@@ -367,6 +368,9 @@ export default function Home() {
     if (cardType === "vrrp-status") {
       defaultSpan = 2;
     }
+    if (cardType === "bgp-status") {
+      defaultSpan = 2;
+    }
     // system-info defaults to 1 column (already set above)
 
     // New cards always start at column 0
@@ -494,6 +498,8 @@ export default function Home() {
         return <OpenVpnCard {...baseProps} />;
       case "vrrp-status":
         return <VrrpStatusCard {...baseProps} />;
+      case "bgp-status":
+        return <BgpStatusCard {...baseProps} />;
       default:
         return null;
     }

--- a/frontend/src/components/dashboard/AddCardModal.tsx
+++ b/frontend/src/components/dashboard/AddCardModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Network, Plus, Server, Shield, Lock, TrendingUp, Gauge, ShieldCheck, Waypoints } from "lucide-react";
+import { Network, Plus, Server, Shield, Lock, TrendingUp, Gauge, ShieldCheck, Waypoints, Route } from "lucide-react";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 
@@ -69,6 +69,13 @@ const AVAILABLE_CARDS: AvailableCard[] = [
     description: "Real-time VRRP group state (MASTER/BACKUP/FAULT) with interface, VRID, priority and last transition",
     icon: Waypoints,
     requiredPermission: FeatureGroup.HIGH_AVAILABILITY,
+  },
+  {
+    type: "bgp-status",
+    name: "BGP Sessions",
+    description: "Live BGP neighbor state (Established/Active/Idle) per address family with remote AS, uptime and prefix counts",
+    icon: Route,
+    requiredPermission: FeatureGroup.BGP,
   },
 ];
 

--- a/frontend/src/components/dashboard/BgpStatusCard.tsx
+++ b/frontend/src/components/dashboard/BgpStatusCard.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { X, Route, RefreshCw, Settings, Clock, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { BgpStatusData, BgpAddressFamilyData, BgpPeerData } from "@/hooks/useDashboardSSE";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
+
+interface BgpStatusCardProps {
+  onRemove?: () => void;
+  span?: number;
+  onSpanChange?: (newSpan: number) => void;
+  config?: Record<string, unknown>;
+  onConfigChange?: (config: Record<string, unknown>) => void;
+}
+
+function StateBadge({ state, established }: { state: string | null; established: boolean }) {
+  const value = state ?? "—";
+  // Established = healthy; Idle = down; everything else (Active/Connect/OpenSent/
+  // OpenConfirm) is a transient mid-handshake state.
+  const style = established
+    ? "border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
+    : (state ?? "").toLowerCase() === "idle"
+    ? "border-red-500/30 text-red-600 dark:text-red-400"
+    : "border-amber-500/30 text-amber-600 dark:text-amber-400";
+  return (
+    <Badge
+      variant="outline"
+      className={`text-[10px] h-4 px-1 font-semibold tracking-wide ${style}`}
+    >
+      {value}
+    </Badge>
+  );
+}
+
+function PeerRow({ peer }: { peer: BgpPeerData }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 text-sm border-b last:border-0">
+      <span className="font-mono font-medium truncate shrink-0 max-w-[11rem]" title={peer.neighbor}>
+        {peer.neighbor}
+      </span>
+      <StateBadge state={peer.state} established={peer.established} />
+      {peer.remote_as != null && (
+        <span className="text-xs text-muted-foreground font-mono shrink-0" title="remote AS">
+          AS{peer.remote_as}
+        </span>
+      )}
+      <div className="flex-1" />
+      {peer.established && (
+        <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground shrink-0 tabular-nums" title="prefixes received / sent">
+          <span className="flex items-center gap-0.5">
+            <ArrowDownToLine className="h-3 w-3" />
+            {peer.pfx_rcd ?? 0}
+          </span>
+          <span className="flex items-center gap-0.5">
+            <ArrowUpFromLine className="h-3 w-3" />
+            {peer.pfx_snt ?? 0}
+          </span>
+        </span>
+      )}
+      {peer.uptime && (
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground shrink-0" title="uptime">
+          <Clock className="h-3 w-3" />
+          {peer.uptime}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FamilySection({ family }: { family: BgpAddressFamilyData }) {
+  return (
+    <div>
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-muted/40 border-b text-[11px] text-muted-foreground sticky top-0">
+        <span className="font-semibold tracking-wide uppercase">{family.label}</span>
+        {family.local_as != null && <span className="font-mono">local AS{family.local_as}</span>}
+        {family.router_id && <span className="font-mono opacity-70">id {family.router_id}</span>}
+        <div className="flex-1" />
+        <span className="tabular-nums">{family.peers.length} peer{family.peers.length === 1 ? "" : "s"}</span>
+      </div>
+      {family.peers.map((p) => (
+        <PeerRow key={`${family.afi}-${p.neighbor}`} peer={p} />
+      ))}
+    </div>
+  );
+}
+
+export function BgpStatusCard({ onRemove, span = 1, onSpanChange }: BgpStatusCardProps) {
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const { status: sseStatus, data: sseData } = useDashboardData();
+  // Snapshot the stream so "Paused" freezes the displayed status.
+  const [snapshot, setSnapshot] = useState<BgpStatusData | null>(null);
+  useEffect(() => {
+    if (autoRefresh && sseData.bgpStatus) setSnapshot(sseData.bgpStatus);
+  }, [autoRefresh, sseData.bgpStatus]);
+
+  const status = snapshot;
+  const loading = status === null;
+  const families = status?.address_families ?? [];
+
+  return (
+    <Card className="flex flex-col h-[520px]">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
+        <div className="flex items-center gap-2">
+          <Route className="h-5 w-5 text-primary" />
+          <CardTitle className="text-lg font-medium">BGP Sessions</CardTitle>
+          {status && status.total_peers > 0 && (
+            <Badge variant="outline" className="text-[10px] h-5 px-1.5 font-medium">
+              {status.established_peers}/{status.total_peers} up
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant={autoRefresh ? "default" : "outline"}
+            size="sm"
+            onClick={() => setAutoRefresh((v) => !v)}
+            title={autoRefresh ? `Live via dashboard stream (${sseStatus})` : "Paused"}
+          >
+            <RefreshCw className={`h-4 w-4 mr-1 ${autoRefresh && sseStatus === "connected" ? "animate-spin" : ""}`} />
+            {autoRefresh ? "Live" : "Paused"}
+          </Button>
+          {onSpanChange && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <Settings className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {([1, 2, 3] as const).map((n) => (
+                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
+                    <div className="flex items-center justify-between w-full">
+                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
+                      {span === n && <span className="ml-2 text-primary">✓</span>}
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          {onRemove && (
+            <Button variant="ghost" size="sm" onClick={onRemove}>
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col flex-1 min-h-0 p-0">
+        {loading ? (
+          <div className="px-4 py-6 text-center text-muted-foreground text-sm">Loading…</div>
+        ) : families.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            No BGP neighbors.
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {families.map((f) => (
+              <FamilySection key={f.afi} family={f} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useDashboardSSE.ts
+++ b/frontend/src/hooks/useDashboardSSE.ts
@@ -103,6 +103,34 @@ export interface VrrpStatusData {
   total: number;
 }
 
+export interface BgpPeerData {
+  neighbor: string;
+  remote_as: number | null;
+  state: string | null;          // "Established" | "Active" | "Connect" | "Idle" | ...
+  established: boolean;
+  uptime: string | null;
+  msg_rcvd: number | null;
+  msg_sent: number | null;
+  pfx_rcd: number | null;
+  pfx_snt: number | null;
+}
+
+export interface BgpAddressFamilyData {
+  afi: string;                   // raw key, e.g. "ipv4_unicast"
+  label: string;                 // display label, e.g. "IPv4 Unicast"
+  router_id: string | null;
+  local_as: number | null;
+  vrf_name: string | null;
+  rib_count: number | null;
+  peers: BgpPeerData[];
+}
+
+export interface BgpStatusData {
+  address_families: BgpAddressFamilyData[];
+  total_peers: number;
+  established_peers: number;
+}
+
 export interface DashboardSSEData {
   interfaceCounters: InterfaceCountersData | null;
   systemInfo: SystemInfoData | null;
@@ -110,6 +138,7 @@ export interface DashboardSSEData {
   qosStats: QoSStatsResponse | null;
   openvpnStatus: OpenVpnStatus | null;
   vrrpStatus: VrrpStatusData | null;
+  bgpStatus: BgpStatusData | null;
 }
 
 export interface DashboardSSEState {
@@ -124,7 +153,7 @@ export interface DashboardSSEState {
 
 export function useDashboardSSE(): DashboardSSEState {
   const [status, setStatus] = useState<SSEStatus>("disconnected");
-  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null, vrrpStatus: null });
+  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null, vrrpStatus: null, bgpStatus: null });
   const [error, setError] = useState<string | null>(null);
   const esRef = useRef<EventSource | null>(null);
 
@@ -188,6 +217,15 @@ export function useDashboardSSE(): DashboardSSEState {
       try {
         const payload = JSON.parse(event.data) as VrrpStatusData;
         setData((prev) => ({ ...prev, vrrpStatus: payload }));
+      } catch {
+        // Ignore malformed payloads
+      }
+    });
+
+    es.addEventListener("bgp-status", (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as BgpStatusData;
+        setData((prev) => ({ ...prev, bgpStatus: payload }));
       } catch {
         // Ignore malformed payloads
       }


### PR DESCRIPTION
Surfaces live BGP neighbor state on the dashboard via the shared SSE stream, mirroring the VRRP/HA status card.

Backend:
- bgp_status.py parses the structured ShowSummaryBgp GraphQL op (FRR "show bgp summary json") into per-address-family session state, decoding neighbor addresses from the underscore-encoded peer keys via id_type.
- Wire BGP into the dashboard SSE broadcaster in show.py: config-gated fetch on the slow cycle, bgp-status event, and FeatureGroup.BGP permission gate.

Frontend:
- BgpStatusCard shows per-AF neighbor rows with state badge (Established=green, mid-handshake=amber, Idle=red), remote AS, uptime and prefix counts, plus an established/total summary badge.
- Register the card (SSE hook types + event, page.tsx render, AddCardModal).

Closes #114 