### PR TITLE
Add user-defined coloured separators for firewall rules

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -26,6 +26,7 @@ from routers.firewall import ipv6 as firewall_ipv6
 from routers.firewall import bridge as firewall_bridge
 from routers.firewall import flowtables as firewall_flowtables
 from routers.firewall import zones as firewall_zones
+from routers.firewall import separators as firewall_separators
 from routers.nat import nat
 from routers.nat64 import nat64
 from routers.nat66 import nat66
@@ -342,6 +343,7 @@ app.include_router(firewall_ipv6.router)
 app.include_router(firewall_bridge.router)
 app.include_router(firewall_flowtables.router)
 app.include_router(firewall_zones.router)
+app.include_router(firewall_separators.router)
 app.include_router(nat.router)
 app.include_router(nat64.router)
 app.include_router(nat66.router)

--- a/backend/routers/firewall/separators.py
+++ b/backend/routers/firewall/separators.py
@@ -1,0 +1,226 @@
+"""
+Firewall Separators Router
+
+User-defined coloured separator bars rendered between firewall rules. These are
+pure UI metadata stored in the VyManager database (NOT in the VyOS config), in
+the same spirit as dashboard layouts. The VyOS config stays the source of truth
+for the rules themselves; separators only describe how to visually group them.
+
+Separators are shared per instance (everyone viewing a router sees the same
+bars) and gated by the FIREWALL_POLICIES permission, matching the firewall
+rules page.
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+from typing import List, Optional
+import asyncpg
+import uuid
+
+from fastapi_permissions import (
+    require_permission,
+    has_permission,
+    PermissionLevel,
+)
+from rbac_permissions import FeatureGroup
+import logging
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/vyos/firewall/separators", tags=["firewall_separators"])
+
+# Families a separator may belong to. Mirrors the firewall rule families.
+VALID_FAMILIES = {"ipv4", "ipv6", "bridge"}
+
+
+async def _require_separator_permission(request: Request, level: PermissionLevel) -> None:
+    """Separators live on firewall chains that are surfaced by both the policies
+    page and the zones page, so accept either firewall permission. Passing the
+    soft check on POLICIES short-circuits; otherwise fall through to ZONES,
+    which raises a clean 403 if that is also missing."""
+    if await has_permission(request, FeatureGroup.FIREWALL_POLICIES, level):
+        return
+    await require_permission(request, FeatureGroup.FIREWALL_ZONES, level)
+
+
+# ========================================================================
+# Pydantic Models
+# ========================================================================
+
+
+class FirewallSeparator(BaseModel):
+    """A single separator bar."""
+
+    id: str
+    family: str
+    chain: str
+    position: int
+    label: str
+    color: str
+
+
+class SeparatorUpsert(BaseModel):
+    """An incoming create/update. When `id` is omitted (or unknown) a new row
+    is created; when it matches an existing row for this instance it updates."""
+
+    id: Optional[str] = None
+    family: str = Field(..., description="ipv4 | ipv6 | bridge")
+    chain: str = Field(..., min_length=1)
+    position: int = Field(..., ge=0)
+    label: str = Field(..., min_length=1, max_length=200)
+    color: str = Field(..., min_length=1, max_length=32)
+
+
+class SeparatorBatchRequest(BaseModel):
+    """Atomic batch of separator changes for the current instance."""
+
+    upserts: List[SeparatorUpsert] = []
+    deletes: List[str] = []
+
+
+class SeparatorListResponse(BaseModel):
+    separators: List[FirewallSeparator]
+
+
+# ========================================================================
+# Helpers
+# ========================================================================
+
+
+def _require_instance(request: Request) -> str:
+    instance = getattr(request.state, "instance", None)
+    if not instance:
+        raise HTTPException(status_code=404, detail="No active instance")
+    return instance["id"]
+
+
+async def _fetch_separators(
+    conn: asyncpg.Connection, instance_id: str
+) -> List[FirewallSeparator]:
+    rows = await conn.fetch(
+        """
+        SELECT id, family, chain, position, label, color
+        FROM firewall_separators
+        WHERE "instanceId" = $1
+        ORDER BY family, chain, position
+        """,
+        instance_id,
+    )
+    return [
+        FirewallSeparator(
+            id=r["id"],
+            family=r["family"],
+            chain=r["chain"],
+            position=r["position"],
+            label=r["label"],
+            color=r["color"],
+        )
+        for r in rows
+    ]
+
+
+# ========================================================================
+# Endpoint: List separators
+# ========================================================================
+
+
+@router.get("", response_model=SeparatorListResponse)
+async def list_separators(request: Request):
+    """List all separators for the current instance."""
+    await _require_separator_permission(request, PermissionLevel.READ)
+    try:
+        instance_id = _require_instance(request)
+        db_pool: asyncpg.Pool = request.app.state.db_pool
+        async with db_pool.acquire() as conn:
+            separators = await _fetch_separators(conn, instance_id)
+        return SeparatorListResponse(separators=separators)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Failed to list firewall separators")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ========================================================================
+# Endpoint: Batch upsert / delete
+# ========================================================================
+
+
+@router.post("/batch", response_model=SeparatorListResponse)
+async def batch_separators(request: Request, body: SeparatorBatchRequest):
+    """Apply a batch of separator upserts and deletes for the current instance,
+    atomically. Returns the full separator list for the instance afterwards."""
+    await _require_separator_permission(request, PermissionLevel.WRITE)
+    try:
+        instance_id = _require_instance(request)
+
+        for up in body.upserts:
+            if up.family not in VALID_FAMILIES:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid family: {up.family}"
+                )
+
+        db_pool: asyncpg.Pool = request.app.state.db_pool
+        async with db_pool.acquire() as conn:
+            async with conn.transaction():
+                # Deletes are scoped to this instance so a caller can never
+                # remove another instance's separators by guessing an id.
+                if body.deletes:
+                    await conn.execute(
+                        """
+                        DELETE FROM firewall_separators
+                        WHERE "instanceId" = $1 AND id = ANY($2::text[])
+                        """,
+                        instance_id,
+                        body.deletes,
+                    )
+
+                for up in body.upserts:
+                    if up.id:
+                        # Update only if the row already belongs to this
+                        # instance; otherwise fall through to an insert with a
+                        # fresh server id (never reuse a client-supplied id, which
+                        # could collide with another instance's primary key).
+                        updated = await conn.fetchval(
+                            """
+                            UPDATE firewall_separators
+                            SET family = $3, chain = $4, position = $5,
+                                label = $6, color = $7, "updatedAt" = NOW()
+                            WHERE id = $1 AND "instanceId" = $2
+                            RETURNING id
+                            """,
+                            up.id,
+                            instance_id,
+                            up.family,
+                            up.chain,
+                            up.position,
+                            up.label,
+                            up.color,
+                        )
+                        if updated:
+                            continue
+
+                    await conn.execute(
+                        """
+                        INSERT INTO firewall_separators
+                            (id, "instanceId", family, chain, position, label,
+                             color, "createdAt", "updatedAt")
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
+                        """,
+                        str(uuid.uuid4()),
+                        instance_id,
+                        up.family,
+                        up.chain,
+                        up.position,
+                        up.label,
+                        up.color,
+                    )
+
+                separators = await _fetch_separators(conn, instance_id)
+
+        return SeparatorListResponse(separators=separators)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Failed to apply firewall separator batch")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -1289,6 +1289,7 @@ BACKUP_TABLES: List[str] = [
     "users",
     "sites",
     "instances",
+    "firewall_separators",
     "accounts",
     "oauth_providers",
     "user_instance_roles",

--- a/frontend/prisma/migrations/20260618_add_firewall_separators/migration.sql
+++ b/frontend/prisma/migrations/20260618_add_firewall_separators/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "firewall_separators" (
+    "id" TEXT NOT NULL,
+    "instanceId" TEXT NOT NULL,
+    "family" TEXT NOT NULL,
+    "chain" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "label" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "firewall_separators_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "firewall_separators_instanceId_idx" ON "firewall_separators"("instanceId");
+
+-- CreateIndex
+CREATE INDEX "firewall_separators_instanceId_family_chain_idx" ON "firewall_separators"("instanceId", "family", "chain");

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -332,6 +332,26 @@ model DashboardLayout {
   @@map("dashboard_layouts")
 }
 
+// FirewallSeparator - User-defined coloured separator bars rendered between
+// firewall rules. Pure UI metadata layered on top of the VyOS config (the
+// config stays authoritative). Shared per instance, like a section label.
+// A bar renders above the first rule whose number >= `position`.
+model FirewallSeparator {
+  id         String   @id @default(cuid())
+  instanceId String // VyOS instance this separator belongs to
+  family     String // "ipv4" | "ipv6" | "bridge"
+  chain      String // ruleset / chain name (forward, input, output, custom)
+  position   Int // bar renders above the first rule with rule_number >= position
+  label      String
+  color      String // colour token or hex (e.g. "#ef4444")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([instanceId])
+  @@index([instanceId, family, chain])
+  @@map("firewall_separators")
+}
+
 // ============================================================================
 // New RBAC System - Fine-Grained Per-Instance Permissions
 // ============================================================================

--- a/frontend/src/app/firewall/policies/page.tsx
+++ b/frontend/src/app/firewall/policies/page.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { DndContext, type DragStartEvent, type DragEndEvent, closestCenter, DragOverlay, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import {
@@ -68,6 +68,16 @@ import { DeleteCustomChainModal } from "@/components/firewall/DeleteCustomChainM
 import { FirewallRuleRow } from "@/components/firewall/FirewallRuleRow";
 import { FirewallReorderBanner } from "@/components/firewall/FirewallReorderBanner";
 import { ColumnToggleButton } from "@/components/firewall/ColumnToggleButton";
+import { SeparatorBar, separatorDragId } from "@/components/firewall/SeparatorBar";
+import { SeparatorInsertZone } from "@/components/firewall/SeparatorInsertZone";
+import { SeparatorModal } from "@/components/firewall/SeparatorModal";
+import {
+  firewallSeparatorsService,
+  type FirewallSeparator,
+  type SeparatorFamily,
+} from "@/lib/api/firewall-separators";
+import { usePermissions } from "@/hooks/usePermissions";
+import { FeatureGroup } from "@/lib/api/user-management";
 import { useColumnVisibility, type ColumnDef } from "@/hooks/useColumnVisibility";
 
 type ChainType = "forward" | "input" | "output" | "prerouting_raw";
@@ -156,6 +166,17 @@ function FirewallPoliciesPageInner() {
   const { visibleColumns, toggleColumn, visibleColumnCount, orderedColumns, visibleOrderedColumns, reorderColumns, resetToDefault } =
     useColumnVisibility("firewall-policies-columns", POLICIES_COLUMNS);
 
+  // Permissions — separator editing follows the firewall rules permission.
+  const { canWrite } = usePermissions();
+  const canEditSeparators = canWrite(FeatureGroup.FIREWALL_POLICIES);
+
+  // Coloured separators (UI-only metadata, shared per instance)
+  const [separators, setSeparators] = useState<FirewallSeparator[]>([]);
+  const [separatorModalOpen, setSeparatorModalOpen] = useState(false);
+  const [editingSeparator, setEditingSeparator] = useState<FirewallSeparator | null>(null);
+  const [separatorAnchor, setSeparatorAnchor] = useState<number | null>(null);
+  const [activeSeparatorId, setActiveSeparatorId] = useState<string | null>(null);
+
   // Drag and drop sensors - require 8px movement before drag starts
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -238,6 +259,34 @@ function FirewallPoliciesPageInner() {
     }
   };
 
+  const loadSeparators = async () => {
+    try {
+      setSeparators(await firewallSeparatorsService.list());
+    } catch (err) {
+      console.error("Error fetching firewall separators:", err);
+    }
+  };
+
+  const handleDeleteSeparator = async (id: string) => {
+    try {
+      setSeparators(await firewallSeparatorsService.delete(id));
+    } catch (err) {
+      console.error("Error deleting firewall separator:", err);
+    }
+  };
+
+  const openCreateSeparator = (anchorRuleNumber: number | null) => {
+    setEditingSeparator(null);
+    setSeparatorAnchor(anchorRuleNumber);
+    setSeparatorModalOpen(true);
+  };
+
+  const openEditSeparator = (separator: FirewallSeparator) => {
+    setEditingSeparator(separator);
+    setSeparatorAnchor(null);
+    setSeparatorModalOpen(true);
+  };
+
   // Handler for changing default action on base chains
   const handleDefaultActionChange = async (
     chain: string,
@@ -308,6 +357,8 @@ function FirewallPoliciesPageInner() {
     fetchCapabilitiesIPv6();
     // Load groups (shared between IPv4 and IPv6)
     fetchGroups();
+    // Load coloured separators (UI metadata from VyManager's DB)
+    loadSeparators();
   }, []);
 
   useEffect(() => {
@@ -393,6 +444,94 @@ function FirewallPoliciesPageInner() {
     }
   };
 
+  // ===== Coloured separators: current chain context + ordering helpers =====
+  // Family on this page is the selected protocol (ipv4 / ipv6); the bridge
+  // family lives on its own page.
+  const currentFamily: SeparatorFamily = selectedProtocol;
+  const currentChain = selectedProtocol === "ipv4" ? (selectedChain as string) : (selectedChainIPv6 as string);
+  const currentSeparators = separators
+    .filter((s) => s.family === currentFamily && s.chain === currentChain)
+    .sort((a, b) => a.position - b.position);
+  // Hide separators while searching: their anchors reference the full rule list.
+  const showSeparators = !searchQuery;
+
+  type SortableDescriptor =
+    | { kind: "sep"; sep: FirewallSeparator }
+    | { kind: "rule"; rule: FirewallRule };
+
+  // Interleave separators (by position) with the given rules, in display order.
+  // A bar sits above the first rule whose number >= its position; bars past the
+  // last rule trail the list.
+  const buildOrderedSortables = (
+    rulesList: FirewallRule[],
+    includeSeparators: boolean
+  ): SortableDescriptor[] => {
+    const seps = includeSeparators ? currentSeparators : [];
+    const out: SortableDescriptor[] = [];
+    let si = 0;
+    const pushUpTo = (upTo: number) => {
+      while (si < seps.length && seps[si].position <= upTo) {
+        out.push({ kind: "sep", sep: seps[si] });
+        si++;
+      }
+    };
+    for (const rule of rulesList) {
+      pushUpTo(rule.rule_number);
+      out.push({ kind: "rule", rule });
+    }
+    pushUpTo(Number.POSITIVE_INFINITY);
+    return out;
+  };
+
+  const dragIdFor = (d: SortableDescriptor): string | number =>
+    d.kind === "sep" ? separatorDragId(d.sep.id) : d.rule.rule_number;
+
+  // Persist a separator's new position (optimistic; reverts on failure).
+  const moveSeparator = async (sepId: string, position: number) => {
+    const sep = separators.find((s) => s.id === sepId);
+    if (!sep || sep.position === position) return;
+    setSeparators((prev) => prev.map((s) => (s.id === sepId ? { ...s, position } : s)));
+    try {
+      setSeparators(
+        await firewallSeparatorsService.save({
+          id: sep.id,
+          family: sep.family,
+          chain: sep.chain,
+          position,
+          label: sep.label,
+          color: sep.color,
+        })
+      );
+    } catch (err) {
+      console.error("Error moving separator:", err);
+      setSeparators((prev) =>
+        prev.map((s) => (s.id === sepId ? { ...s, position: sep.position } : s))
+      );
+    }
+  };
+
+  // Derive and persist a dragged separator's new position from where it landed.
+  const handleSeparatorDragEnd = (activeDragId: string, overId: string | number) => {
+    const ids = buildOrderedSortables(currentRules, true).map(dragIdFor);
+    const oldIndex = ids.indexOf(activeDragId);
+    const newIndex = ids.indexOf(overId);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const newIds = arrayMove(ids, oldIndex, newIndex);
+    const at = newIds.indexOf(activeDragId);
+    let position: number | null = null;
+    for (let j = at + 1; j < newIds.length; j++) {
+      if (typeof newIds[j] === "number") {
+        position = newIds[j] as number;
+        break;
+      }
+    }
+    if (position == null) {
+      const nums = currentRules.map((r) => r.rule_number);
+      position = (nums.length ? Math.max(...nums) : 0) + 1;
+    }
+    void moveSeparator(activeDragId.slice("sep:".length), position);
+  };
+
   // Initialize reordered rules when current rules change or chain changes
   useEffect(() => {
     if (selectedProtocol === "ipv4") {
@@ -443,8 +582,16 @@ function FirewallPoliciesPageInner() {
     ? (hasChanges ? reorderedRules : getCurrentRules())
     : (hasChangesIPv6 ? reorderedRulesIPv6 : getCurrentRules());
 
-  // Drag and drop handlers (IPv4)
+  // Drag and drop handlers (IPv4). Separators (string ids) and rules (numeric
+  // ids) share one DndContext; we branch on the active id type.
+  const isSeparatorDragId = (id: string | number): id is string =>
+    typeof id === "string" && id.startsWith("sep:");
+
   const handleDragStart = (event: DragStartEvent) => {
+    if (isSeparatorDragId(event.active.id)) {
+      setActiveSeparatorId(event.active.id);
+      return;
+    }
     if (selectedProtocol === "ipv4") {
       setActiveId(event.active.id as number);
     } else {
@@ -455,34 +602,49 @@ function FirewallPoliciesPageInner() {
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
-    if (selectedProtocol === "ipv4") {
-      setActiveId(null);
-    } else {
-      setActiveIdIPv6(null);
-    }
+    setActiveId(null);
+    setActiveIdIPv6(null);
+    setActiveSeparatorId(null);
 
     if (!over || active.id === over.id) {
       return;
     }
 
+    // Dragging a separator → reposition it (DB only, no VyOS write).
+    if (isSeparatorDragId(active.id)) {
+      handleSeparatorDragEnd(active.id, over.id);
+      return;
+    }
+
+    // Dragging a rule → reorder. Move within the combined (rules + separators)
+    // list, then derive the new RULE order. Dropping a rule next to a separator
+    // without crossing another rule leaves the rule order unchanged, so we only
+    // enter reorder mode when the rule sequence actually differs.
+    const ids = buildOrderedSortables(currentRules, true).map(dragIdFor);
+    const oldIndex = ids.indexOf(active.id);
+    const newIndex = ids.indexOf(over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+
+    const newRuleNumbers = arrayMove(ids, oldIndex, newIndex).filter(
+      (id): id is number => typeof id === "number"
+    );
+    const currentRuleNumbers = currentRules.map((r) => r.rule_number);
+    const unchanged =
+      newRuleNumbers.length === currentRuleNumbers.length &&
+      newRuleNumbers.every((n, i) => n === currentRuleNumbers[i]);
+    if (unchanged) return;
+
+    const ruleByNumber = new Map(currentRules.map((r) => [r.rule_number, r]));
+    const newRules = newRuleNumbers
+      .map((n) => ruleByNumber.get(n))
+      .filter((r): r is FirewallRule => r !== undefined);
+
     if (selectedProtocol === "ipv4") {
-      setReorderedRules((rules) => {
-        const oldIndex = rules.findIndex((r) => r.rule_number === active.id);
-        const newIndex = rules.findIndex((r) => r.rule_number === over.id);
-
-        const newRules = arrayMove(rules, oldIndex, newIndex);
-        setHasChanges(true);
-        return newRules;
-      });
+      setReorderedRules(newRules);
+      setHasChanges(true);
     } else {
-      setReorderedRulesIPv6((rules) => {
-        const oldIndex = rules.findIndex((r) => r.rule_number === active.id);
-        const newIndex = rules.findIndex((r) => r.rule_number === over.id);
-
-        const newRules = arrayMove(rules, oldIndex, newIndex);
-        setHasChangesIPv6(true);
-        return newRules;
-      });
+      setReorderedRulesIPv6(newRules);
+      setHasChangesIPv6(true);
     }
   };
 
@@ -674,6 +836,67 @@ function FirewallPoliciesPageInner() {
       rule.destination?.address?.toLowerCase().includes(query)
     );
   });
+
+  // Display order of draggable rows (separators interleaved with rules). Used
+  // both for SortableContext items and for rendering.
+  const orderedSortables = buildOrderedSortables(filteredRules, showSeparators);
+  const sortableIds = orderedSortables.map(dragIdFor);
+
+  // Render the interleaved separator bars, insert zones, and rule rows.
+  const renderRows = () => {
+    const out: ReactNode[] = [];
+    const colSpan = 4 + visibleColumnCount;
+    let lastRuleNumber: number | null = null;
+    for (const item of orderedSortables) {
+      if (item.kind === "sep") {
+        out.push(
+          <SeparatorBar
+            key={`sep-${item.sep.id}`}
+            separator={item.sep}
+            colSpan={colSpan}
+            canWrite={canEditSeparators}
+            onEdit={() => openEditSeparator(item.sep)}
+            onDelete={() => handleDeleteSeparator(item.sep.id)}
+          />
+        );
+        continue;
+      }
+      // Gap above this rule — click to drop a separator right here.
+      if (canEditSeparators && showSeparators) {
+        out.push(
+          <SeparatorInsertZone
+            key={`insert-${item.rule.rule_number}`}
+            colSpan={colSpan}
+            onInsert={() => openCreateSeparator(item.rule.rule_number)}
+          />
+        );
+      }
+      out.push(
+        <FirewallRuleRow
+          key={item.rule.rule_number}
+          rule={item.rule}
+          onEdit={() => setEditingRule(item.rule)}
+          onClone={() => { setCloningRule(item.rule); setCreateModalOpen(true); }}
+          onDelete={() => setDeletingRule(item.rule)}
+          isDragging={(selectedProtocol === "ipv4" ? activeId : activeIdIPv6) === item.rule.rule_number}
+          groups={groups}
+          visibleOrderedColumns={visibleOrderedColumns}
+        />
+      );
+      lastRuleNumber = item.rule.rule_number;
+    }
+    // Final gap below the last rule.
+    if (canEditSeparators && showSeparators && lastRuleNumber !== null) {
+      out.push(
+        <SeparatorInsertZone
+          key="insert-bottom"
+          colSpan={colSpan}
+          onInsert={() => openCreateSeparator(lastRuleNumber! + 1)}
+        />
+      );
+    }
+    return out;
+  };
 
   const handleChainSelect = (chain: string, custom: boolean = false) => {
     if (selectedProtocol === "ipv4") {
@@ -1025,6 +1248,12 @@ function FirewallPoliciesPageInner() {
                   onReorder={reorderColumns}
                   onReset={resetToDefault}
                 />
+                {canEditSeparators && (
+                  <Button variant="outline" onClick={() => openCreateSeparator(null)}>
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add Separator
+                  </Button>
+                )}
                 <Button onClick={() => setCreateModalOpen(true)}>
                   <Plus className="h-4 w-4 mr-2" />
                   Add Rule
@@ -1204,7 +1433,7 @@ function FirewallPoliciesPageInner() {
                       </TableHeader>
                       <TableBody>
                         <SortableContext
-                          items={filteredRules.map((r) => r.rule_number)}
+                          items={sortableIds}
                           strategy={verticalListSortingStrategy}
                         >
                           {filteredRules.length === 0 ? (
@@ -1224,18 +1453,7 @@ function FirewallPoliciesPageInner() {
                               </TableCell>
                             </TableRow>
                           ) : (
-                            filteredRules.map((rule) => (
-                              <FirewallRuleRow
-                                key={rule.rule_number}
-                                rule={rule}
-                                onEdit={() => setEditingRule(rule)}
-                                onClone={() => { setCloningRule(rule); setCreateModalOpen(true); }}
-                                onDelete={() => setDeletingRule(rule)}
-                                isDragging={(selectedProtocol === "ipv4" ? activeId : activeIdIPv6) === rule.rule_number}
-                                groups={groups}
-                                visibleOrderedColumns={visibleOrderedColumns}
-                              />
-                            ))
+                            renderRows()
                           )}
                         </SortableContext>
                       </TableBody>
@@ -1246,7 +1464,28 @@ function FirewallPoliciesPageInner() {
                         easing: "cubic-bezier(0.18, 0.67, 0.6, 1.22)",
                       }}
                     >
-                      {(selectedProtocol === "ipv4" ? activeId : activeIdIPv6) !== null ? (
+                      {activeSeparatorId ? (() => {
+                        const sep = separators.find(
+                          (s) => separatorDragId(s.id) === activeSeparatorId
+                        );
+                        if (!sep) return null;
+                        return (
+                          <div
+                            className="rounded-md px-3 py-1.5 shadow-2xl"
+                            style={{
+                              backgroundColor: `${sep.color}1a`,
+                              borderLeft: `3px solid ${sep.color}`,
+                            }}
+                          >
+                            <span
+                              className="text-xs font-semibold uppercase tracking-wide"
+                              style={{ color: sep.color }}
+                            >
+                              {sep.label}
+                            </span>
+                          </div>
+                        );
+                      })() : (selectedProtocol === "ipv4" ? activeId : activeIdIPv6) !== null ? (
                         <div className="bg-card border-2 border-primary shadow-2xl rounded-lg overflow-hidden">
                           <Table>
                             <TableBody>
@@ -1362,6 +1601,16 @@ function FirewallPoliciesPageInner() {
         }}
         chain={deletingChain}
         protocol={selectedProtocol}
+      />
+
+      <SeparatorModal
+        open={separatorModalOpen}
+        onOpenChange={setSeparatorModalOpen}
+        family={currentFamily}
+        chain={currentChain}
+        editing={editingSeparator}
+        defaultPosition={separatorAnchor}
+        onSaved={setSeparators}
       />
     </AppLayout>
   );

--- a/frontend/src/app/firewall/zones/page.tsx
+++ b/frontend/src/app/firewall/zones/page.tsx
@@ -26,10 +26,11 @@ import {
   Plus,
   GripVertical,
   ArrowUpDown,
+  ArrowRight,
   Globe,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useState, useEffect, useCallback, type CSSProperties } from "react";
+import { useState, useEffect, useCallback, type CSSProperties, type ReactNode } from "react";
 import { firewallZonesService, resolveChainName } from "@/lib/api/firewall-zones";
 import { firewallGroupsService, type FirewallGroup } from "@/lib/api/firewall-groups";
 import { firewallIPv4Service } from "@/lib/api/firewall-ipv4";
@@ -39,6 +40,15 @@ import type { FirewallConfigResponse, FirewallRule, FirewallCapabilitiesResponse
 import { CreateZoneModal } from "@/components/firewall/zones/CreateZoneModal";
 import { EditZoneModal } from "@/components/firewall/zones/EditZoneModal";
 import { ZoneRulePanel } from "@/components/firewall/zones/ZoneRulePanel";
+import { SeparatorBar, separatorDragId } from "@/components/firewall/SeparatorBar";
+import { SeparatorDivider } from "@/components/firewall/SeparatorDivider";
+import { SeparatorInsertZone } from "@/components/firewall/SeparatorInsertZone";
+import { SeparatorModal } from "@/components/firewall/SeparatorModal";
+import {
+  firewallSeparatorsService,
+  type FirewallSeparator,
+  type SeparatorFamily,
+} from "@/lib/api/firewall-separators";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 import { cn } from "@/lib/utils";
@@ -418,6 +428,14 @@ export default function FirewallZonesPage() {
   const [savingReorder, setSavingReorder] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
 
+  // Coloured separators (UI-only metadata, shared per instance). On this page a
+  // separator's chain is the custom chain backing a zone-pair.
+  const [separators, setSeparators] = useState<FirewallSeparator[]>([]);
+  const [separatorModalOpen, setSeparatorModalOpen] = useState(false);
+  const [editingSeparator, setEditingSeparator] = useState<FirewallSeparator | null>(null);
+  const [separatorAnchor, setSeparatorAnchor] = useState<number | null>(null);
+  const [activeSeparatorId, setActiveSeparatorId] = useState<string | null>(null);
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
   );
@@ -428,19 +446,21 @@ export default function FirewallZonesPage() {
     setLoading(true);
     setError(null);
     try {
-      const [caps, zonesData, v4, v6, fwCaps, groupsData] = await Promise.all([
+      const [caps, zonesData, v4, v6, fwCaps, groupsData, seps] = await Promise.all([
         firewallZonesService.getCapabilities(),
         firewallZonesService.getConfig(refresh),
         firewallIPv4Service.getConfig(refresh),
         firewallIPv6Service.getConfig(refresh),
         firewallIPv4Service.getCapabilities(),
         firewallGroupsService.getConfig(refresh),
+        firewallSeparatorsService.list(),
       ]);
       setCapabilities(caps);
       setZones(zonesData.zones);
       setIpv4Config(v4);
       setIpv6Config(v6);
       setFirewallCaps(fwCaps);
+      setSeparators(seps);
       setGroups([
         ...groupsData.address_groups,
         ...groupsData.ipv6_address_groups,
@@ -563,6 +583,119 @@ export default function FirewallZonesPage() {
   const allPolicyRows = buildPolicyRows();
   const displayRows = isReordering ? reorderedRows : allPolicyRows;
 
+  // ── Separators ────────────────────────────────────────────────────────────
+  // On this page a separator's `chain` is the custom chain backing a zone-pair
+  // and its `family` is the selected IP version. Editing is offered only in the
+  // focused single-pair view; the "all" overview shows them read-only.
+  const canEditSeparators = canEdit;
+  const currentFamily: SeparatorFamily = ipVersion;
+  const focusedChain =
+    selectedPair !== "all"
+      ? resolveChainName(selectedPair.source, selectedPair.dest, ipVersion, zones)
+      : null;
+  const focusedSeparators = focusedChain
+    ? separators
+        .filter((s) => s.family === currentFamily && s.chain === focusedChain)
+        .sort((a, b) => a.position - b.position)
+    : [];
+  // Editable separators are shown in the focused pair view outside reorder mode.
+  const showFocusedSeparators =
+    selectedPair !== "all" && !isReordering && !!focusedChain && !searchQuery;
+
+  type SortableDescriptor =
+    | { kind: "sep"; sep: FirewallSeparator }
+    | { kind: "rule"; row: PolicyRow };
+
+  // Interleave the focused chain's separators (by position) with its rule rows.
+  const buildFocusedOrder = (rows: PolicyRow[]): SortableDescriptor[] => {
+    const out: SortableDescriptor[] = [];
+    let si = 0;
+    const pushUpTo = (upTo: number) => {
+      while (si < focusedSeparators.length && focusedSeparators[si].position <= upTo) {
+        out.push({ kind: "sep", sep: focusedSeparators[si] });
+        si++;
+      }
+    };
+    for (const row of rows) {
+      pushUpTo(row.rule.rule_number);
+      out.push({ kind: "rule", row });
+    }
+    pushUpTo(Number.POSITIVE_INFINITY);
+    return out;
+  };
+
+  const dragIdFor = (d: SortableDescriptor): string =>
+    d.kind === "sep" ? separatorDragId(d.sep.id) : `${d.row.chainName}-${d.row.rule.rule_number}`;
+
+  const openCreateSeparator = (anchorRuleNumber: number | null) => {
+    setEditingSeparator(null);
+    setSeparatorAnchor(anchorRuleNumber);
+    setSeparatorModalOpen(true);
+  };
+
+  const openEditSeparator = (sep: FirewallSeparator) => {
+    setEditingSeparator(sep);
+    setSeparatorAnchor(null);
+    setSeparatorModalOpen(true);
+  };
+
+  const handleDeleteSeparator = async (id: string) => {
+    try {
+      setSeparators(await firewallSeparatorsService.delete(id));
+    } catch (err) {
+      console.error("Error deleting separator:", err);
+    }
+  };
+
+  // Persist a separator's new position (optimistic; reverts on failure).
+  const moveSeparator = async (sepId: string, position: number) => {
+    const sep = separators.find((s) => s.id === sepId);
+    if (!sep || sep.position === position) return;
+    setSeparators((prev) => prev.map((s) => (s.id === sepId ? { ...s, position } : s)));
+    try {
+      setSeparators(
+        await firewallSeparatorsService.save({
+          id: sep.id,
+          family: sep.family,
+          chain: sep.chain,
+          position,
+          label: sep.label,
+          color: sep.color,
+        })
+      );
+    } catch (err) {
+      console.error("Error moving separator:", err);
+      setSeparators((prev) =>
+        prev.map((s) => (s.id === sepId ? { ...s, position: sep.position } : s))
+      );
+    }
+  };
+
+  // Derive and persist a dragged separator's new position from where it landed.
+  const handleSeparatorDragEnd = (activeDragId: string, overId: string | number) => {
+    const focusedRules = displayRows.filter((r) => r.chainName === focusedChain);
+    const ids = buildFocusedOrder(focusedRules).map(dragIdFor);
+    const oldIndex = ids.indexOf(activeDragId);
+    const newIndex = ids.indexOf(String(overId));
+    if (oldIndex < 0 || newIndex < 0) return;
+    const newIds = arrayMove(ids, oldIndex, newIndex);
+    const at = newIds.indexOf(activeDragId);
+    // The bar's position is the rule that now follows it (rule ids look like
+    // "<chain>-<number>"); past the last rule it trails the chain.
+    let position: number | null = null;
+    for (let j = at + 1; j < newIds.length; j++) {
+      if (!newIds[j].startsWith("sep:")) {
+        position = Number(newIds[j].slice(newIds[j].lastIndexOf("-") + 1));
+        break;
+      }
+    }
+    if (position == null) {
+      const nums = focusedRules.map((r) => r.rule.rule_number);
+      position = (nums.length ? Math.max(...nums) : 0) + 1;
+    }
+    void moveSeparator(activeDragId.slice("sep:".length), position);
+  };
+
   // ── Reorder handlers ──────────────────────────────────────────────────────
 
   const handleEnterReorder = () => {
@@ -576,17 +709,34 @@ export default function FirewallZonesPage() {
     setActiveId(null);
   };
 
+  const isSeparatorDragId = (id: string | number): id is string =>
+    typeof id === "string" && id.startsWith("sep:");
+
   const handleDragStart = (event: { active: { id: string | number } }) => {
+    if (isSeparatorDragId(event.active.id)) {
+      setActiveSeparatorId(event.active.id);
+      return;
+    }
     setActiveId(String(event.active.id));
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     setActiveId(null);
+    setActiveSeparatorId(null);
     if (!over || active.id === over.id) return;
+
+    // Dragging a separator → reposition it (DB only, instant, no VyOS write).
+    if (isSeparatorDragId(active.id)) {
+      handleSeparatorDragEnd(active.id, over.id);
+      return;
+    }
+
+    // Dragging a rule → existing reorder (focused pair, reorder mode only).
     setReorderedRows((prev) => {
       const oldIdx = prev.findIndex((r) => `${r.chainName}-${r.rule.rule_number}` === active.id);
       const newIdx = prev.findIndex((r) => `${r.chainName}-${r.rule.rule_number}` === over.id);
+      if (oldIdx < 0 || newIdx < 0) return prev;
       return arrayMove(prev, oldIdx, newIdx);
     });
   };
@@ -656,6 +806,148 @@ export default function FirewallZonesPage() {
   }
 
   const canReorder = selectedPair !== "all";
+
+  // Separator sortable ids (focused editable view only); used by SortableContext.
+  const separatorSortableIds = showFocusedSeparators
+    ? buildFocusedOrder(displayRows).map(dragIdFor)
+    : displayRows.map((r) => `${r.chainName}-${r.rule.rule_number}`);
+
+  // Render the policy table body: rule rows plus separators. In the focused
+  // pair view separators are editable (drag + insert zones); in the "all"
+  // overview they are read-only colour dividers grouped per chain.
+  const renderPolicyRows = (): ReactNode[] => {
+    const out: ReactNode[] = [];
+    const colSpan = 13;
+
+    if (showFocusedSeparators) {
+      let lastRuleNumber: number | null = null;
+      for (const item of buildFocusedOrder(displayRows)) {
+        if (item.kind === "sep") {
+          out.push(
+            <SeparatorBar
+              key={`sep-${item.sep.id}`}
+              separator={item.sep}
+              colSpan={colSpan}
+              canWrite={canEditSeparators}
+              onEdit={() => openEditSeparator(item.sep)}
+              onDelete={() => handleDeleteSeparator(item.sep.id)}
+            />
+          );
+          continue;
+        }
+        const row = item.row;
+        const id = `${row.chainName}-${row.rule.rule_number}`;
+        if (canEditSeparators) {
+          out.push(
+            <SeparatorInsertZone
+              key={`insert-${id}`}
+              colSpan={colSpan}
+              onInsert={() => openCreateSeparator(row.rule.rule_number)}
+            />
+          );
+        }
+        out.push(
+          <SortableRuleRow
+            key={id}
+            id={id}
+            row={row}
+            isReordering={isReordering}
+            onClick={() => openEditPanel(row)}
+            onClone={() => openClonePanel(row)}
+            groups={groups}
+          />
+        );
+        lastRuleNumber = row.rule.rule_number;
+      }
+      if (canEditSeparators && lastRuleNumber !== null) {
+        out.push(
+          <SeparatorInsertZone
+            key="insert-bottom"
+            colSpan={colSpan}
+            onInsert={() => openCreateSeparator(lastRuleNumber! + 1)}
+          />
+        );
+      }
+      return out;
+    }
+
+    // All-view (and focused while reordering/searching): plain rows. In the
+    // "all" overview, group rules under a per-policy (zone-pair) header band and
+    // interleave read-only dividers within each chain block.
+    const allViewGrouping = selectedPair === "all";
+    const allViewDividers = allViewGrouping && !searchQuery;
+    // Rule count per policy/chain, computed in one pass (header bands below).
+    const chainCounts = new Map<string, number>();
+    if (allViewGrouping) {
+      for (const r of displayRows) {
+        chainCounts.set(r.chainName, (chainCounts.get(r.chainName) ?? 0) + 1);
+      }
+    }
+    let currentChain: string | null = null;
+    let chainSeps: FirewallSeparator[] = [];
+    let csi = 0;
+    displayRows.forEach((row, idx) => {
+      const id = `${row.chainName}-${row.rule.rule_number}`;
+      if (allViewGrouping && row.chainName !== currentChain) {
+        currentChain = row.chainName;
+        // Policy section header for this zone-pair.
+        const count = chainCounts.get(currentChain) ?? 0;
+        const intra = row.sourceZone === row.destZone;
+        out.push(
+          <TableRow key={`grp-${currentChain}`} className="hover:bg-transparent border-y bg-muted/40">
+            <TableCell colSpan={colSpan} className="py-1.5">
+              <div className="flex items-center gap-2">
+                <Badge variant="outline" className="font-mono text-[10px]">{row.sourceZone}</Badge>
+                <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                <Badge variant="outline" className="font-mono text-[10px]">{row.destZone}</Badge>
+                {intra && (
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wide">intra-zone</span>
+                )}
+                <span className="ml-auto text-[11px] text-muted-foreground">
+                  {count} rule{count !== 1 ? "s" : ""}
+                </span>
+              </div>
+            </TableCell>
+          </TableRow>
+        );
+        chainSeps = allViewDividers
+          ? separators
+              .filter((s) => s.family === currentFamily && s.chain === currentChain)
+              .sort((a, b) => a.position - b.position)
+          : [];
+        csi = 0;
+      }
+      if (allViewDividers) {
+        while (csi < chainSeps.length && chainSeps[csi].position <= row.rule.rule_number) {
+          out.push(
+            <SeparatorDivider key={`div-${chainSeps[csi].id}`} separator={chainSeps[csi]} colSpan={colSpan} />
+          );
+          csi++;
+        }
+      }
+      out.push(
+        <SortableRuleRow
+          key={`${id}-${idx}`}
+          id={id}
+          row={row}
+          isReordering={isReordering}
+          onClick={() => openEditPanel(row)}
+          onClone={() => openClonePanel(row)}
+          groups={groups}
+        />
+      );
+      const next = displayRows[idx + 1];
+      if (allViewDividers && (!next || next.chainName !== currentChain)) {
+        while (csi < chainSeps.length) {
+          out.push(
+            <SeparatorDivider key={`div-${chainSeps[csi].id}`} separator={chainSeps[csi]} colSpan={colSpan} />
+          );
+          csi++;
+        }
+      }
+    });
+    return out;
+  };
 
   return (
     <AppLayout>
@@ -949,6 +1241,19 @@ export default function FirewallZonesPage() {
                   </Button>
                 )}
 
+                {/* Add Separator button — focused pair view only */}
+                {canEditSeparators && showFocusedSeparators && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs gap-1"
+                    onClick={() => openCreateSeparator(null)}
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add Separator
+                  </Button>
+                )}
+
                 {/* Search */}
                 {!isReordering && (
                   <div className="relative flex-1 max-w-xs">
@@ -966,8 +1271,10 @@ export default function FirewallZonesPage() {
                 {!isReordering && selectedPair !== "all" && (
                   <div className="flex items-center gap-1">
                     <Filter className="h-3.5 w-3.5 text-muted-foreground" />
-                    <span className="text-xs text-muted-foreground font-mono">
-                      {selectedPair.source} → {selectedPair.dest}
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
+                      {selectedPair.source}
+                      <ArrowRight className="h-3 w-3 shrink-0" />
+                      {selectedPair.dest}
                     </span>
                     <Button
                       variant="ghost"
@@ -1042,38 +1349,44 @@ export default function FirewallZonesPage() {
                     {displayRows.length === 0 ? (
                       <TableRow>
                         <TableCell colSpan={12} className="text-center py-8 text-muted-foreground text-sm">
-                          {selectedPair !== "all"
-                            ? `No firewall rules for ${selectedPair.source} → ${selectedPair.dest}`
-                            : "No firewall rules found for any zone pair"}
+                          {selectedPair !== "all" ? (
+                            <span className="inline-flex items-center gap-1">
+                              No firewall rules for {selectedPair.source}
+                              <ArrowRight className="h-3 w-3 shrink-0" />
+                              {selectedPair.dest}
+                            </span>
+                          ) : (
+                            "No firewall rules found for any zone pair"
+                          )}
                         </TableCell>
                       </TableRow>
                     ) : (
                       <SortableContext
-                        items={displayRows.map((r) => `${r.chainName}-${r.rule.rule_number}`)}
+                        items={separatorSortableIds}
                         strategy={verticalListSortingStrategy}
                       >
-                        {displayRows.map((row, idx) => {
-                          const id = `${row.chainName}-${row.rule.rule_number}`;
-                          return (
-                            <SortableRuleRow
-                              key={`${id}-${idx}`}
-                              id={id}
-                              row={row}
-                              isReordering={isReordering}
-                              onClick={() => openEditPanel(row)}
-                              onClone={() => openClonePanel(row)}
-                              groups={groups}
-                            />
-                          );
-                        })}
+                        {renderPolicyRows()}
                       </SortableContext>
                     )}
                   </TableBody>
                 </Table>
 
-                {/* Drag overlay — ghost of the row being dragged */}
+                {/* Drag overlay — ghost of the row or separator being dragged */}
                 <DragOverlay>
-                  {activeId && (() => {
+                  {activeSeparatorId ? (() => {
+                    const sep = separators.find((s) => separatorDragId(s.id) === activeSeparatorId);
+                    if (!sep) return null;
+                    return (
+                      <div
+                        className="rounded-md px-3 py-1.5 shadow-2xl"
+                        style={{ backgroundColor: `${sep.color}1a`, borderLeft: `3px solid ${sep.color}` }}
+                      >
+                        <span className="text-xs font-semibold uppercase tracking-wide" style={{ color: sep.color }}>
+                          {sep.label}
+                        </span>
+                      </div>
+                    );
+                  })() : activeId ? (() => {
                     const row = displayRows.find((r) => `${r.chainName}-${r.rule.rule_number}` === activeId);
                     if (!row) return null;
                     return (
@@ -1082,14 +1395,21 @@ export default function FirewallZonesPage() {
                         {row.rule.description ? ` — ${row.rule.description}` : ""}
                       </div>
                     );
-                  })()}
+                  })() : null}
                 </DragOverlay>
               </DndContext>
 
               {displayRows.length > 0 && (
-                <div className="px-4 py-2 border-t text-xs text-muted-foreground">
+                <div className="flex items-center px-4 py-2 border-t text-xs text-muted-foreground">
                   {displayRows.length} rule{displayRows.length !== 1 ? "s" : ""}
-                  {selectedPair !== "all" && ` for ${selectedPair.source} → ${selectedPair.dest}`}
+                  {selectedPair !== "all" && (
+                    <span className="inline-flex items-center gap-1">
+                      <span className="ml-1">for</span>
+                      {selectedPair.source}
+                      <ArrowRight className="h-3 w-3 shrink-0" />
+                      {selectedPair.dest}
+                    </span>
+                  )}
                   {isReordering && (
                     <span className="ml-2 text-primary font-medium">• reorder mode</span>
                   )}
@@ -1109,6 +1429,18 @@ export default function FirewallZonesPage() {
           capabilities={capabilities}
           existingZones={zones}
         />
+
+        {focusedChain && (
+          <SeparatorModal
+            open={separatorModalOpen}
+            onOpenChange={setSeparatorModalOpen}
+            family={currentFamily}
+            chain={focusedChain}
+            editing={editingSeparator}
+            defaultPosition={separatorAnchor}
+            onSaved={setSeparators}
+          />
+        )}
 
         {selectedZone && (() => {
           const nonLocalZones = zones.filter((z) => !z.local_zone);

--- a/frontend/src/components/firewall/BridgeRuleRow.tsx
+++ b/frontend/src/components/firewall/BridgeRuleRow.tsx
@@ -104,8 +104,15 @@ export function BridgeRuleRow({ rule, isV15, onEdit, onDelete, visibleOrderedCol
 
     return (
       <Badge variant="outline" className={`capitalize ${actionColors[action] || ""}`}>
-        {action}
-        {action === "jump" && rule.jump_target && ` → ${rule.jump_target}`}
+        {action === "jump" && rule.jump_target ? (
+          <span className="inline-flex items-center gap-1">
+            {action}
+            <ArrowRight className="h-3 w-3 shrink-0" />
+            {rule.jump_target}
+          </span>
+        ) : (
+          action
+        )}
       </Badge>
     );
   };

--- a/frontend/src/components/firewall/SeparatorBar.tsx
+++ b/frontend/src/components/firewall/SeparatorBar.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Pencil, Trash2 } from "lucide-react";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import type { FirewallSeparator } from "@/lib/api/firewall-separators";
+
+/** dnd-kit sortable id for a separator (string, vs numeric rule ids). */
+export const separatorDragId = (id: string) => `sep:${id}`;
+
+interface SeparatorBarProps {
+  separator: FirewallSeparator;
+  colSpan: number;
+  canWrite: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+/**
+ * A full-width coloured bar rendered between firewall rule rows to visually
+ * group them into sections. Pure UI metadata — it maps to no VyOS config.
+ * When the user can edit, it can be dragged by its grip into another gap.
+ */
+export function SeparatorBar({
+  separator,
+  colSpan,
+  canWrite,
+  onEdit,
+  onDelete,
+}: SeparatorBarProps) {
+  const color = separator.color;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: separatorDragId(separator.id) });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <TableRow
+      ref={setNodeRef}
+      style={style}
+      className={cn("border-0 hover:bg-transparent", isDragging && "opacity-50")}
+    >
+      <TableCell colSpan={colSpan} className="py-1">
+        <div
+          className="group flex items-center gap-1 rounded-md py-1.5 pr-2"
+          // `${color}1a` appends ~10% alpha to the 6-digit hex for a subtle tint.
+          style={{ backgroundColor: `${color}1a`, borderLeft: `3px solid ${color}` }}
+        >
+          {canWrite ? (
+            <div
+              {...attributes}
+              {...listeners}
+              aria-label="Drag separator"
+              className="flex cursor-grab items-center self-stretch px-1.5 text-muted-foreground/60 hover:text-foreground active:cursor-grabbing"
+            >
+              <GripVertical className="h-4 w-4" />
+            </div>
+          ) : (
+            <span className="pl-3" />
+          )}
+          <span
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color }}
+          >
+            {separator.label}
+          </span>
+          {canWrite && (
+            <div className="ml-auto flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+              <button
+                type="button"
+                onClick={onEdit}
+                aria-label="Edit separator"
+                className="rounded p-1 text-muted-foreground hover:text-foreground"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                aria-label="Delete separator"
+                className="rounded p-1 text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/src/components/firewall/SeparatorDivider.tsx
+++ b/frontend/src/components/firewall/SeparatorDivider.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { TableCell, TableRow } from "@/components/ui/table";
+import type { FirewallSeparator } from "@/lib/api/firewall-separators";
+
+interface SeparatorDividerProps {
+  separator: FirewallSeparator;
+  colSpan: number;
+}
+
+/**
+ * Read-only coloured section divider. Used where separators are shown purely
+ * for context (e.g. the zones "all policies" overview) — no grip, edit, delete,
+ * or drag, and crucially no dnd-kit `useSortable` so it can live in a list that
+ * isn't being sorted.
+ */
+export function SeparatorDivider({ separator, colSpan }: SeparatorDividerProps) {
+  const color = separator.color;
+  return (
+    <TableRow className="border-0 hover:bg-transparent">
+      <TableCell colSpan={colSpan} className="py-1">
+        <div
+          className="flex items-center rounded-md px-3 py-1"
+          // `${color}1a` appends ~10% alpha to the 6-digit hex for a subtle tint.
+          style={{ backgroundColor: `${color}1a`, borderLeft: `3px solid ${color}` }}
+        >
+          <span
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color }}
+          >
+            {separator.label}
+          </span>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/src/components/firewall/SeparatorInsertZone.tsx
+++ b/frontend/src/components/firewall/SeparatorInsertZone.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { TableCell, TableRow } from "@/components/ui/table";
+
+interface SeparatorInsertZoneProps {
+  colSpan: number;
+  onInsert: () => void;
+}
+
+/**
+ * A thin gap rendered between two firewall rule rows. On hover it reveals a
+ * line and a "+ Separator" button so a separator can be dropped exactly into
+ * that gap.
+ */
+export function SeparatorInsertZone({ colSpan, onInsert }: SeparatorInsertZoneProps) {
+  return (
+    <TableRow className="group/ins border-0 hover:bg-transparent">
+      <TableCell colSpan={colSpan} className="relative h-2 p-0">
+        <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent transition-colors group-hover/ins:bg-primary/40" />
+        <button
+          type="button"
+          onClick={onInsert}
+          aria-label="Insert separator here"
+          className="absolute left-1/2 top-1/2 z-20 flex -translate-x-1/2 -translate-y-1/2 items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-[11px] font-medium text-muted-foreground opacity-0 shadow-sm transition-opacity hover:border-primary hover:text-foreground group-hover/ins:opacity-100"
+        >
+          <Plus className="h-3 w-3" />
+          Separator
+        </button>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/src/components/firewall/SeparatorModal.tsx
+++ b/frontend/src/components/firewall/SeparatorModal.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  firewallSeparatorsService,
+  type FirewallSeparator,
+  type SeparatorFamily,
+} from "@/lib/api/firewall-separators";
+
+// A small preset palette. 6-digit hex so SeparatorBar's alpha tint works.
+const COLORS = [
+  { name: "Red", value: "#ef4444" },
+  { name: "Orange", value: "#f97316" },
+  { name: "Amber", value: "#f59e0b" },
+  { name: "Green", value: "#22c55e" },
+  { name: "Teal", value: "#14b8a6" },
+  { name: "Blue", value: "#3b82f6" },
+  { name: "Indigo", value: "#6366f1" },
+  { name: "Purple", value: "#a855f7" },
+  { name: "Pink", value: "#ec4899" },
+  { name: "Slate", value: "#64748b" },
+];
+
+interface SeparatorModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  family: SeparatorFamily;
+  chain: string;
+  /** When set, edit this separator; otherwise create a new one. */
+  editing?: FirewallSeparator | null;
+  /**
+   * Position for a new separator, taken from the gap that was clicked. The bar
+   * renders above the first rule whose number >= this value. Defaults to the
+   * top of the chain. Ignored when editing (drag the bar to move it instead).
+   */
+  defaultPosition?: number | null;
+  /** Called with the instance's refreshed separator list after a save. */
+  onSaved: (separators: FirewallSeparator[]) => void;
+}
+
+export function SeparatorModal({
+  open,
+  onOpenChange,
+  family,
+  chain,
+  editing,
+  defaultPosition,
+  onSaved,
+}: SeparatorModalProps) {
+  const [label, setLabel] = useState("");
+  const [color, setColor] = useState(COLORS[0].value);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed the form whenever the modal is opened.
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    if (editing) {
+      setLabel(editing.label);
+      setColor(editing.color);
+    } else {
+      setLabel("");
+      setColor(COLORS[0].value);
+    }
+  }, [open, editing]);
+
+  const handleSave = async () => {
+    const trimmed = label.trim();
+    if (!trimmed) {
+      setError("Label is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      // Keep the existing position when editing; for a new separator use the
+      // clicked gap (defaultPosition), falling back to the top of the chain.
+      const position = editing ? editing.position : defaultPosition ?? 0;
+      const separators = await firewallSeparatorsService.save({
+        id: editing?.id,
+        family,
+        chain,
+        position,
+        label: trimmed,
+        color,
+      });
+      onSaved(separators);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save separator");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit Separator" : "Add Separator"}</DialogTitle>
+          <DialogDescription>
+            Separators are visual section labels for the{" "}
+            <span className="font-medium capitalize">{chain} </span> chain. They
+            are stored in VyManager and don&apos;t change the router config.
+            {editing ? " Drag the bar to move it between rules." : ""}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="separator-label">Label</Label>
+            <Input
+              id="separator-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Ingress, Management, VPN"
+              maxLength={200}
+              autoFocus
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Colour</Label>
+            <div className="flex flex-wrap gap-2">
+              {COLORS.map((c) => (
+                <button
+                  key={c.value}
+                  type="button"
+                  aria-label={c.name}
+                  onClick={() => setColor(c.value)}
+                  className={cn(
+                    "h-7 w-7 rounded-full border-2 transition-transform",
+                    color === c.value
+                      ? "scale-110 border-foreground"
+                      : "border-transparent"
+                  )}
+                  style={{ backgroundColor: c.value }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              {error}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? "Saving..." : editing ? "Save Changes" : "Add Separator"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api/firewall-separators.ts
+++ b/frontend/src/lib/api/firewall-separators.ts
@@ -1,0 +1,75 @@
+/**
+ * Firewall Separators API Service
+ *
+ * User-defined coloured separator bars rendered between firewall rules. These
+ * are pure UI metadata stored in the VyManager database (NOT in the VyOS
+ * config) and shared per instance. A bar renders above the first rule whose
+ * number >= `position`.
+ */
+
+import { apiClient } from "./client";
+
+// ==================== Type Definitions ====================
+
+export type SeparatorFamily = "ipv4" | "ipv6" | "bridge";
+
+export interface FirewallSeparator {
+  id: string;
+  family: SeparatorFamily;
+  chain: string;
+  position: number;
+  label: string;
+  color: string;
+}
+
+/** An upsert payload. Omit `id` to create; provide an existing `id` to update. */
+export interface SeparatorUpsert {
+  id?: string;
+  family: SeparatorFamily;
+  chain: string;
+  position: number;
+  label: string;
+  color: string;
+}
+
+export interface SeparatorBatchRequest {
+  upserts?: SeparatorUpsert[];
+  deletes?: string[];
+}
+
+interface SeparatorListResponse {
+  separators: FirewallSeparator[];
+}
+
+// ==================== Service ====================
+
+class FirewallSeparatorsService {
+  /** List every separator for the current instance (all families/chains). */
+  async list(): Promise<FirewallSeparator[]> {
+    const res = await apiClient.get<SeparatorListResponse>(
+      "/vyos/firewall/separators"
+    );
+    return res.separators;
+  }
+
+  /** Apply a batch of upserts/deletes; returns the instance's full list after. */
+  async batch(request: SeparatorBatchRequest): Promise<FirewallSeparator[]> {
+    const res = await apiClient.post<SeparatorListResponse>(
+      "/vyos/firewall/separators/batch",
+      { upserts: request.upserts ?? [], deletes: request.deletes ?? [] }
+    );
+    return res.separators;
+  }
+
+  /** Convenience: create or update a single separator. */
+  async save(separator: SeparatorUpsert): Promise<FirewallSeparator[]> {
+    return this.batch({ upserts: [separator] });
+  }
+
+  /** Convenience: delete a single separator by id. */
+  async delete(id: string): Promise<FirewallSeparator[]> {
+    return this.batch({ deletes: [id] });
+  }
+}
+
+export const firewallSeparatorsService = new FirewallSeparatorsService();


### PR DESCRIPTION
## Summary

Adds **coloured separators** — section labels that group firewall rules visually without touching the VyOS config. They're pure UI metadata stored in VyManager's database (the same pattern as dashboard layouts) and shared per instance. A bar renders above the first rule whose number ≥ its `position`.

Closes #294.

## Backend
- New `firewall_separators` table (Prisma model + migration) keyed on `(instanceId, family, chain, position, label, color)`.
- `routers/firewall/separators.py`: `GET` list + `POST /batch` (upsert/delete), scoped to the active instance, gated by **`FIREWALL_POLICIES` OR `FIREWALL_ZONES`**. Inserts always allocate a fresh server id so a client-supplied id can't collide with another instance's row.
- Wired into the encrypted backup/restore (`BACKUP_TABLES`, right after `instances`) — verified round-trip through `encrypt_backup`/`decrypt_backup`.

## Frontend
- **Policies page**: separators render between rule rows. Create by clicking the gap between rows; reposition by dragging the bar (dnd-kit); edit/delete inline. Rule reorder is only flagged when the rule order actually changes (fixes a spurious "reorder pending" when dropping a rule next to a separator).
- **Zones page**: full editing in the focused zone-pair view; the **all-policies overview** groups rules under per-policy header bands (`source → dest`, rule count) with read-only colour dividers nested in each policy.
- New components: `SeparatorBar`, `SeparatorDivider`, `SeparatorInsertZone`, `SeparatorModal`; API service `firewall-separators.ts`.
- Replaced literal `→` glyphs with the `ArrowRight` icon across the zones table and bridge rule rows.

## Validation
- `tsc --noEmit` and ESLint clean on all changed files.
- Backend parses; routes live; permission helper imports.
- Migration applied and verified in Postgres; backup capture confirmed end-to-end.

## Known follow-ups (minor, from self-review)
- Separator drag/interleave logic is near-duplicated across the two pages — candidate for a shared hook.
- The "bar above first rule ≥ position" interleave is implemented in three spots; could be consolidated.
- Zones separator rows use a hardcoded `colSpan`; could be derived.
- During an *unsaved* rule reorder, bars can render transiently misplaced (self-corrects on save/reload).