### PR TITLE
Add in-app bug reporter via GitHub device flow

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -78,6 +78,7 @@ from routers.rpki import rpki as rpki_router
 from routers.traffic_engineering import traffic_engineering as te_router
 from routers.broadcast_relay import broadcast_relay as broadcast_relay_router
 from routers.lldp import lldp as lldp_router
+from routers.bug_report import bug_report as bug_report_router
 from routers.ndp_proxy import ndp_proxy as ndp_proxy_router
 from routers.ntp import ntp as ntp_router
 from routers.snmp import snmp as snmp_router
@@ -395,6 +396,7 @@ app.include_router(rpki_router.router)
 app.include_router(te_router.router)
 app.include_router(broadcast_relay_router.router)
 app.include_router(lldp_router.router)
+app.include_router(bug_report_router.router)
 app.include_router(ndp_proxy_router.router)
 app.include_router(ntp_router.router)
 app.include_router(snmp_router.router)

--- a/backend/routers/bug_report/bug_report.py
+++ b/backend/routers/bug_report/bug_report.py
@@ -1,0 +1,411 @@
+"""Bug Reporter Router.
+
+Lets authenticated users file a GitHub issue from inside VyManager using *their
+own* GitHub account, via the OAuth Device Authorization flow.
+
+Security / privacy design (see also redaction.py):
+  - The GitHub user token NEVER reaches the browser. It is held only in
+    backend memory, wrapped in ``_SecureStr`` so it cannot be logged or
+    JSON-serialised, with a short TTL, and is wiped immediately after the issue
+    is created (wipe-after-submit).
+  - Only a PUBLIC OAuth ``client_id`` is shipped; no client secret and no
+    redirect URL are required (that is the whole point of the device flow), so
+    a single configuration works for every self-hosted deployment.
+  - The target ``owner/repo`` is fixed by the operator via env. It is never
+    taken from the request, so a user cannot redirect issues elsewhere or
+    point the token at an arbitrary GitHub resource.
+  - Redaction is enforced HERE, server-side, at submit time — the client only
+    ever sends structured fields, never raw markdown, and the backend
+    assembles + redacts the final body itself. The in-app preview is generated
+    by the same code path, so what the user reviews is exactly what is sent.
+  - Per-user and global rate limits guard against issue spam.
+
+Endpoints (all require an authenticated session via the auth middleware):
+  GET  /bug-report/status              — feature enabled? user connected?
+  POST /bug-report/github/device/start — begin device authorization
+  POST /bug-report/github/device/poll  — poll for authorization completion
+  POST /bug-report/preview             — assembled + redacted markdown preview
+  POST /bug-report/submit              — create the issue, then wipe the token
+"""
+
+import logging
+import os
+import re
+import time
+from collections import deque
+from typing import Deque, Dict, Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from middleware.session import _SecureStr
+from .redaction import redact
+
+logger = logging.getLogger(__name__)
+
+# Mounted under /vyos so it is reached via the frontend's existing
+# /api/vyos/[...path] proxy (the app's generic backend-proxy namespace).
+router = APIRouter(prefix="/vyos/bug-report", tags=["bug-report"])
+
+# ============================================================================
+# Configuration (operator-supplied, never from the request)
+# ============================================================================
+
+# Project-wide defaults so the feature works out of the box with NO per-deployment
+# configuration. Both values are safe to ship in source:
+#   - The OAuth client_id is PUBLIC. The device flow has no client secret, so
+#     there is nothing secret to leak (GitHub's own CLI ships its client_id too).
+#   - The repo is the VyManager issue tracker — the same for every deployment.
+# The env vars exist only so a fork can route bug reports to its own repo/app.
+DEFAULT_GITHUB_CLIENT_ID = "Ov23lignyrCHrXxi5tg7"  # VyManager OAuth App (device flow enabled)
+DEFAULT_GITHUB_REPO = "Community-VyProjects/VyManager"
+
+GITHUB_CLIENT_ID = os.getenv("GITHUB_BUG_REPORT_CLIENT_ID", DEFAULT_GITHUB_CLIENT_ID).strip()
+GITHUB_REPO = os.getenv("GITHUB_BUG_REPORT_REPO", DEFAULT_GITHUB_REPO).strip()  # "owner/repo"
+# Minimal scope: create issues on a public repo. The token cannot push code or
+# read private repositories. Use "repo" only if the target repo is private.
+GITHUB_SCOPE = os.getenv("GITHUB_BUG_REPORT_SCOPE", "public_repo").strip()
+
+GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+# Token / device-code lifetimes and abuse limits.
+TOKEN_TTL_SECONDS = 600          # connected token is usable for 10 min, then expires
+DEVICE_TTL_SECONDS = 900         # device authorization window
+MAX_BODY_CHARS = 60000           # GitHub hard limit is 65536; stay under it
+RATE_LIMIT_PER_USER = 5          # issues per user per window
+RATE_LIMIT_WINDOW = 3600         # seconds
+RATE_LIMIT_GLOBAL = 50           # issues across all users per window
+
+
+def feature_enabled() -> bool:
+    return bool(GITHUB_CLIENT_ID and _REPO_RE.match(GITHUB_REPO))
+
+
+# ============================================================================
+# In-memory state (never persisted to disk/DB)
+# ============================================================================
+
+# user_id -> {"device_code": _SecureStr, "interval": int, "expires": float}
+_pending_device: Dict[str, dict] = {}
+# user_id -> {"token": _SecureStr, "expires": float}
+_tokens: Dict[str, dict] = {}
+# user_id -> deque[timestamps]; plus a global deque for the system-wide cap
+_user_submits: Dict[str, Deque[float]] = {}
+_global_submits: Deque[float] = deque()
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _get_user_id(request: Request) -> str:
+    user = getattr(request.state, "user", None)
+    if not user or "id" not in user:
+        # Should not happen behind the auth middleware, but fail closed.
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user["id"]
+
+
+def _store_token(user_id: str, token: str) -> None:
+    _tokens[user_id] = {"token": _SecureStr(token), "expires": _now() + TOKEN_TTL_SECONDS}
+
+
+def _get_token(user_id: str) -> Optional[str]:
+    entry = _tokens.get(user_id)
+    if not entry:
+        return None
+    if entry["expires"] < _now():
+        _wipe_token(user_id)
+        return None
+    return entry["token"].value
+
+
+def _wipe_token(user_id: str) -> None:
+    _tokens.pop(user_id, None)
+
+
+def _check_rate_limit(user_id: str) -> None:
+    now = _now()
+    cutoff = now - RATE_LIMIT_WINDOW
+
+    while _global_submits and _global_submits[0] < cutoff:
+        _global_submits.popleft()
+    if len(_global_submits) >= RATE_LIMIT_GLOBAL:
+        raise HTTPException(status_code=429, detail="Too many bug reports right now. Please try again later.")
+
+    dq = _user_submits.setdefault(user_id, deque())
+    while dq and dq[0] < cutoff:
+        dq.popleft()
+    if len(dq) >= RATE_LIMIT_PER_USER:
+        raise HTTPException(status_code=429, detail="You have submitted too many bug reports. Please try again later.")
+
+
+def _record_submit(user_id: str) -> None:
+    now = _now()
+    _global_submits.append(now)
+    _user_submits.setdefault(user_id, deque()).append(now)
+
+
+def _ensure_enabled() -> None:
+    if not feature_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail="Bug reporting is not configured on this server.",
+        )
+
+
+# ============================================================================
+# Pydantic models
+# ============================================================================
+
+CATEGORIES = {"bug", "crash", "ui", "performance", "other"}
+
+
+class StatusResponse(BaseModel):
+    enabled: bool
+    connected: bool
+    repo: Optional[str] = None
+
+
+class DeviceStartResponse(BaseModel):
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+
+
+class DevicePollResponse(BaseModel):
+    status: str  # "pending" | "connected" | "expired" | "denied" | "error"
+
+
+class Diagnostics(BaseModel):
+    app_version: Optional[str] = None
+    vyos_version: Optional[str] = None
+    browser: Optional[str] = None
+    page: Optional[str] = None
+
+
+class ReportRequest(BaseModel):
+    title: str = Field(..., min_length=3, max_length=200)
+    category: str = Field("bug")
+    description: str = Field(..., min_length=10, max_length=20000)
+    include_diagnostics: bool = False
+    diagnostics: Optional[Diagnostics] = None
+    error_text: Optional[str] = Field(None, max_length=30000)
+
+
+class PreviewResponse(BaseModel):
+    title: str
+    body: str
+
+
+class SubmitResponse(BaseModel):
+    url: str
+    number: int
+
+
+# ============================================================================
+# Body assembly (single source of truth for preview AND submit)
+# ============================================================================
+
+def _safe_category(category: str) -> str:
+    return category if category in CATEGORIES else "other"
+
+
+def _build_issue(req: ReportRequest) -> tuple[str, str]:
+    """Assemble the issue title and markdown body from structured fields, then
+    redact. Both the preview and submit endpoints call this, guaranteeing the
+    user reviews exactly what gets sent."""
+    title = f"[{_safe_category(req.category)}] {req.title.strip()}"
+
+    parts = ["### Description", req.description.strip(), ""]
+
+    if req.error_text and req.error_text.strip():
+        parts += [
+            "### Error / stack trace",
+            "```",
+            req.error_text.strip(),
+            "```",
+            "",
+        ]
+
+    if req.include_diagnostics and req.diagnostics:
+        d = req.diagnostics
+        diag_lines = []
+        if d.app_version:
+            diag_lines.append(f"- VyManager: {d.app_version}")
+        if d.vyos_version:
+            diag_lines.append(f"- VyOS: {d.vyos_version}")
+        if d.browser:
+            diag_lines.append(f"- Browser: {d.browser}")
+        if d.page:
+            diag_lines.append(f"- Page: {d.page}")
+        if diag_lines:
+            parts += ["### Diagnostics", *diag_lines, ""]
+
+    parts.append("_Submitted from VyManager. Sensitive data is automatically redacted; please review before posting._")
+
+    body = "\n".join(parts)
+
+    # The privacy boundary: redact the FINAL assembled text, server-side.
+    title = redact(title)
+    body = redact(body)
+
+    if len(body) > MAX_BODY_CHARS:
+        body = body[:MAX_BODY_CHARS] + "\n\n_…truncated._"
+    return title, body
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+@router.get("/status", response_model=StatusResponse)
+async def status(request: Request) -> StatusResponse:
+    user_id = _get_user_id(request)
+    if not feature_enabled():
+        return StatusResponse(enabled=False, connected=False)
+    return StatusResponse(
+        enabled=True,
+        connected=_get_token(user_id) is not None,
+        repo=GITHUB_REPO,
+    )
+
+
+@router.post("/github/device/start", response_model=DeviceStartResponse)
+async def device_start(request: Request) -> DeviceStartResponse:
+    _ensure_enabled()
+    user_id = _get_user_id(request)
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            GITHUB_DEVICE_CODE_URL,
+            headers={"Accept": "application/json"},
+            data={"client_id": GITHUB_CLIENT_ID, "scope": GITHUB_SCOPE},
+        )
+    if resp.status_code != 200:
+        logger.warning("GitHub device-code request failed: %s", resp.status_code)
+        raise HTTPException(status_code=502, detail="Could not start GitHub authorization.")
+
+    data = resp.json()
+    device_code = data.get("device_code")
+    user_code = data.get("user_code")
+    verification_uri = data.get("verification_uri")
+    if not device_code or not user_code or not verification_uri:
+        raise HTTPException(status_code=502, detail="Unexpected response from GitHub.")
+
+    interval = int(data.get("interval", 5))
+    _pending_device[user_id] = {
+        "device_code": _SecureStr(device_code),
+        "interval": interval,
+        "expires": _now() + min(int(data.get("expires_in", DEVICE_TTL_SECONDS)), DEVICE_TTL_SECONDS),
+    }
+
+    return DeviceStartResponse(
+        user_code=user_code,
+        verification_uri=verification_uri,
+        expires_in=int(data.get("expires_in", DEVICE_TTL_SECONDS)),
+        interval=interval,
+    )
+
+
+@router.post("/github/device/poll", response_model=DevicePollResponse)
+async def device_poll(request: Request) -> DevicePollResponse:
+    _ensure_enabled()
+    user_id = _get_user_id(request)
+
+    pending = _pending_device.get(user_id)
+    if not pending:
+        return DevicePollResponse(status="expired")
+    if pending["expires"] < _now():
+        _pending_device.pop(user_id, None)
+        return DevicePollResponse(status="expired")
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            GITHUB_TOKEN_URL,
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": GITHUB_CLIENT_ID,
+                "device_code": pending["device_code"].value,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+        )
+    data = resp.json() if resp.status_code == 200 else {}
+
+    access_token = data.get("access_token")
+    if access_token:
+        _store_token(user_id, access_token)
+        _pending_device.pop(user_id, None)
+        return DevicePollResponse(status="connected")
+
+    error = data.get("error")
+    if error == "authorization_pending" or error == "slow_down":
+        return DevicePollResponse(status="pending")
+    if error == "expired_token":
+        _pending_device.pop(user_id, None)
+        return DevicePollResponse(status="expired")
+    if error == "access_denied":
+        _pending_device.pop(user_id, None)
+        return DevicePollResponse(status="denied")
+
+    return DevicePollResponse(status="pending")
+
+
+@router.post("/preview", response_model=PreviewResponse)
+async def preview(request: Request, body: ReportRequest) -> PreviewResponse:
+    _ensure_enabled()
+    _get_user_id(request)  # auth check
+    title, md = _build_issue(body)
+    return PreviewResponse(title=title, body=md)
+
+
+@router.post("/submit", response_model=SubmitResponse)
+async def submit(request: Request, body: ReportRequest) -> SubmitResponse:
+    _ensure_enabled()
+    user_id = _get_user_id(request)
+
+    token = _get_token(user_id)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not connected to GitHub. Please connect first.")
+
+    _check_rate_limit(user_id)
+
+    title, md = _build_issue(body)
+    labels = ["from-app"]
+    cat = _safe_category(body.category)
+    if cat != "other":
+        labels.append(cat)
+
+    owner, repo = GITHUB_REPO.split("/", 1)
+    try:
+        async with httpx.AsyncClient(timeout=20) as client:
+            resp = await client.post(
+                f"{GITHUB_API_URL}/repos/{owner}/{repo}/issues",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"token {token}",
+                    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+                },
+                json={"title": title, "body": md, "labels": labels},
+            )
+    finally:
+        # Wipe-after-submit: the token is single-use from our side regardless of
+        # whether the GitHub call succeeded or raised.
+        _wipe_token(user_id)
+
+    if resp.status_code == 201:
+        _record_submit(user_id)
+        data = resp.json()
+        return SubmitResponse(url=data["html_url"], number=data["number"])
+
+    if resp.status_code in (401, 403):
+        raise HTTPException(status_code=401, detail="GitHub authorization failed or was revoked. Please reconnect.")
+    logger.warning("GitHub issue creation failed: %s", resp.status_code)
+    raise HTTPException(status_code=502, detail="GitHub rejected the issue. Please try again.")

--- a/backend/routers/bug_report/redaction.py
+++ b/backend/routers/bug_report/redaction.py
@@ -27,11 +27,19 @@ REDACTED = "[REDACTED]"
 REDACTED_PEM = "[REDACTED CERTIFICATE/KEY]"
 REDACTED_IP = "[REDACTED PUBLIC IP]"
 
-# 1. PEM blocks — certificates and private keys. Multiline, non-greedy.
-_PEM_RE = re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL)
+# 1. PEM blocks — certificates and private keys. The label class is restricted
+#    to letters/digits/spaces (disjoint from '-') and bounded, so the engine
+#    cannot backtrack character-by-character — avoids the polynomial-time ReDoS
+#    that an unbounded "[^-]+" would allow on adversarial input.
+_PEM_RE = re.compile(
+    r"-----BEGIN [A-Za-z0-9 ]{1,64}-----.*?-----END [A-Za-z0-9 ]{1,64}-----",
+    re.DOTALL,
+)
 
 # 2. key: value / key = value secrets. The key is preserved, the value redacted.
 #    Matches VyOS-style (password 'xxx'), JSON ("token": "xxx") and env (API_KEY=xxx).
+#    The value run is matched deterministically (no closing-quote backreference),
+#    which both avoids backtracking and still scrubs unbalanced/unclosed quotes.
 _SECRET_KEYS = (
     r"pre-?shared-?secret|preshared-?key|passphrase|password|passwd|"
     r"secret|client[-_]?secret|api[-_]?key|apikey|access[-_]?token|"
@@ -41,8 +49,7 @@ _SECRET_KV_RE = re.compile(
     r"(?i)\b(" + _SECRET_KEYS + r")\b"      # 1: key
     r"(\s*['\"]?\s*[:=]\s*|\s+)"            # 2: separator (':', '=', or whitespace)
     r"(['\"]?)"                             # 3: opening quote (maybe empty)
-    r"([^\s'\"]{3,})"                       # 4: the secret value
-    r"\3"                                   # matching closing quote
+    r"([^\s'\"]{3,})"                       # 4: the secret value (a quote/space ends it)
 )
 
 # 3. HTTP bearer tokens.
@@ -67,8 +74,9 @@ _CGNAT = ipaddress.ip_network("100.64.0.0/10")
 
 
 def _redact_kv(m: Match[str]) -> str:
-    quote = m.group(3)
-    return f"{m.group(1)}{m.group(2)}{quote}{REDACTED}{quote}"
+    # group(3) is the opening quote (if any); any closing quote is left in place
+    # since it is no longer part of the match.
+    return f"{m.group(1)}{m.group(2)}{m.group(3)}{REDACTED}"
 
 
 def _redact_ipv4(m: Match[str]) -> str:

--- a/backend/routers/bug_report/redaction.py
+++ b/backend/routers/bug_report/redaction.py
@@ -1,0 +1,130 @@
+"""Server-side redaction for user-submitted bug reports.
+
+This module is the authoritative privacy boundary for the bug reporter. Because
+a malicious or compromised browser could bypass any client-side scrubbing, the
+backend re-runs this redaction on the final text immediately before it is sent
+to GitHub. The design favours OVER-redaction: when in doubt, redact.
+
+What it removes:
+  - PEM blocks (certificates, private keys)
+  - key/value secrets (password, passphrase, pre-shared-secret, api-key, token...)
+  - HTTP bearer tokens
+  - WireGuard-style and other long base64 keys
+  - long hexadecimal blobs (hashes, keys)
+  - public IPv4 / IPv6 addresses (private/loopback/link-local ranges are kept,
+    because they are not sensitive and are useful for debugging)
+
+What it deliberately does NOT do: guarantee that every possible secret typed in
+free-text is caught. That is why the UI also forces a human review step before
+anything is submitted.
+"""
+
+import ipaddress
+import re
+from typing import Match
+
+REDACTED = "[REDACTED]"
+REDACTED_PEM = "[REDACTED CERTIFICATE/KEY]"
+REDACTED_IP = "[REDACTED PUBLIC IP]"
+
+# 1. PEM blocks — certificates and private keys. Multiline, non-greedy.
+_PEM_RE = re.compile(r"-----BEGIN [^-]+-----.*?-----END [^-]+-----", re.DOTALL)
+
+# 2. key: value / key = value secrets. The key is preserved, the value redacted.
+#    Matches VyOS-style (password 'xxx'), JSON ("token": "xxx") and env (API_KEY=xxx).
+_SECRET_KEYS = (
+    r"pre-?shared-?secret|preshared-?key|passphrase|password|passwd|"
+    r"secret|client[-_]?secret|api[-_]?key|apikey|access[-_]?token|"
+    r"auth[-_]?token|authorization|private-?key|psk|token"
+)
+_SECRET_KV_RE = re.compile(
+    r"(?i)\b(" + _SECRET_KEYS + r")\b"      # 1: key
+    r"(\s*['\"]?\s*[:=]\s*|\s+)"            # 2: separator (':', '=', or whitespace)
+    r"(['\"]?)"                             # 3: opening quote (maybe empty)
+    r"([^\s'\"]{3,})"                       # 4: the secret value
+    r"\3"                                   # matching closing quote
+)
+
+# 3. HTTP bearer tokens.
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]+")
+
+# 4. WireGuard keys and other long base64 blobs (32-byte key -> 44 base64 chars).
+_B64KEY_RE = re.compile(r"\b[A-Za-z0-9+/]{43,}={0,2}")
+
+# 5. Long hexadecimal blobs (sha256 hashes, hex-encoded keys, etc.).
+_HEX_RE = re.compile(r"\b[0-9a-fA-F]{32,}\b")
+
+# 6. IP addresses. The regex is intentionally permissive; each candidate is
+#    validated with the ipaddress module so non-addresses (timestamps, version
+#    strings) are left untouched, and private ranges are preserved. The IPv6
+#    pattern allows empty groups so it matches "::"-compressed addresses.
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_IPV6_RE = re.compile(r"(?<![:.\w])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}(?![:.\w])")
+
+# Carrier-grade NAT (RFC 6598). Not sensitive; some ipaddress versions do not
+# flag it as private, so keep it explicitly.
+_CGNAT = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _redact_kv(m: Match[str]) -> str:
+    quote = m.group(3)
+    return f"{m.group(1)}{m.group(2)}{quote}{REDACTED}{quote}"
+
+
+def _redact_ipv4(m: Match[str]) -> str:
+    token = m.group(0)
+    try:
+        ip = ipaddress.IPv4Address(token)
+    except ValueError:
+        return token  # not a real address (e.g. a version string) — leave it
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+        or ip in _CGNAT
+    ):
+        return token
+    return REDACTED_IP
+
+
+def _redact_ipv6(m: Match[str]) -> str:
+    token = m.group(0)
+    try:
+        ip = ipaddress.IPv6Address(token)
+    except ValueError:
+        return token
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    ):
+        return token
+    return REDACTED_IP
+
+
+def redact(text: str) -> str:
+    """Return ``text`` with sensitive content replaced by redaction markers.
+
+    Order matters: structured/high-confidence patterns (PEM, key/value secrets,
+    bearer tokens) run before the broad base64/hex/IP catch-alls so that, e.g.,
+    a private key body is removed as one PEM block rather than leaving fragments.
+    """
+    if not text:
+        return text
+
+    text = _PEM_RE.sub(REDACTED_PEM, text)
+    # Bearer runs before the key/value pass so that "Authorization: Bearer <tok>"
+    # has the token removed (the kv pass alone would only redact the word "Bearer").
+    text = _BEARER_RE.sub("Bearer " + REDACTED, text)
+    text = _SECRET_KV_RE.sub(_redact_kv, text)
+    text = _B64KEY_RE.sub(REDACTED, text)
+    text = _HEX_RE.sub(REDACTED, text)
+    text = _IPV4_RE.sub(_redact_ipv4, text)
+    text = _IPV6_RE.sub(_redact_ipv6, text)
+    return text

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -87,7 +87,32 @@ async def banner_events(request: Request):
     """
     await require_read_permission(request, FeatureGroup.CONFIGURATION)
 
-    instance_id = request.state.instance["id"]
+    instance = getattr(request.state, "instance", None)
+    if not instance:
+        # No active instance yet (e.g. on the site-selection screen). Return an
+        # idle keepalive stream instead of erroring, so the client's EventSource
+        # doesn't spin in an error/reconnect loop. A real stream is established
+        # once an instance is selected and this endpoint is reconnected.
+        async def idle_stream():
+            try:
+                yield _format_sse("banner_state", {})
+                while True:
+                    await asyncio.sleep(30)
+                    yield ": keepalive\n\n"
+            except asyncio.CancelledError:
+                pass
+
+        return StreamingResponse(
+            idle_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+
+    instance_id = instance["id"]
     user_id = request.state.user["id"]
     db_pool = request.app.state.db_pool
     queue = event_manager.subscribe(instance_id)

--- a/backend/tests/test_bug_report_redaction.py
+++ b/backend/tests/test_bug_report_redaction.py
@@ -1,0 +1,115 @@
+"""Unit tests for the bug-report redaction boundary.
+
+These run in isolation (no VyOS, no network) per the project's testing guidance.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from routers.bug_report.redaction import redact, REDACTED, REDACTED_IP, REDACTED_PEM
+
+
+def test_pem_block_is_removed():
+    text = (
+        "here is my key:\n"
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA1234567890abcdef\n"
+        "abcdefghijklmnopqrstuvwxyz0987654\n"
+        "-----END RSA PRIVATE KEY-----\n"
+        "thanks"
+    )
+    out = redact(text)
+    assert REDACTED_PEM in out
+    assert "MIIEowIBAAKCAQEA" not in out
+    assert "BEGIN RSA PRIVATE KEY" not in out
+
+
+def test_certificate_block_is_removed():
+    text = "-----BEGIN CERTIFICATE-----\nAAAABBBBCCCCDDDD\n-----END CERTIFICATE-----"
+    out = redact(text)
+    assert REDACTED_PEM in out
+    assert "AAAABBBBCCCC" not in out
+
+
+def test_password_kv_redacted_preserving_key():
+    for sample in [
+        "set vpn ipsec authentication password 'SuperSecret123'",
+        '"api_key": "abcd1234efgh"',
+        "PASSWORD=hunter2horse",
+        "pre-shared-secret = MyPSKvalue99",
+    ]:
+        out = redact(sample)
+        assert REDACTED in out, sample
+        assert "SuperSecret123" not in out
+        assert "abcd1234efgh" not in out
+        assert "hunter2horse" not in out
+        assert "MyPSKvalue99" not in out
+
+
+def test_bearer_token_redacted():
+    out = redact("Authorization: Bearer ghp_AbCdEf123456789Token")
+    assert "ghp_AbCdEf123456789Token" not in out
+    assert REDACTED in out
+
+
+def test_wireguard_key_redacted():
+    wg = "WJ8sKzQ2Z1bN3mF4pV6rT8yU0wX2aC5dE7gH9jK1lMq="  # 44-char base64 (43 + pad)
+    out = redact(f"public-key {wg}")
+    assert wg not in out
+    assert REDACTED in out
+
+
+def test_long_hex_blob_redacted():
+    h = "a" * 64
+    out = redact(f"hash is {h} done")
+    assert h not in out
+    assert REDACTED in out
+
+
+def test_public_ipv4_redacted():
+    out = redact("server at 8.8.8.8 failed")
+    assert "8.8.8.8" not in out
+    assert REDACTED_IP in out
+
+
+def test_private_ipv4_kept():
+    for ip in ["10.0.0.1", "192.168.1.1", "172.16.5.4", "127.0.0.1", "100.64.64.50"]:
+        out = redact(f"connecting to {ip}")
+        assert ip in out, f"private/special IP should be kept: {ip}"
+
+
+def test_version_string_not_treated_as_ip():
+    # A semver-with-suffix is not a valid IPv4 and must be left untouched.
+    # (A bare 4-octet "1.0.0.3" IS a valid public IP and is intentionally
+    # redacted — over-redaction is acceptable for the safety boundary.)
+    out = redact("VyManager version 1.0.0-beta.3 running")
+    assert "1.0.0-beta.3" in out
+
+
+def test_public_ipv6_redacted_private_kept():
+    assert REDACTED_IP in redact("addr 2606:4700:4700::1111 here")
+    assert "fe80::1" in redact("link local fe80::1 ok")
+    assert "::1" in redact("loopback ::1 ok")
+
+
+def test_empty_string():
+    assert redact("") == ""
+
+
+if __name__ == "__main__":
+    import traceback
+
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except Exception:
+                failures += 1
+                print(f"FAIL {name}")
+                traceback.print_exc()
+    print(f"\n{'ALL PASSED' if not failures else str(failures) + ' FAILED'}")
+    sys.exit(1 if failures else 0)

--- a/backend/tests/test_bug_report_redaction.py
+++ b/backend/tests/test_bug_report_redaction.py
@@ -94,6 +94,25 @@ def test_public_ipv6_redacted_private_kept():
     assert "::1" in redact("loopback ::1 ok")
 
 
+def test_unbalanced_quote_secret_still_redacted():
+    # No closing quote — must still scrub the value (hardened KV regex).
+    out = redact('password "secretvalue')
+    assert "secretvalue" not in out
+    assert REDACTED in out
+
+
+def test_pem_redos_pathological_input_is_fast():
+    # Adversarial input that the old unbounded "[^-]+" matched in polynomial
+    # time. The bounded label class must keep this near-linear.
+    import time
+
+    evil = "-----BEGIN ," * 20000
+    start = time.perf_counter()
+    redact(evil)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"redaction too slow on adversarial input: {elapsed:.3f}s"
+
+
 def test_empty_string():
     assert redact("") == ""
 

--- a/frontend/src/components/bug-report/BugReportModal.tsx
+++ b/frontend/src/components/bug-report/BugReportModal.tsx
@@ -28,6 +28,11 @@ import {
   type ReportRequest,
   type ReportPreview,
 } from "@/lib/api/bug-report";
+import {
+  getRecentErrors,
+  formatErrorsForReport,
+  hasRecentErrors,
+} from "@/lib/error-capture";
 
 interface BugReportModalProps {
   open: boolean;
@@ -60,6 +65,7 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
   const [description, setDescription] = useState("");
   const [errorText, setErrorText] = useState("");
   const [includeDiagnostics, setIncludeDiagnostics] = useState(true);
+  const [autoAttached, setAutoAttached] = useState(false);
 
   // Preview / result
   const [preview, setPreview] = useState<ReportPreview | null>(null);
@@ -87,6 +93,7 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
     setDescription("");
     setErrorText("");
     setIncludeDiagnostics(true);
+    setAutoAttached(false);
     setPreview(null);
     setIssueUrl("");
   }, [stopPolling]);
@@ -97,6 +104,17 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
       resetAll();
       return;
     }
+
+    // Auto-attach any recently captured errors so the user doesn't have to find
+    // and paste a stack trace themselves.
+    if (hasRecentErrors()) {
+      const recent = getRecentErrors();
+      setErrorText(formatErrorsForReport(recent));
+      // A failed config operation is a "bug"; an uncaught/render error is a "crash".
+      setCategory(recent[recent.length - 1].kind === "api" ? "bug" : "crash");
+      setAutoAttached(true);
+    }
+
     let cancelled = false;
     (async () => {
       try {
@@ -326,7 +344,27 @@ export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="br-error">Error / stack trace (optional)</Label>
+              <div className="flex items-center justify-between gap-2">
+                <Label htmlFor="br-error">Error / stack trace (optional)</Label>
+                {errorText.trim() && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setErrorText("");
+                      setAutoAttached(false);
+                    }}
+                    className="text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              {autoAttached && (
+                <p className="text-xs text-muted-foreground">
+                  Recent errors were detected and attached automatically. Review and edit
+                  or clear them below.
+                </p>
+              )}
               <Textarea
                 id="br-error"
                 value={errorText}

--- a/frontend/src/components/bug-report/BugReportModal.tsx
+++ b/frontend/src/components/bug-report/BugReportModal.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AlertCircle, CheckCircle2, ExternalLink, Github, Loader2, ShieldCheck } from "lucide-react";
+import {
+  bugReportService,
+  type ReportRequest,
+  type ReportPreview,
+} from "@/lib/api/bug-report";
+
+interface BugReportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type Step = "loading" | "connect" | "form" | "preview" | "done";
+
+const CATEGORIES = [
+  { value: "bug", label: "Bug" },
+  { value: "crash", label: "Crash / error" },
+  { value: "ui", label: "UI / display" },
+  { value: "performance", label: "Performance" },
+  { value: "other", label: "Other" },
+];
+
+export function BugReportModal({ open, onOpenChange }: BugReportModalProps) {
+  const [step, setStep] = useState<Step>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Device-flow state
+  const [userCode, setUserCode] = useState<string>("");
+  const [verificationUri, setVerificationUri] = useState<string>("");
+  const [polling, setPolling] = useState(false);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState("bug");
+  const [description, setDescription] = useState("");
+  const [errorText, setErrorText] = useState("");
+  const [includeDiagnostics, setIncludeDiagnostics] = useState(true);
+
+  // Preview / result
+  const [preview, setPreview] = useState<ReportPreview | null>(null);
+  const [issueUrl, setIssueUrl] = useState<string>("");
+
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) {
+      clearTimeout(pollTimer.current);
+      pollTimer.current = null;
+    }
+    setPolling(false);
+  }, []);
+
+  const resetAll = useCallback(() => {
+    stopPolling();
+    setStep("loading");
+    setError(null);
+    setBusy(false);
+    setUserCode("");
+    setVerificationUri("");
+    setTitle("");
+    setCategory("bug");
+    setDescription("");
+    setErrorText("");
+    setIncludeDiagnostics(true);
+    setPreview(null);
+    setIssueUrl("");
+  }, [stopPolling]);
+
+  // Load connection status when opening.
+  useEffect(() => {
+    if (!open) {
+      resetAll();
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await bugReportService.getStatus();
+        if (cancelled) return;
+        if (!status.enabled) {
+          setError("Bug reporting is not configured on this server.");
+          setStep("connect");
+          return;
+        }
+        setStep(status.connected ? "form" : "connect");
+      } catch {
+        if (!cancelled) {
+          setError("Could not load bug reporter.");
+          setStep("connect");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, resetAll]);
+
+  useEffect(() => () => stopPolling(), [stopPolling]);
+
+  const buildRequest = (): ReportRequest => ({
+    title: title.trim(),
+    category,
+    description: description.trim(),
+    error_text: errorText.trim() || undefined,
+    include_diagnostics: includeDiagnostics,
+    diagnostics: includeDiagnostics
+      ? {
+          browser: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+          page: typeof window !== "undefined" ? window.location.pathname : undefined,
+        }
+      : undefined,
+  });
+
+  const poll = useCallback(
+    async (intervalMs: number) => {
+      try {
+        const res = await bugReportService.devicePoll();
+        if (res.status === "connected") {
+          stopPolling();
+          setStep("form");
+          return;
+        }
+        if (res.status === "expired" || res.status === "denied") {
+          stopPolling();
+          setError(
+            res.status === "expired"
+              ? "The authorization request expired. Please try again."
+              : "Authorization was denied."
+          );
+          return;
+        }
+        pollTimer.current = setTimeout(() => poll(intervalMs), intervalMs);
+      } catch {
+        pollTimer.current = setTimeout(() => poll(intervalMs), intervalMs);
+      }
+    },
+    [stopPolling]
+  );
+
+  const handleConnect = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await bugReportService.deviceStart();
+      setUserCode(res.user_code);
+      setVerificationUri(res.verification_uri);
+      setPolling(true);
+      const intervalMs = Math.max(res.interval, 5) * 1000;
+      pollTimer.current = setTimeout(() => poll(intervalMs), intervalMs);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not start GitHub authorization.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const validateForm = (): string | null => {
+    if (title.trim().length < 3) return "Please enter a short title (at least 3 characters).";
+    if (description.trim().length < 10) return "Please describe the problem (at least 10 characters).";
+    return null;
+  };
+
+  const handlePreview = async () => {
+    const v = validateForm();
+    if (v) {
+      setError(v);
+      return;
+    }
+    setError(null);
+    setBusy(true);
+    try {
+      const p = await bugReportService.preview(buildRequest());
+      setPreview(p);
+      setStep("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not generate preview.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await bugReportService.submit(buildRequest());
+      setIssueUrl(res.url);
+      setStep("done");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Could not submit the report.";
+      setError(msg);
+      // A revoked/expired token sends us back to connect.
+      if (/connect|authoriz/i.test(msg)) setStep("connect");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Github className="h-5 w-5" />
+            Report a Bug
+          </DialogTitle>
+          <DialogDescription>
+            File a GitHub issue using your own GitHub account.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {step === "loading" && (
+          <div className="flex items-center justify-center py-10 text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
+          </div>
+        )}
+
+        {step === "connect" && (
+          <div className="space-y-4 py-2">
+            {!userCode ? (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  Connect your GitHub account to submit a report. We never see or store your
+                  GitHub password, and the connection is used only to create this one issue.
+                </p>
+                <Button onClick={handleConnect} disabled={busy} className="gap-2">
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Github className="h-4 w-4" />}
+                  Connect GitHub
+                </Button>
+              </>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm">
+                  1. Copy this code:
+                  <span className="ml-2 select-all rounded bg-muted px-2 py-1 font-mono text-base font-semibold tracking-widest">
+                    {userCode}
+                  </span>
+                </p>
+                <p className="text-sm">
+                  2. Open GitHub, paste the code, and authorize:
+                </p>
+                <Button asChild variant="outline" className="gap-2">
+                  <a href={verificationUri} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="h-4 w-4" />
+                    Open GitHub
+                  </a>
+                </Button>
+                {polling && (
+                  <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Waiting for authorization…
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {step === "form" && (
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="br-title">Title</Label>
+              <Input
+                id="br-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Short summary of the problem"
+                maxLength={200}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Category</Label>
+              <Select value={category} onValueChange={setCategory}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORIES.map((c) => (
+                    <SelectItem key={c.value} value={c.value}>
+                      {c.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="br-desc">Description</Label>
+              <Textarea
+                id="br-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What happened? What did you expect? Steps to reproduce."
+                rows={5}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="br-error">Error / stack trace (optional)</Label>
+              <Textarea
+                id="br-error"
+                value={errorText}
+                onChange={(e) => setErrorText(e.target.value)}
+                placeholder="Paste any error message or stack trace here"
+                rows={4}
+                className="font-mono text-xs"
+              />
+            </div>
+            <label className="flex items-start gap-2 text-sm">
+              <Checkbox
+                checked={includeDiagnostics}
+                onCheckedChange={(v) => setIncludeDiagnostics(v === true)}
+                className="mt-0.5"
+              />
+              <span className="text-muted-foreground">
+                Include basic diagnostics (browser and current page). No router configuration is
+                attached.
+              </span>
+            </label>
+            <p className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/30 p-2 text-xs text-muted-foreground">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+              Sensitive data (public IPs, passwords, keys, certificates) is automatically redacted.
+              You will review the final report before it is sent.
+            </p>
+          </div>
+        )}
+
+        {step === "preview" && preview && (
+          <div className="space-y-3 py-2">
+            <p className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/30 p-2 text-xs text-muted-foreground">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+              This is exactly what will be posted to GitHub. Anything detected as sensitive has been
+              replaced with <code className="font-mono">[REDACTED]</code>. Review it before submitting.
+            </p>
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Title</Label>
+              <div className="rounded-md border bg-muted/20 px-3 py-2 text-sm font-medium">
+                {preview.title}
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs text-muted-foreground">Body</Label>
+              <ScrollArea className="h-64 rounded-md border bg-muted/20">
+                <pre className="whitespace-pre-wrap break-words p-3 text-xs">{preview.body}</pre>
+              </ScrollArea>
+            </div>
+          </div>
+        )}
+
+        {step === "done" && (
+          <div className="space-y-4 py-6 text-center">
+            <CheckCircle2 className="mx-auto h-10 w-10 text-green-500" />
+            <p className="text-sm">Thanks! Your report was submitted.</p>
+            {issueUrl && (
+              <Button asChild variant="outline" className="gap-2">
+                <a href={issueUrl} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-4 w-4" />
+                  View issue
+                </a>
+              </Button>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {step === "form" && (
+            <>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={handlePreview} disabled={busy}>
+                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Review report
+              </Button>
+            </>
+          )}
+          {step === "preview" && (
+            <>
+              <Button variant="ghost" onClick={() => setStep("form")} disabled={busy}>
+                Back
+              </Button>
+              <Button onClick={handleSubmit} disabled={busy}>
+                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Submit to GitHub
+              </Button>
+            </>
+          )}
+          {step === "done" && (
+            <Button onClick={() => onOpenChange(false)}>Close</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, Bug, RotateCcw } from "lucide-react";
+import { recordError } from "@/lib/error-capture";
+import { BugReportModal } from "@/components/bug-report/BugReportModal";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  message: string;
+  reportOpen: boolean;
+}
+
+/**
+ * Catches render-time errors in the page subtree so a crash shows a friendly
+ * fallback (with a one-click bug report) instead of a blank screen. The error
+ * is pushed into the capture buffer so the report auto-attaches the stack.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, message: "", reportOpen: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, message: error.message };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+    recordError({
+      time: Date.now(),
+      kind: "react",
+      message: error.message || "React render error",
+      stack: `${error.stack ?? ""}${info.componentStack ? `\n\nComponent stack:${info.componentStack}` : ""}`,
+    });
+  }
+
+  private reset = () => this.setState({ hasError: false, message: "", reportOpen: false });
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+        <AlertTriangle className="h-10 w-10 text-destructive" />
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            This part of the app hit an unexpected error. You can report it (the error
+            details are attached automatically) or try reloading.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="default" className="gap-2" onClick={() => this.setState({ reportOpen: true })}>
+            <Bug className="h-4 w-4" />
+            Report a Bug
+          </Button>
+          <Button variant="outline" className="gap-2" onClick={this.reset}>
+            <RotateCcw className="h-4 w-4" />
+            Try again
+          </Button>
+        </div>
+        <BugReportModal
+          open={this.state.reportOpen}
+          onOpenChange={(open) => this.setState({ reportOpen: open })}
+        />
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/error/ErrorBoundary.tsx
+++ b/frontend/src/components/error/ErrorBoundary.tsx
@@ -12,7 +12,6 @@ interface Props {
 
 interface State {
   hasError: boolean;
-  message: string;
   reportOpen: boolean;
 }
 
@@ -22,10 +21,10 @@ interface State {
  * is pushed into the capture buffer so the report auto-attaches the stack.
  */
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false, message: "", reportOpen: false };
+  state: State = { hasError: false, reportOpen: false };
 
-  static getDerivedStateFromError(error: Error): Partial<State> {
-    return { hasError: true, message: error.message };
+  static getDerivedStateFromError(_error: Error): Partial<State> {
+    return { hasError: true };
   }
 
   componentDidCatch(error: Error, info: { componentStack?: string | null }) {
@@ -37,7 +36,7 @@ export class ErrorBoundary extends Component<Props, State> {
     });
   }
 
-  private reset = () => this.setState({ hasError: false, message: "", reportOpen: false });
+  private reset = () => this.setState({ hasError: false, reportOpen: false });
 
   render() {
     if (!this.state.hasError) return this.props.children;

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -11,6 +11,8 @@ import { Loader2 } from "lucide-react";
 import { UnifiedView } from "../ui/unified-view";
 import { useUnifiedView } from "@/contexts/UnifiedViewContext";
 import { useBannerEvents } from "@/hooks/useBannerEvents";
+import { ErrorBoundary } from "../error/ErrorBoundary";
+import { installGlobalErrorCapture } from "@/lib/error-capture";
 
 
 function AppLayoutInner({ children }: { children: React.ReactNode }) {
@@ -19,6 +21,11 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
   const [isChecking, setIsChecking] = useState(true);
   const { unifiedViewData, closeUnifiedView } = useUnifiedView();
   const bannerEvents = useBannerEvents();
+
+  // Start capturing uncaught errors/rejections so the bug reporter can attach them.
+  useEffect(() => {
+    installGlobalErrorCapture();
+  }, []);
 
   useEffect(() => {
     const checkSession = async () => {
@@ -71,7 +78,7 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
           <PowerActionBanner powerStatus={bannerEvents.data.powerStatus} />
           <UnsavedChangesBanner configDiff={bannerEvents.data.configDiff} commitConfirm={bannerEvents.data.commitConfirm} />
           <div className="flex-1 min-h-0 overflow-y-auto">
-            {children}
+            <ErrorBoundary>{children}</ErrorBoundary>
           </div>
         </main>
       </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ChevronDown, LogOut, User, Building2, Power, PowerOff } from "lucide-react";
+import { ChevronDown, LogOut, User, Building2, Power, PowerOff, Bug } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { useSession, signOut } from "@/lib/auth-client";
@@ -19,6 +19,7 @@ import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 import { ThemeSelector } from "@/components/ui/theme-selector";
 import { SearchCommand } from "@/components/search/SearchCommand";
+import { BugReportModal } from "@/components/bug-report/BugReportModal";
 
 import { getSidebarNavigation, type NavItem, type NavChild } from "@/lib/navigation";
 
@@ -27,6 +28,7 @@ export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const [openItems, setOpenItems] = useState<string[]>([]);
+  const [bugReportOpen, setBugReportOpen] = useState(false);
   const { data: session } = useSession();
   const { activeSession, loadSession, disconnectFromInstance } = useSessionStore();
   const { canRead } = usePermissions();
@@ -322,100 +324,77 @@ export function Sidebar() {
       </ScrollArea>
 
       {/* Footer */}
-      <div className="border-t border-border/50 p-4 space-y-3 shrink-0">
+      <div className="border-t border-border/50 p-3 space-y-2 shrink-0">
+        {/* Report a Bug */}
+        <Button
+          onClick={() => setBugReportOpen(true)}
+          variant="ghost"
+          size="sm"
+          className="w-full justify-center gap-2 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <Bug className="h-3.5 w-3.5" />
+          Report a Bug
+        </Button>
+        <BugReportModal open={bugReportOpen} onOpenChange={setBugReportOpen} />
+
         {/* Theme Selector */}
-        <div className="space-y-2">
-          <ThemeSelector />
-        </div>
+        <ThemeSelector />
 
         {/* Active Instance Indicator */}
         {activeSession ? (
-          <div className="space-y-2">
-            <div className="rounded-lg bg-primary/10 border border-primary/30 p-3 glow-border">
-              <div className="flex items-center gap-2 mb-2">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/20">
-                  <Building2 className="h-4 w-4 text-primary glow-text" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-xs font-medium text-primary truncate">
-                    {activeSession.instance_name}
-                  </p>
-                  <p className="text-xs text-muted-foreground truncate">
-                    {activeSession.site_name}
-                  </p>
-                </div>
-                <div
-                  className="h-2 w-2 rounded-full bg-primary animate-pulse glow-primary-subtle"
-                  title="Connected"
-                />
-              </div>
-              <Button
-                onClick={async () => {
-                  await disconnectFromInstance();
-                  router.push("/sites");
-                }}
-                variant="outline"
-                size="sm"
-                className="w-full justify-center gap-2 text-xs"
-              >
-                <PowerOff className="h-3 w-3" />
-                Disconnect Instance
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            <div className="rounded-lg bg-muted/30 border border-border/50 p-3">
-              <div className="flex items-center gap-2 mb-2">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted/50">
-                  <Building2 className="h-4 w-4 text-muted-foreground" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    No Instance
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Not connected
-                  </p>
-                </div>
-                <div
-                  className="h-2 w-2 rounded-full bg-muted-foreground/50"
-                  title="Disconnected"
-                />
-              </div>
-              <Button
-                onClick={() => router.push("/sites")}
-                variant="default"
-                size="sm"
-                className="w-full justify-center gap-2 text-xs"
-              >
-                <Power className="h-3 w-3" />
-                Connect to Instance
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* User Info & Logout */}
-        <div className="rounded-lg bg-muted/30 border border-border/50 p-3">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
-              <User className="h-4 w-4 text-primary glow-text" />
-            </div>
+          <div className="flex items-center gap-2 rounded-lg bg-primary/10 border border-primary/30 px-2.5 py-2 glow-border">
+            <Building2 className="h-4 w-4 text-primary glow-text shrink-0" />
             <div className="flex-1 min-w-0">
-              <p className="text-xs font-semibold text-foreground truncate">
-                {session?.user?.name || session?.user?.email || "User"}
+              <p className="text-xs font-medium text-primary truncate">
+                {activeSession.instance_name}
+              </p>
+              <p className="text-[11px] text-muted-foreground truncate leading-tight">
+                {activeSession.site_name}
               </p>
             </div>
+            <span
+              className="h-2 w-2 rounded-full bg-primary animate-pulse glow-primary-subtle shrink-0"
+              title="Connected"
+            />
+            <Button
+              onClick={async () => {
+                await disconnectFromInstance();
+                router.push("/sites");
+              }}
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+              title="Disconnect instance"
+            >
+              <PowerOff className="h-3.5 w-3.5" />
+            </Button>
           </div>
+        ) : (
+          <Button
+            onClick={() => router.push("/sites")}
+            variant="default"
+            size="sm"
+            className="w-full justify-center gap-2 text-xs"
+          >
+            <Power className="h-3 w-3" />
+            Connect to Instance
+          </Button>
+        )}
+
+        {/* User Info & Logout (single compact row) */}
+        <div className="flex items-center gap-2 rounded-lg bg-muted/30 border border-border/50 px-2.5 py-1.5">
+          <User className="h-4 w-4 text-primary glow-text shrink-0" />
+          <span className="flex-1 min-w-0 truncate text-xs font-semibold text-foreground">
+            {session?.user?.name || session?.user?.email || "User"}
+          </span>
           <Button
             onClick={handleLogout}
-            variant="outline"
-            className="w-full justify-center gap-2 text-xs"
-            size="sm"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+            title="Logout"
           >
-            <LogOut className="h-3 w-3" />
-            Logout
+            <LogOut className="h-3.5 w-3.5" />
           </Button>
         </div>
       </div>

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -36,12 +36,26 @@ function loadThemeId(): string {
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [customThemes, setCustomThemes] = useState<ThemeDefinition[]>(loadCustomThemes);
-  const [themeId, setThemeIdRaw] = useState<string>(() => loadThemeId());
+  // Start from SSR-safe defaults so the server-rendered markup and the first
+  // client (hydration) render are identical. The persisted theme is loaded from
+  // localStorage after mount; otherwise the client's first render would use the
+  // saved theme while the server used "dark", causing a hydration mismatch.
+  const [customThemes, setCustomThemes] = useState<ThemeDefinition[]>([]);
+  const [themeId, setThemeIdRaw] = useState<string>("dark");
+  const [mounted, setMounted] = useState(false);
 
   const allThemes = [...BUILT_IN_THEMES, ...customThemes];
 
   useEffect(() => {
+    setCustomThemes(loadCustomThemes());
+    setThemeIdRaw(loadThemeId());
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    // Don't apply/persist until the saved theme has been loaded, or we would
+    // clobber localStorage's "theme-id" with the temporary "dark" default.
+    if (!mounted) return;
     const theme = allThemes.find((t) => t.id === themeId) ?? BUILT_IN_THEMES[0];
     const root = document.documentElement;
     Object.entries(theme.variables).forEach(([k, v]) => {
@@ -51,7 +65,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     root.classList.toggle("light", !theme.isDark);
     localStorage.setItem("theme-id", theme.id);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [themeId, customThemes]);
+  }, [themeId, customThemes, mounted]);
 
   function setThemeId(id: string) {
     setThemeIdRaw(id);

--- a/frontend/src/lib/api/bug-report.ts
+++ b/frontend/src/lib/api/bug-report.ts
@@ -1,0 +1,70 @@
+import { apiClient } from "./client";
+
+export interface BugReportStatus {
+  enabled: boolean;
+  connected: boolean;
+  repo?: string | null;
+}
+
+export interface DeviceStart {
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+export type DevicePollStatus = "pending" | "connected" | "expired" | "denied" | "error";
+
+export interface DevicePoll {
+  status: DevicePollStatus;
+}
+
+export interface Diagnostics {
+  app_version?: string;
+  vyos_version?: string;
+  browser?: string;
+  page?: string;
+}
+
+export interface ReportRequest {
+  title: string;
+  category: string;
+  description: string;
+  include_diagnostics: boolean;
+  diagnostics?: Diagnostics;
+  error_text?: string;
+}
+
+export interface ReportPreview {
+  title: string;
+  body: string;
+}
+
+export interface SubmitResult {
+  url: string;
+  number: number;
+}
+
+class BugReportService {
+  async getStatus(): Promise<BugReportStatus> {
+    return apiClient.get<BugReportStatus>("/vyos/bug-report/status");
+  }
+
+  async deviceStart(): Promise<DeviceStart> {
+    return apiClient.post<DeviceStart>("/vyos/bug-report/github/device/start");
+  }
+
+  async devicePoll(): Promise<DevicePoll> {
+    return apiClient.post<DevicePoll>("/vyos/bug-report/github/device/poll");
+  }
+
+  async preview(req: ReportRequest): Promise<ReportPreview> {
+    return apiClient.post<ReportPreview>("/vyos/bug-report/preview", req);
+  }
+
+  async submit(req: ReportRequest): Promise<SubmitResult> {
+    return apiClient.post<SubmitResult>("/vyos/bug-report/submit", req);
+  }
+}
+
+export const bugReportService = new BugReportService();

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -18,6 +18,7 @@ function resolveBackendUrl(): string {
 }
 
 import { ApiError } from "../types/api";
+import { recordApiError } from "../error-capture";
 
 export class ApiClient {
   private readonly _baseUrl?: string;
@@ -86,6 +87,15 @@ export class ApiClient {
           details: errorDetails,
         };
 
+        // Capture for the bug reporter: unexpected server errors (5xx) and any
+        // failure on a config mutation (/batch), where a 400 usually signals a
+        // batching bug. Skip routine 4xx on read endpoints (auth/not-found).
+        const isBatch = endpoint.includes("/batch");
+        if (response.status >= 500 || (isBatch && response.status >= 400)) {
+          const payload = typeof options?.body === "string" ? options.body : undefined;
+          recordApiError(endpoint, response.status, errorMessage, payload);
+        }
+
         throw error;
       }
 
@@ -93,7 +103,23 @@ export class ApiClient {
       const responseText = await response.text();
 
       try {
-        return JSON.parse(responseText);
+        const parsed = JSON.parse(responseText);
+        // VyOS commit failures come back as HTTP 200 with { success: false }, so
+        // capture those here (with the payload) — they never hit the !ok branch.
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          (parsed as { success?: unknown }).success === false
+        ) {
+          const payload = typeof options?.body === "string" ? options.body : undefined;
+          recordApiError(
+            endpoint,
+            response.status,
+            (parsed as { error?: string }).error || "Operation failed",
+            payload,
+          );
+        }
+        return parsed;
       } catch {
         // If response is not valid JSON, throw error
         if (responseText.includes("<!DOCTYPE")) {
@@ -113,8 +139,10 @@ export class ApiClient {
         throw error;
       }
 
+      const message = error instanceof Error ? error.message : "Network error occurred";
+      recordApiError(endpoint, 0, message);
       throw {
-        message: error instanceof Error ? error.message : "Network error occurred",
+        message,
         details: error,
       } as ApiError;
     }

--- a/frontend/src/lib/error-capture.ts
+++ b/frontend/src/lib/error-capture.ts
@@ -1,0 +1,128 @@
+/**
+ * Lightweight client-side error capture.
+ *
+ * Keeps a small rolling buffer of recent runtime errors so the bug reporter can
+ * auto-attach them — users no longer have to hunt for and paste a stack trace.
+ *
+ * Sources captured:
+ *   - uncaught exceptions          (window "error")
+ *   - unhandled promise rejections (window "unhandledrejection")
+ *   - React render errors          (recorded by ErrorBoundary)
+ *   - failed backend requests      (recorded by the API client, 5xx/network)
+ *
+ * Everything captured here is still passed through the backend's redaction
+ * before it can be submitted, so stacks that embed paths/hosts are scrubbed.
+ */
+
+export type CapturedErrorKind = "error" | "unhandledrejection" | "react" | "api";
+
+export interface CapturedError {
+  time: number;
+  kind: CapturedErrorKind;
+  message: string;
+  stack?: string;
+  source?: string;
+}
+
+const MAX_ERRORS = 15;
+const MAX_REPORT_CHARS = 20000;
+
+const buffer: CapturedError[] = [];
+let installed = false;
+
+export function recordError(entry: CapturedError): void {
+  buffer.push(entry);
+  if (buffer.length > MAX_ERRORS) buffer.shift();
+}
+
+export function getRecentErrors(): CapturedError[] {
+  return [...buffer];
+}
+
+export function hasRecentErrors(): boolean {
+  return buffer.length > 0;
+}
+
+export function clearRecentErrors(): void {
+  buffer.length = 0;
+}
+
+/**
+ * Record a failed backend request. Called by the API client.
+ *
+ * `payload` is the request body (e.g. a batch operations array). Including it is
+ * the single most useful thing for diagnosing config failures — most VyOS 400s
+ * are an app bug in how operations were batched, which is only visible from the
+ * actual payload. Secrets in it are scrubbed by the backend redaction on submit.
+ */
+export function recordApiError(
+  endpoint: string,
+  status: number,
+  message: string,
+  payload?: string,
+): void {
+  let stack: string | undefined;
+  if (payload) {
+    const trimmed = payload.length > 4000 ? `${payload.slice(0, 4000)} …(truncated)` : payload;
+    stack = `Request payload:\n${trimmed}`;
+  }
+  recordError({
+    time: Date.now(),
+    kind: "api",
+    message: `${status || "network"} ${message}`.trim(),
+    stack,
+    source: endpoint,
+  });
+}
+
+/** Render the buffered errors as plain text suitable for an issue body. */
+export function formatErrorsForReport(errors: CapturedError[] = buffer): string {
+  if (errors.length === 0) return "";
+  const text = errors
+    .map((e) => {
+      const when = new Date(e.time).toISOString();
+      const head = `[${when}] (${e.kind}) ${e.message}`;
+      const src = e.source ? `\n  at ${e.source}` : "";
+      const stack = e.stack ? `\n${e.stack}` : "";
+      return head + src + stack;
+    })
+    .join("\n\n---\n\n");
+  return text.length > MAX_REPORT_CHARS
+    ? text.slice(text.length - MAX_REPORT_CHARS) // keep the most recent tail
+    : text;
+}
+
+/** Install the global listeners once (no-op on the server or if already done). */
+export function installGlobalErrorCapture(): void {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  window.addEventListener("error", (event: ErrorEvent) => {
+    // Ignore resource-load errors (img/script); those target an element, not window.
+    if (event.target && event.target !== window) return;
+    const err = event.error as Error | undefined;
+    recordError({
+      time: Date.now(),
+      kind: "error",
+      message: err?.message || event.message || "Uncaught error",
+      stack: err?.stack,
+      source: event.filename ? `${event.filename}:${event.lineno}:${event.colno}` : undefined,
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+    const message =
+      reason instanceof Error
+        ? reason.message
+        : typeof reason === "string"
+          ? reason
+          : "Unhandled promise rejection";
+    recordError({
+      time: Date.now(),
+      kind: "unhandledrejection",
+      message,
+      stack: reason instanceof Error ? reason.stack : undefined,
+    });
+  });
+}


### PR DESCRIPTION
Let authenticated users file a GitHub issue from inside VyManager using their own GitHub account, with a privacy-first design.

Backend (routers/bug_report):
- OAuth device flow (start/poll) so only a public client_id is needed — no client secret, no callback URL, works on every deployment
- Server-side redaction enforced at submit time (public IPs, PEM blocks, passwords/PSKs/keys, bearer tokens, base64/hex blobs); private IPs kept
- Preview + submit assemble the body from structured fields only; token is held in memory wrapped in _SecureStr and wiped after submit
- Per-user/global rate limits; client_id + repo baked in as zero-config defaults (env vars remain optional overrides for forks)

Frontend:
- Bug report modal (connect -> form -> redacted preview -> submit) and sidebar trigger; service routes through the existing /api/vyos proxy

Also fixes two pre-existing issues found along the way:
- events.py: /vyos/events/banners 500 when no instance is connected; now returns an idle keepalive SSE stream instead of dereferencing None
- ThemeContext: hydration mismatch by loading persisted theme after mount

Compacted the sidebar footer and reordered: bug report, theme, instance, user/logout.