### PR TITLE
Fix IPSec remote-access display and harden connection edit (#410)

### DIFF
--- a/backend/vyos_builders/ipsec/ipsec.py
+++ b/backend/vyos_builders/ipsec/ipsec.py
@@ -458,14 +458,26 @@ class IPSecBatchBuilder:
     def delete_ra_connection_disable(self, conn: str) -> "IPSecBatchBuilder":
         return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_disable_path(conn))
 
+    def delete_ra_connection_description(self, conn: str, description: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_description_path(conn, description))
+
     def set_ra_connection_esp_group(self, conn: str, esp_group: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_esp_group_path(conn, esp_group))
+
+    def delete_ra_connection_esp_group(self, conn: str, esp_group: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_esp_group_path(conn, esp_group))
 
     def set_ra_connection_ike_group(self, conn: str, ike_group: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_ike_group_path(conn, ike_group))
 
+    def delete_ra_connection_ike_group(self, conn: str, ike_group: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_ike_group_path(conn, ike_group))
+
     def set_ra_connection_local_address(self, conn: str, address: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_local_address_path(conn, address))
+
+    def delete_ra_connection_local_address(self, conn: str, address: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_local_address_path(conn, address))
 
     def set_ra_connection_dhcp_interface(self, conn: str, interface: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_dhcp_interface_path(conn, interface))
@@ -498,11 +510,20 @@ class IPSecBatchBuilder:
     def set_ra_connection_auth_server_mode(self, conn: str, mode: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_server_mode_path(conn, mode))
 
+    def delete_ra_connection_auth_server_mode(self, conn: str, mode: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_auth_server_mode_path(conn, mode))
+
     def set_ra_connection_auth_client_mode(self, conn: str, mode: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_client_mode_path(conn, mode))
 
+    def delete_ra_connection_auth_client_mode(self, conn: str, mode: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_auth_client_mode_path(conn, mode))
+
     def set_ra_connection_auth_local_id(self, conn: str, local_id: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_local_id_path(conn, local_id))
+
+    def delete_ra_connection_auth_local_id(self, conn: str, local_id: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_auth_local_id_path(conn, local_id))
 
     def set_ra_connection_auth_eap_id(self, conn: str, eap_id: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_eap_id_path(conn, eap_id))
@@ -513,8 +534,14 @@ class IPSecBatchBuilder:
     def set_ra_connection_auth_x509_ca_cert(self, conn: str, ca_cert: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_x509_ca_cert_path(conn, ca_cert))
 
+    def delete_ra_connection_auth_x509_ca_cert(self, conn: str, ca_cert: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_auth_x509_ca_cert_path(conn, ca_cert))
+
     def set_ra_connection_auth_x509_cert(self, conn: str, cert: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_x509_cert_path(conn, cert))
+
+    def delete_ra_connection_auth_x509_cert(self, conn: str, cert: str) -> "IPSecBatchBuilder":
+        return self.add_delete(self.mappers[self.mapper_key].get_ra_connection_auth_x509_cert_path(conn, cert))
 
     def set_ra_connection_auth_x509_passphrase(self, conn: str, passphrase: str) -> "IPSecBatchBuilder":
         return self.add_set(self.mappers[self.mapper_key].get_ra_connection_auth_x509_passphrase_path(conn, passphrase))

--- a/backend/vyos_mappers/ipsec/ipsec.py
+++ b/backend/vyos_mappers/ipsec/ipsec.py
@@ -682,13 +682,16 @@ class IPSecMapper:
         auth = config.get("authentication", {})
         x509 = auth.get("x509", {})
         local = config.get("local", {})
-        local_users = {}
+        ppk = auth.get("ppk", {})
+        local_users = []
         for username, user_config in auth.get("local-users", {}).get("username", {}).items():
-            local_users[username] = {
+            user_config = user_config or {}
+            local_users.append({
                 "username": username,
                 "disabled": "disable" in user_config,
                 "password": user_config.get("password"),
-            }
+            })
+        ca_certs = self._normalize_to_list(x509.get("ca-certificate"))
         return {
             "name": name,
             "description": config.get("description"),
@@ -697,35 +700,37 @@ class IPSecMapper:
             "ike_group": config.get("ike-group"),
             "local_address": config.get("local-address"),
             "dhcp_interface": config.get("dhcp-interface"),
-            "pool": self._normalize_to_list(config.get("pool")),
+            "pools": self._normalize_to_list(config.get("pool")),
             "replay_window": config.get("replay-window"),
             "timeout": config.get("timeout"),
             "unique": config.get("unique"),
-            "local": {
-                "prefix": self._normalize_to_list(local.get("prefix")),
-                "port": local.get("port"),
-            },
-            "authentication": {
-                "server_mode": auth.get("server-mode"),
-                "client_mode": auth.get("client-mode"),
-                "local_id": auth.get("local-id"),
-                "eap_id": auth.get("eap-id"),
-                "pre_shared_secret": auth.get("pre-shared-secret"),
-                "x509": {
-                    "ca_certificate": self._normalize_to_list(x509.get("ca-certificate")),
-                    "certificate": x509.get("certificate"),
-                    "passphrase": x509.get("passphrase"),
-                },
-                "local_users": local_users,
-            },
+            "local_prefix": self._normalize_to_list(local.get("prefix")),
+            "local_port": local.get("port"),
+            "bind": config.get("bind"),
+            "childless": "childless" in config,
+            "auth_server_mode": auth.get("server-mode"),
+            "auth_client_mode": auth.get("client-mode"),
+            "auth_local_id": auth.get("local-id"),
+            "auth_eap_id": auth.get("eap-id"),
+            "auth_psk": auth.get("pre-shared-secret"),
+            "auth_always_send_cert": "always-send-cert" in auth,
+            "auth_x509_ca_cert": ca_certs[0] if ca_certs else None,
+            "auth_x509_cert": x509.get("certificate"),
+            "auth_x509_passphrase": x509.get("passphrase"),
+            "auth_ppk_id": ppk.get("id"),
+            "auth_ppk_required": "required" in ppk,
+            "local_users": local_users,
         }
 
     def _parse_ra_pool(self, name: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        rng = config.get("range", {})
         return {
             "name": name,
             "prefix": self._normalize_to_list(config.get("prefix")),
-            "name_server": self._normalize_to_list(config.get("name-server")),
+            "name_servers": self._normalize_to_list(config.get("name-server")),
             "exclude": self._normalize_to_list(config.get("exclude")),
+            "range_start": rng.get("start"),
+            "range_stop": rng.get("stop"),
         }
 
     def _normalize_to_list(self, value: Any) -> list:

--- a/frontend/src/components/vpn/ipsec/RemoteAccessModal.tsx
+++ b/frontend/src/components/vpn/ipsec/RemoteAccessModal.tsx
@@ -20,7 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
-import { AlertCircle, Loader2, Wifi, Eye, EyeOff } from "lucide-react";
+import { AlertCircle, Loader2, Wifi, Eye, EyeOff, Plus, Trash2 } from "lucide-react";
 import {
   ipsecService,
   RAConnection,
@@ -42,10 +42,17 @@ interface RemoteAccessModalProps {
   existingConnection: RAConnection | null;
 }
 
+interface LocalUserRow {
+  username: string;
+  password: string;
+  disabled: boolean;
+}
+
 export function RemoteAccessModal({
   open,
   onOpenChange,
   onSuccess,
+  capabilities,
   ikeGroups,
   espGroups,
   pools,
@@ -66,6 +73,8 @@ export function RemoteAccessModal({
   const [showPsk, setShowPsk] = useState(false);
   const [authX509CaCert, setAuthX509CaCert] = useState("");
   const [authX509Cert, setAuthX509Cert] = useState("");
+  const [alwaysSendCert, setAlwaysSendCert] = useState(false);
+  const [localUsers, setLocalUsers] = useState<LocalUserRow[]>([]);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -85,6 +94,14 @@ export function RemoteAccessModal({
         setAuthPsk("");
         setAuthX509CaCert(existingConnection.auth_x509_ca_cert || "");
         setAuthX509Cert(existingConnection.auth_x509_cert || "");
+        setAlwaysSendCert(!!existingConnection.auth_always_send_cert);
+        setLocalUsers(
+          (existingConnection.local_users || []).map((u) => ({
+            username: u.username,
+            password: u.password || "",
+            disabled: !!u.disabled,
+          }))
+        );
       } else {
         setName("");
         setDescription("");
@@ -98,6 +115,8 @@ export function RemoteAccessModal({
         setAuthPsk("");
         setAuthX509CaCert("");
         setAuthX509Cert("");
+        setAlwaysSendCert(false);
+        setLocalUsers([]);
       }
       setShowPsk(false);
       setError(null);
@@ -111,11 +130,13 @@ export function RemoteAccessModal({
     setError(null);
 
     try {
-      if (isEdit) await ipsecService.deleteRAConnection(existingConnection!.name);
-
       const poolList = selectedPools.split(",").map((p) => p.trim()).filter(Boolean);
+      const isX509 = authServerMode === "x509";
+      const cleanedUsers = localUsers
+        .map((u) => ({ username: u.username.trim(), password: u.password, disabled: u.disabled }))
+        .filter((u) => u.username);
 
-      const result = await ipsecService.createRAConnection(name.trim(), {
+      const payload = {
         description: description || undefined,
         esp_group: espGroup || undefined,
         ike_group: ikeGroup || undefined,
@@ -124,10 +145,16 @@ export function RemoteAccessModal({
         auth_server_mode: authServerMode || undefined,
         auth_client_mode: authClientMode || undefined,
         auth_local_id: authLocalId || undefined,
-        auth_psk: authPsk || undefined,
-        auth_x509_ca_cert: authX509CaCert || undefined,
-        auth_x509_cert: authX509Cert || undefined,
-      });
+        auth_psk: !isX509 ? authPsk || undefined : undefined,
+        auth_x509_ca_cert: isX509 ? authX509CaCert || undefined : undefined,
+        auth_x509_cert: isX509 ? authX509Cert || undefined : undefined,
+        auth_always_send_cert: isX509 ? alwaysSendCert || undefined : undefined,
+        local_users: cleanedUsers,
+      };
+
+      const result = isEdit
+        ? await ipsecService.updateRAConnection(existingConnection!.name, payload, existingConnection!)
+        : await ipsecService.createRAConnection(name.trim(), payload);
 
       if (result.success) {
         onOpenChange(false);
@@ -267,17 +294,85 @@ export function RemoteAccessModal({
               </div>
             )}
             {authServerMode === "x509" && (
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label>CA Certificate</Label>
-                  <Input value={authX509CaCert} onChange={(e) => setAuthX509CaCert(e.target.value)} placeholder="ca-cert" />
+              <>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label>CA Certificate</Label>
+                    <Input value={authX509CaCert} onChange={(e) => setAuthX509CaCert(e.target.value)} placeholder="ca-cert" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>Certificate</Label>
+                    <Input value={authX509Cert} onChange={(e) => setAuthX509Cert(e.target.value)} placeholder="server-cert" />
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label>Certificate</Label>
-                  <Input value={authX509Cert} onChange={(e) => setAuthX509Cert(e.target.value)} placeholder="server-cert" />
-                </div>
-              </div>
+                {(capabilities?.features.always_send_cert.supported ?? true) && (
+                  <div className="flex items-start gap-2">
+                    <Checkbox
+                      id="always-send-cert"
+                      checked={alwaysSendCert}
+                      onCheckedChange={(checked) => setAlwaysSendCert(checked === true)}
+                    />
+                    <div className="space-y-0.5">
+                      <Label htmlFor="always-send-cert" className="cursor-pointer text-sm">Always send certificate</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Send the server certificate even when not requested. Required by some clients (e.g. Windows).
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label className="text-xs text-muted-foreground">Local Users</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setLocalUsers([...localUsers, { username: "", password: "", disabled: false }])}
+                >
+                  <Plus className="mr-1 h-3 w-3" /> Add User
+                </Button>
+              </div>
+              {localUsers.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No local users configured</p>
+              ) : (
+                <div className="space-y-2">
+                  {localUsers.map((user, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <Input
+                        value={user.username}
+                        onChange={(e) => {
+                          const next = [...localUsers];
+                          next[idx] = { ...next[idx], username: e.target.value };
+                          setLocalUsers(next);
+                        }}
+                        placeholder="username"
+                      />
+                      <Input
+                        type="password"
+                        value={user.password}
+                        onChange={(e) => {
+                          const next = [...localUsers];
+                          next[idx] = { ...next[idx], password: e.target.value };
+                          setLocalUsers(next);
+                        }}
+                        placeholder="password"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setLocalUsers(localUsers.filter((_, i) => i !== idx))}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/frontend/src/lib/api/ipsec.ts
+++ b/frontend/src/lib/api/ipsec.ts
@@ -466,6 +466,8 @@ class IPSecService {
     auth_psk?: string;
     auth_x509_ca_cert?: string;
     auth_x509_cert?: string;
+    auth_always_send_cert?: boolean;
+    local_users?: { username: string; password?: string; disabled?: boolean }[];
   }): Promise<VyOSResponse> {
     const ops: BatchOperation[] = [{ op: "create_ra_connection" }];
     if (config.description) ops.push({ op: "set_ra_connection_description", value: config.description });
@@ -483,6 +485,95 @@ class IPSecService {
     if (config.auth_psk) ops.push({ op: "set_ra_connection_auth_psk", value: config.auth_psk });
     if (config.auth_x509_ca_cert) ops.push({ op: "set_ra_connection_auth_x509_ca_cert", value: config.auth_x509_ca_cert });
     if (config.auth_x509_cert) ops.push({ op: "set_ra_connection_auth_x509_cert", value: config.auth_x509_cert });
+    if (config.auth_always_send_cert) ops.push({ op: "set_ra_connection_auth_always_send_cert" });
+    if (config.local_users) {
+      for (const user of config.local_users) {
+        if (!user.username) continue;
+        ops.push({ op: "create_ra_connection_auth_local_user", value: user.username });
+        if (user.password) ops.push({ op: "set_ra_connection_auth_local_user_password", value: `${user.username}|${user.password}` });
+        if (user.disabled) ops.push({ op: "set_ra_connection_auth_local_user_disable", value: user.username });
+      }
+    }
+    return this.batchConfigure(name, ops);
+  }
+
+  async updateRAConnection(name: string, config: {
+    description?: string;
+    esp_group?: string;
+    ike_group?: string;
+    local_address?: string;
+    pools?: string[];
+    auth_server_mode?: string;
+    auth_client_mode?: string;
+    auth_local_id?: string;
+    auth_psk?: string;
+    auth_x509_ca_cert?: string;
+    auth_x509_cert?: string;
+    auth_always_send_cert?: boolean;
+    local_users?: { username: string; password?: string; disabled?: boolean }[];
+  }, existing: RAConnection): Promise<VyOSResponse> {
+    const ops: BatchOperation[] = [];
+
+    // Single-valued leaf: set (replaces) when changed, delete when cleared.
+    const diffLeaf = (setOp: string, deleteOp: string, newVal?: string | null, oldVal?: string | null) => {
+      const nv = (newVal || "").trim();
+      const ov = (oldVal || "").trim();
+      if (nv && nv !== ov) ops.push({ op: setOp, value: nv });
+      else if (!nv && ov) ops.push({ op: deleteOp, value: ov });
+    };
+
+    diffLeaf("set_ra_connection_description", "delete_ra_connection_description", config.description, existing.description);
+    diffLeaf("set_ra_connection_esp_group", "delete_ra_connection_esp_group", config.esp_group, existing.esp_group);
+    diffLeaf("set_ra_connection_ike_group", "delete_ra_connection_ike_group", config.ike_group, existing.ike_group);
+    diffLeaf("set_ra_connection_local_address", "delete_ra_connection_local_address", config.local_address, existing.local_address);
+    diffLeaf("set_ra_connection_auth_server_mode", "delete_ra_connection_auth_server_mode", config.auth_server_mode, existing.auth_server_mode);
+    diffLeaf("set_ra_connection_auth_client_mode", "delete_ra_connection_auth_client_mode", config.auth_client_mode, existing.auth_client_mode);
+    diffLeaf("set_ra_connection_auth_local_id", "delete_ra_connection_auth_local_id", config.auth_local_id, existing.auth_local_id);
+    diffLeaf("set_ra_connection_auth_x509_cert", "delete_ra_connection_auth_x509_cert", config.auth_x509_cert, existing.auth_x509_cert);
+
+    // X.509 CA cert is a multi-value node: replacing requires deleting the old value.
+    {
+      const nv = (config.auth_x509_ca_cert || "").trim();
+      const ov = (existing.auth_x509_ca_cert || "").trim();
+      if (ov && ov !== nv) ops.push({ op: "delete_ra_connection_auth_x509_ca_cert", value: ov });
+      if (nv && nv !== ov) ops.push({ op: "set_ra_connection_auth_x509_ca_cert", value: nv });
+    }
+
+    // Pools (multi-value): reconcile add/remove.
+    {
+      const oldPools = existing.pools || [];
+      const newPools = config.pools || [];
+      for (const p of oldPools) if (!newPools.includes(p)) ops.push({ op: "delete_ra_connection_pool", value: p });
+      for (const p of newPools) if (!oldPools.includes(p)) ops.push({ op: "set_ra_connection_pool", value: p });
+    }
+
+    // PSK is never returned by the API, so only set it when the user typed one;
+    // leaving it blank preserves the existing key.
+    if (config.auth_psk) ops.push({ op: "set_ra_connection_auth_psk", value: config.auth_psk });
+
+    // always-send-cert flag.
+    if (config.auth_always_send_cert && !existing.auth_always_send_cert) {
+      ops.push({ op: "set_ra_connection_auth_always_send_cert" });
+    } else if (!config.auth_always_send_cert && existing.auth_always_send_cert) {
+      ops.push({ op: "delete_ra_connection_auth_always_send_cert" });
+    }
+
+    // Local users (multi-value): reconcile add/remove + password/disable.
+    {
+      const oldUsers = existing.local_users || [];
+      const newUsers = (config.local_users || []).filter((u) => u.username);
+      const oldByName = new Map(oldUsers.map((u) => [u.username, u]));
+      const newNames = new Set(newUsers.map((u) => u.username));
+      for (const u of oldUsers) if (!newNames.has(u.username)) ops.push({ op: "delete_ra_connection_auth_local_user", value: u.username });
+      for (const u of newUsers) {
+        const old = oldByName.get(u.username);
+        if (!old) ops.push({ op: "create_ra_connection_auth_local_user", value: u.username });
+        if (u.password) ops.push({ op: "set_ra_connection_auth_local_user_password", value: `${u.username}|${u.password}` });
+        if (u.disabled && !old?.disabled) ops.push({ op: "set_ra_connection_auth_local_user_disable", value: u.username });
+        else if (!u.disabled && old?.disabled) ops.push({ op: "delete_ra_connection_auth_local_user_disable", value: u.username });
+      }
+    }
+
     return this.batchConfigure(name, ops);
   }
 


### PR DESCRIPTION
The IPSec config parser emitted a nested shape while the frontend reads a flat one, so the Remote Access and Pool edit modals fell back to defaults: server mode showed Pre-Shared Secret instead of X.509, the pool checkbox was unchecked, and DNS servers appeared empty.

- Parser: emit flat fields the frontend expects (pools, auth_server_mode, auth_x509_ca_cert/cert, auth_always_send_cert, local_users, name_servers, range_start/stop) plus bind/childless/ppk/local_prefix/local_port.
- Modal: add the always-send-cert checkbox and a local-users editor.
- Edit is now non-destructive: updateRAConnection diffs the form against the existing connection and emits only the needed set/delete ops, preserving unmodeled fields (timeout, unique, dhcp-interface, ppk, ...) and never wiping the PSK. Added the supporting delete_* builder methods.

closes #410 