### PR TITLE
Fix IPSec S2S tunnel creation and VPN list scrolling

### DIFF
--- a/frontend/src/app/vpn/ipsec/page.tsx
+++ b/frontend/src/app/vpn/ipsec/page.tsx
@@ -252,7 +252,7 @@ function IPSecPageInner() {
               </TabsList>
             </div>
 
-            <ScrollArea className="flex-1">
+            <ScrollArea className="flex-1 min-h-0">
               <div className="p-6">
                 {/* Site-to-Site Tab */}
                 <TabsContent value="s2s" className="mt-0">

--- a/frontend/src/app/vpn/wireguard/page.tsx
+++ b/frontend/src/app/vpn/wireguard/page.tsx
@@ -315,7 +315,7 @@ export default function WireGuardPage() {
           </div>
 
           {/* Interface List */}
-          <ScrollArea className="flex-1">
+          <ScrollArea className="flex-1 min-h-0">
             <div className="p-2">
               {!config?.interfaces.length ? (
                 <div className="text-center py-8 px-4">
@@ -624,7 +624,7 @@ export default function WireGuardPage() {
                   </Button>
                 </div>
 
-                <ScrollArea className="flex-1">
+                <ScrollArea className="flex-1 min-h-0">
                   <div className="p-4">
                     {filteredPeers.length === 0 ? (
                       <div className="text-center py-12">

--- a/frontend/src/components/vpn/ipsec/SiteToSiteModal.tsx
+++ b/frontend/src/components/vpn/ipsec/SiteToSiteModal.tsx
@@ -189,6 +189,18 @@ export function SiteToSiteModal({
 
       const remoteAddrs = remoteAddresses.split(",").map((a) => a.trim()).filter(Boolean);
 
+      const tunnelConfigs = tunnels.map((t) => {
+        const localPrefixes = t.local_prefix.split(",").map((p) => p.trim()).filter(Boolean);
+        const remotePrefixes = t.remote_prefix.split(",").map((p) => p.trim()).filter(Boolean);
+        return {
+          number: t.number,
+          esp_group: t.esp_group || undefined,
+          local_prefix: localPrefixes.length > 0 ? localPrefixes : undefined,
+          remote_prefix: remotePrefixes.length > 0 ? remotePrefixes : undefined,
+          protocol: t.protocol || undefined,
+        };
+      });
+
       const result = await ipsecService.createS2SPeer(name.trim(), {
         ike_group: ikeGroup || undefined,
         default_esp_group: defaultEspGroup || undefined,
@@ -215,31 +227,13 @@ export function SiteToSiteModal({
         vti_ts_remote_prefix: vtiBind
           ? (vtiTsRemotePrefix.split(",").map((p) => p.trim()).filter(Boolean) || undefined)
           : undefined,
+        tunnels: tunnelConfigs.length > 0 ? tunnelConfigs : undefined,
       });
 
       if (!result.success) {
         setError(result.error || "Failed to create peer");
         setLoading(false);
         return;
-      }
-
-      // Create tunnels
-      for (const tunnel of tunnels) {
-        const localPrefixes = tunnel.local_prefix.split(",").map((p) => p.trim()).filter(Boolean);
-        const remotePrefixes = tunnel.remote_prefix.split(",").map((p) => p.trim()).filter(Boolean);
-
-        const tResult = await ipsecService.createS2STunnel(name.trim(), tunnel.number, {
-          esp_group: tunnel.esp_group || undefined,
-          local_prefix: localPrefixes.length > 0 ? localPrefixes : undefined,
-          remote_prefix: remotePrefixes.length > 0 ? remotePrefixes : undefined,
-          protocol: tunnel.protocol || undefined,
-        });
-
-        if (!tResult.success) {
-          setError(tResult.error || `Failed to create tunnel ${tunnel.number}`);
-          setLoading(false);
-          return;
-        }
       }
 
       onOpenChange(false);

--- a/frontend/src/lib/api/ipsec.ts
+++ b/frontend/src/lib/api/ipsec.ts
@@ -378,6 +378,13 @@ class IPSecService {
     vti_esp_group?: string;
     vti_ts_local_prefix?: string[];
     vti_ts_remote_prefix?: string[];
+    tunnels?: Array<{
+      number: string;
+      esp_group?: string;
+      local_prefix?: string[];
+      remote_prefix?: string[];
+      protocol?: string;
+    }>;
   }): Promise<VyOSResponse> {
     const ops: BatchOperation[] = [{ op: "create_s2s_peer" }];
     if (config.description) ops.push({ op: "set_s2s_peer_description", value: config.description });
@@ -413,6 +420,14 @@ class IPSecService {
         ops.push({ op: "set_s2s_peer_vti_ts_remote_prefix", value: prefix });
       }
     }
+    // Append tunnel operations so the peer and its tunnels are committed in a
+    // single atomic batch. A site-to-site peer without a tunnel (or VTI) is
+    // rejected by VyOS with a 400, so they must not be committed separately.
+    if (config.tunnels) {
+      for (const tunnel of config.tunnels) {
+        ops.push(...this.buildS2STunnelOps(tunnel.number, tunnel));
+      }
+    }
     return this.batchConfigure(name, ops);
   }
 
@@ -424,12 +439,12 @@ class IPSecService {
   // S2S Tunnel Operations
   // ==========================================================================
 
-  async createS2STunnel(peerName: string, tunnelNum: string, config: {
+  private buildS2STunnelOps(tunnelNum: string, config: {
     esp_group?: string;
     local_prefix?: string[];
     remote_prefix?: string[];
     protocol?: string;
-  }): Promise<VyOSResponse> {
+  }): BatchOperation[] {
     const ops: BatchOperation[] = [{ op: "create_s2s_peer_tunnel", value: tunnelNum }];
     if (config.esp_group) ops.push({ op: "set_s2s_peer_tunnel_esp_group", value: `${tunnelNum}|${config.esp_group}` });
     if (config.local_prefix) {
@@ -443,7 +458,16 @@ class IPSecService {
       }
     }
     if (config.protocol) ops.push({ op: "set_s2s_peer_tunnel_protocol", value: `${tunnelNum}|${config.protocol}` });
-    return this.batchConfigure(peerName, ops);
+    return ops;
+  }
+
+  async createS2STunnel(peerName: string, tunnelNum: string, config: {
+    esp_group?: string;
+    local_prefix?: string[];
+    remote_prefix?: string[];
+    protocol?: string;
+  }): Promise<VyOSResponse> {
+    return this.batchConfigure(peerName, this.buildS2STunnelOps(tunnelNum, config));
   }
 
   async deleteS2STunnel(peerName: string, tunnelNum: string): Promise<VyOSResponse> {


### PR DESCRIPTION
Send the site-to-site peer and its tunnels in a single atomic batch so VyOS no longer rejects the peer-only commit with a 400 when tunnels are configured. Add min-h-0 to the IPSec and WireGuard list ScrollAreas so long peer/interface lists scroll instead of being clipped.

Closes #412
Closes #413