### PR TITLE
Add IPSec operational status, reset/bounce, and isolate OpenVPN status

### DIFF
--- a/backend/ipsec_status.py
+++ b/backend/ipsec_status.py
@@ -1,0 +1,128 @@
+"""IPSec live status for the dashboard stream.
+
+Parses the structured ``ShowConnectionsSummaryIpsec`` GraphQL op into per-tunnel
+up/down state (with byte/packet counters and the negotiated ESP proposal), and
+builds the GraphQL alias field the dashboard broadcaster folds into its shared
+query.
+
+This is the site-to-site connection view: one entry per configured tunnel, each
+reporting whether its child SA is currently installed. It is the same op the
+IPSec page's on-demand status refresh uses, so the dashboard card and the page
+agree on tunnel state.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class IPSecProposal(BaseModel):
+    cipher: Optional[str] = None       # e.g. "AES"
+    mode: Optional[str] = None         # e.g. "CBC"
+    key_size: Optional[str] = None     # e.g. "256"
+    hash: Optional[str] = None         # e.g. "HMAC_SHA2_256_128"
+    dh: Optional[str] = None           # e.g. "MODP_2048" (None for ESP w/o PFS)
+
+
+class IPSecTunnel(BaseModel):
+    name: Optional[str] = None         # e.g. "peer5-tunnel-0"
+    state: Optional[str] = None        # "up" / "down"
+    local_ts: List[str] = []           # local traffic selectors (subnets)
+    remote_ts: List[str] = []          # remote traffic selectors (subnets)
+    bytes_in: Optional[str] = None
+    bytes_out: Optional[str] = None
+    packets_in: Optional[str] = None
+    packets_out: Optional[str] = None
+    esp_proposal: Optional[IPSecProposal] = None
+
+
+def ipsec_configured(full_config) -> bool:
+    """True when IPSec has peers/connections to show (gates the dashboard fetch).
+
+    The op-mode summary errors out when strongSwan isn't running, so we only
+    fetch it when there is actual site-to-site or remote-access config.
+    """
+    ipsec = ((full_config or {}).get("vpn", {}) or {}).get("ipsec") or {}
+    return bool(ipsec.get("site-to-site") or ipsec.get("remote-access"))
+
+
+def ipsec_gql_fields(key_literal: str) -> List[str]:
+    """GraphQL alias field fetching the site-to-site connection summary.
+
+    ``key_literal`` must be a JSON-encoded API key (``json.dumps(key)``).
+    """
+    return [
+        f"IpsecSummary: ShowConnectionsSummaryIpsec(data: {{key: {key_literal}}}) "
+        "{ success data { result } }"
+    ]
+
+
+def _summary_result(gql: dict) -> Optional[dict]:
+    """Extract the ShowConnectionsSummaryIpsec result object, or None on failure."""
+    node = (gql or {}).get("IpsecSummary")
+    if not isinstance(node, dict) or not node.get("success"):
+        return None
+    inner = node.get("data")
+    if isinstance(inner, dict) and isinstance(inner.get("result"), dict):
+        return inner["result"]
+    return None
+
+
+def _parse_proposal(raw) -> Optional[IPSecProposal]:
+    if not isinstance(raw, dict):
+        return None
+    return IPSecProposal(
+        cipher=raw.get("cipher"),
+        mode=raw.get("mode"),
+        key_size=raw.get("key_size"),
+        hash=raw.get("hash"),
+        dh=raw.get("dh"),
+    )
+
+
+def _parse_tunnels(result: dict) -> List[IPSecTunnel]:
+    tunnels: List[IPSecTunnel] = []
+    for t in (result.get("tunnels") or []):
+        if not isinstance(t, dict):
+            continue
+        sa = t.get("sa") if isinstance(t.get("sa"), dict) else {}
+        tunnels.append(IPSecTunnel(
+            name=t.get("name"),
+            state=t.get("state"),
+            local_ts=t.get("local_ts") or [],
+            remote_ts=t.get("remote_ts") or [],
+            bytes_in=sa.get("bytes_in"),
+            bytes_out=sa.get("bytes_out"),
+            packets_in=sa.get("packets_in"),
+            packets_out=sa.get("packets_out"),
+            esp_proposal=_parse_proposal(t.get("esp_proposal")),
+        ))
+    return tunnels
+
+
+def build_ipsec_status(gql: dict) -> dict:
+    """Build the ``ipsec-status`` SSE payload from the shared GraphQL result.
+
+    Returns counts plus the per-tunnel list. When the op failed (strongSwan down
+    or nothing established), tunnels is empty and counts are zero.
+    """
+    result = _summary_result(gql)
+    if result is None:
+        return {"tunnels": [], "total": 0, "up": 0, "down": 0}
+    tunnels = _parse_tunnels(result)
+    # Prefer strongSwan's own counts; fall back to deriving from the parsed list.
+    up = result.get("up")
+    down = result.get("down")
+    total = result.get("total")
+    if not isinstance(up, int):
+        up = sum(1 for t in tunnels if (t.state or "").lower() == "up")
+    if not isinstance(down, int):
+        down = sum(1 for t in tunnels if (t.state or "").lower() != "up")
+    if not isinstance(total, int):
+        total = len(tunnels)
+    return {
+        "tunnels": [t.dict() for t in tunnels],
+        "total": total,
+        "up": up,
+        "down": down,
+    }

--- a/backend/routers/ipsec/ipsec.py
+++ b/backend/routers/ipsec/ipsec.py
@@ -15,7 +15,10 @@ from vyos_builders.ipsec import IPSecBatchBuilder
 from vyos_mappers.ipsec import IPSecMapper
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+from ipsec_status import ipsec_gql_fields, build_ipsec_status
+import httpx
 import inspect
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -49,6 +52,17 @@ class VyOSResponse(BaseModel):
     success: bool
     data: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
+
+
+class IPSecResetPeerRequest(BaseModel):
+    """Reset (bounce) one site-to-site peer, or a single tunnel of it."""
+    peer: str = Field(..., description="Site-to-site peer name")
+    tunnel: Optional[str] = Field(None, description="Optional tunnel id to bounce just that tunnel")
+
+
+class IPSecResetRemoteAccessRequest(BaseModel):
+    """Reset remote-access (IKEv2 road-warrior) sessions."""
+    username: Optional[str] = Field(None, description="Optional username; omit to reset all RA sessions")
 
 
 # ========================================================================
@@ -255,6 +269,146 @@ async def ipsec_batch_configure(http_request: Request, request: IPSecBatchReques
             data={"message": "IPSec configuration updated"},
             error=response.error if response.error else None,
         )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ========================================================================
+# Operational Commands (live status + reset/bounce)
+#
+# These are op-mode actions, not config changes, so they go through the VyOS
+# GraphQL API directly (mirroring the DHCP lease-clear pattern) rather than the
+# batch/config endpoint.
+# ========================================================================
+
+async def _ipsec_graphql(service, query: str) -> dict:
+    """POST a GraphQL query/mutation to VyOS and return the parsed body.
+
+    Raises HTTPException(502) on transport/HTTP failure so callers can stay terse.
+    """
+    api_key = str(service.config.apikey)
+    url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
+    try:
+        async with httpx.AsyncClient(verify=service.config.verify, timeout=15.0) as client:
+            resp = await client.post(url, json={"query": query}, auth=("vyos", api_key))
+    except Exception:
+        logger.exception("IPSec GraphQL request failed")
+        raise HTTPException(status_code=502, detail="VyOS GraphQL request failed")
+    if resp.status_code != 200:
+        logger.error("IPSec GraphQL HTTP error %d", resp.status_code)
+        raise HTTPException(status_code=502, detail="VyOS GraphQL request failed")
+    return resp.json()
+
+
+def _reset_response(body: dict, mutation_name: str) -> VyOSResponse:
+    """Fold a Reset*Ipsec mutation response into a VyOSResponse.
+
+    Note: ResetPeerIpsec reports ``success: true`` even for a non-existent peer
+    (strongSwan simply issues the reset), so this success flag confirms the
+    command was accepted, not that a tunnel re-established. Callers should
+    re-query status to confirm tunnel state.
+    """
+    if body.get("errors"):
+        logger.warning("IPSec %s GraphQL errors: %s", mutation_name, body["errors"])
+        return VyOSResponse(success=False, error="VyOS reported an error")
+    node = (body.get("data") or {}).get(mutation_name) or {}
+    success = bool(node.get("success"))
+    error = None
+    if not success:
+        errs = node.get("errors") or []
+        error = "; ".join(str(e) for e in errs) if errs else "Reset failed"
+    return VyOSResponse(success=success, error=error)
+
+
+@router.get("/status")
+async def get_ipsec_status(request: Request):
+    """
+    Live site-to-site tunnel status (on-demand refresh source for the IPSec page).
+
+    Returns the same shape the dashboard pushes over SSE: per-tunnel up/down
+    state with byte/packet counters and the negotiated ESP proposal, plus
+    up/down/total counts. Returns empty/zero when strongSwan isn't running or
+    no tunnel has established.
+    """
+    await require_read_permission(request, FeatureGroup.IPSEC)
+    try:
+        service = get_session_vyos_service(request)
+        key_literal = json.dumps(str(service.config.apikey))
+        query = "{ " + " ".join(ipsec_gql_fields(key_literal)) + " }"
+        body = await _ipsec_graphql(service, query)
+        if body.get("errors"):
+            logger.warning("IPSec status GraphQL errors: %s", body["errors"])
+        return build_ipsec_status(body.get("data") or {})
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/reset/peer", response_model=VyOSResponse)
+async def reset_ipsec_peer(http_request: Request, request: IPSecResetPeerRequest):
+    """Bounce a single site-to-site peer (or just one of its tunnels)."""
+    await require_write_permission(http_request, FeatureGroup.IPSEC)
+    try:
+        service = get_session_vyos_service(http_request)
+        key_literal = json.dumps(str(service.config.apikey))
+        peer_literal = json.dumps(request.peer)
+        data = f"key: {key_literal}, peer: {peer_literal}"
+        if request.tunnel is not None:
+            data += f", tunnel: {json.dumps(request.tunnel)}"
+        query = (
+            "mutation { ResetPeerIpsec(data: {" + data + "}) "
+            "{ success errors } }"
+        )
+        body = await _ipsec_graphql(service, query)
+        return _reset_response(body, "ResetPeerIpsec")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/reset/all", response_model=VyOSResponse)
+async def reset_ipsec_all_peers(http_request: Request):
+    """Bounce every configured site-to-site peer at once."""
+    await require_write_permission(http_request, FeatureGroup.IPSEC)
+    try:
+        service = get_session_vyos_service(http_request)
+        key_literal = json.dumps(str(service.config.apikey))
+        query = (
+            "mutation { ResetAllPeersIpsec(data: {key: " + key_literal + "}) "
+            "{ success errors } }"
+        )
+        body = await _ipsec_graphql(service, query)
+        return _reset_response(body, "ResetAllPeersIpsec")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unhandled error")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/reset/remote-access", response_model=VyOSResponse)
+async def reset_ipsec_remote_access(http_request: Request, request: IPSecResetRemoteAccessRequest):
+    """Reset remote-access (IKEv2 road-warrior) sessions, optionally for one user."""
+    await require_write_permission(http_request, FeatureGroup.IPSEC)
+    try:
+        service = get_session_vyos_service(http_request)
+        key_literal = json.dumps(str(service.config.apikey))
+        data = f"key: {key_literal}"
+        if request.username is not None:
+            data += f", username: {json.dumps(request.username)}"
+        query = (
+            "mutation { ResetRaIpsec(data: {" + data + "}) "
+            "{ success errors } }"
+        )
+        body = await _ipsec_graphql(service, query)
+        return _reset_response(body, "ResetRaIpsec")
     except HTTPException:
         raise
     except Exception:

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -32,6 +32,7 @@ from routers.qos.qos import (
 from openvpn_status import openvpn_configured, openvpn_gql_fields, build_openvpn_status
 from vrrp_status import vrrp_configured, vrrp_gql_fields, build_vrrp_status
 from bgp_status import bgp_configured, bgp_gql_fields, build_bgp_status
+from ipsec_status import ipsec_configured, ipsec_gql_fields, build_ipsec_status
 import logging
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ def _wg_alias(iface_name: str) -> str:
     return f"WGStatus_{safe}"
 
 
-def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False, include_bgp: bool = False) -> dict:
+def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Optional[list] = None, include_vrrp: bool = False, include_bgp: bool = False, include_ipsec: bool = False) -> dict:
     """
     Build the JSON body for the slow dashboard GraphQL query.
 
@@ -135,12 +136,12 @@ def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Opti
         f"InterfaceCounters: ShowCountersInterfaces(data: {{key: {k}}}) {{ data {{ result }} }}",
     ]
     fields += qos_gql_fields(k, cake_targets or [])
-    if include_openvpn:
-        fields += openvpn_gql_fields(k)
     if include_vrrp:
         fields += vrrp_gql_fields(k)
     if include_bgp:
         fields += bgp_gql_fields(k)
+    if include_ipsec:
+        fields += ipsec_gql_fields(k)
     if include_wireguard:
         fields.append(
             f'WireGuardConfig: ShowConfig(data: {{key: {k}, path: ["interfaces", "wireguard"]}}) {{ data {{ result }} }}'
@@ -159,7 +160,7 @@ def _build_gql_wg_status_payload(api_key: str, iface_names: List[str]) -> dict:
     return {"query": "{ " + " ".join(fields) + " }"}
 
 
-async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_openvpn: bool = False, include_vrrp: bool = False, include_bgp: bool = False) -> Optional[dict]:
+async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_targets: Optional[list] = None, include_vrrp: bool = False, include_bgp: bool = False, include_ipsec: bool = False) -> Optional[dict]:
     """
     Fire a single GraphQL POST for the full dashboard data.
 
@@ -168,7 +169,7 @@ async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_target
     api_key = str(service.config.apikey)
     url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
     verify = service.config.verify
-    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_openvpn, include_vrrp, include_bgp)
+    payload = _build_gql_payload(api_key, include_wireguard, cake_targets, include_vrrp, include_bgp, include_ipsec)
 
     try:
         async with httpx.AsyncClient(verify=verify, timeout=15.0) as client:
@@ -188,28 +189,29 @@ async def _fetch_graphql_dashboard(service, include_wireguard: bool, cake_target
         return None
 
 
-def _build_fast_gql_payload(api_key: str, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> dict:
-    """Build the fast GraphQL payload: interface counters + (gated) QoS + OpenVPN.
+def _build_fast_gql_payload(api_key: str, cake_targets: Optional[list] = None) -> dict:
+    """Build the fast GraphQL payload: interface counters + (gated) QoS.
 
     QoS rides this 3 s call so its live bandwidth stays smooth. ``ShowShaperQos``
     is always included (it returns ``success:false`` when nothing is applied, which
     can't break the other fields); per-cake ``ShowCakeQos`` aliases are added only
-    for the cake interfaces discovered from config. OpenVPN status (3 modes) is
-    added only when OpenVPN is configured.
+    for the cake interfaces discovered from config.
+
+    OpenVPN status is intentionally excluded — ``ShowOpenvpn`` is slow and erratic
+    on some hosts (2–16 s), so it is fetched in its own concurrent task
+    (``_fetch_gql_openvpn_status``) where it cannot stall counters/QoS.
     """
     k = json.dumps(api_key)
     fields = [f"InterfaceCounters: ShowCountersInterfaces(data: {{key: {k}}}) {{ data {{ result }} }}"]
     fields += qos_gql_fields(k, cake_targets or [])
-    if include_openvpn:
-        fields += openvpn_gql_fields(k)
     return {"query": "{ " + " ".join(fields) + " }"}
 
 
-async def _fetch_graphql_fast(service, cake_targets: Optional[list] = None, include_openvpn: bool = False) -> Optional[dict]:
-    """Fire a minimal GraphQL POST for interface counters + QoS + OpenVPN status."""
+async def _fetch_graphql_fast(service, cake_targets: Optional[list] = None) -> Optional[dict]:
+    """Fire a minimal GraphQL POST for interface counters + QoS."""
     api_key = str(service.config.apikey)
     url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
-    payload = _build_fast_gql_payload(api_key, cake_targets, include_openvpn)
+    payload = _build_fast_gql_payload(api_key, cake_targets)
     try:
         async with httpx.AsyncClient(verify=service.config.verify, timeout=15.0) as client:
             resp = await client.post(url, json=payload, auth=("vyos", api_key))
@@ -223,6 +225,33 @@ async def _fetch_graphql_fast(service, cake_targets: Optional[list] = None, incl
     except Exception:
         logger.exception("GraphQL fast dashboard fetch failed")
         return None
+
+
+async def _fetch_gql_openvpn_status(service) -> dict:
+    """Fetch OpenVPN status (all 3 modes) in one GraphQL POST, on its own task.
+
+    ``ShowOpenvpn`` can take anywhere from 2 to 16 s on a loaded host, so it runs
+    concurrently with a generous timeout instead of riding the fast/slow shared
+    query. Returns the ``data`` dict (``{OpenvpnServer: ..., ...}``) for
+    ``build_openvpn_status``, or an empty dict on any error so callers degrade
+    gracefully.
+    """
+    api_key = str(service.config.apikey)
+    url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
+    payload = {"query": "{ " + " ".join(openvpn_gql_fields(json.dumps(api_key))) + " }"}
+    try:
+        async with httpx.AsyncClient(verify=service.config.verify, timeout=30.0) as client:
+            resp = await client.post(url, json=payload, auth=("vyos", api_key))
+        if resp.status_code != 200:
+            logger.error("GraphQL OpenVPN status HTTP error %d", resp.status_code)
+            return {}
+        body = resp.json()
+        if "errors" in body:
+            logger.warning("GraphQL OpenVPN status field errors: %s", body["errors"])
+        return body.get("data") or {}
+    except Exception:
+        logger.exception("GraphQL OpenVPN status fetch failed")
+        return {}
 
 
 def _gql_result(gql: dict, key: str):
@@ -1015,6 +1044,7 @@ def _parse_wg_summary(output: str) -> dict:
 _FAST_INTERVAL = 3.0     # seconds between fast cycles (interface counters)
 _SLOW_EVERY = 5          # emit system-info / WG every N fast cycles (= every 15 s)
 _WG_MIN_INTERVAL = 15.0  # minimum seconds between WireGuard status queries
+_OPENVPN_MIN_INTERVAL = 6.0  # minimum seconds between (slow, erratic) OpenVPN status queries
 
 
 class DeviceDataBroadcaster:
@@ -1037,6 +1067,12 @@ class DeviceDataBroadcaster:
         self._last_wg_status: dict = {}
         self._cached_wg_ifaces: list[str] = []
         self._last_wg_query_time: float = 0.0
+        # OpenVPN status runs on its own task (ShowOpenvpn is slow/erratic) so it
+        # never stalls the fast counters/QoS query.
+        self._openvpn_task: Optional[asyncio.Task] = None
+        self._last_openvpn_status: dict = {}
+        self._last_openvpn_query_time: float = 0.0
+        self._openvpn_fetched: bool = False
         # Cake interfaces (interface, policy) discovered from config; refreshed on
         # the slow cycle and used to build per-cake GraphQL aliases each cycle.
         self._cached_cake_targets: list = []
@@ -1046,6 +1082,8 @@ class DeviceDataBroadcaster:
         self._vrrp_configured: bool = False
         # Whether BGP is configured (gates the show bgp summary fetch).
         self._bgp_configured: bool = False
+        # Whether IPSec is configured (gates the show ipsec connections fetch).
+        self._ipsec_configured: bool = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -1071,6 +1109,8 @@ class DeviceDataBroadcaster:
                 self._task.cancel()
             if self._wg_task and not self._wg_task.done():
                 self._wg_task.cancel()
+            if self._openvpn_task and not self._openvpn_task.done():
+                self._openvpn_task.cancel()
             _broadcasters.pop(self._key, None)
 
     # ------------------------------------------------------------------
@@ -1187,16 +1227,43 @@ class DeviceDataBroadcaster:
             self._openvpn_configured = openvpn_configured(cfg)
             self._vrrp_configured = vrrp_configured(cfg)
             self._bgp_configured = bgp_configured(cfg)
+            self._ipsec_configured = ipsec_configured(cfg)
         except Exception:
             logger.exception("Broadcaster: config-state refresh error")
 
-    def _broadcast_openvpn(self, gql: dict) -> None:
-        """Parse OpenVPN status from the shared GraphQL result and push an event."""
+    def _handle_openvpn_cycle(self) -> None:
+        """Drive the concurrent OpenVPN status fetch and push the latest snapshot.
+
+        Mirrors ``_handle_wg_cycle``: collect a completed fetch, start a new one
+        when the cooldown has elapsed, and push the last good snapshot every cycle.
+        ``ShowOpenvpn`` is slow/erratic, so it runs off the shared query path here.
+        Only pushes once a first result has arrived, so the card shows "Loading…"
+        rather than flashing an empty list before the initial fetch returns.
+        """
         try:
-            self._push_to_all({"type": "openvpn-status", "data": build_openvpn_status(gql)})
+            # Collect a completed fetch.
+            if self._openvpn_task is not None and self._openvpn_task.done():
+                try:
+                    self._last_openvpn_status = self._openvpn_task.result() or {}
+                except Exception:
+                    self._last_openvpn_status = {}
+                self._openvpn_fetched = True
+                self._openvpn_task = None
+                self._last_openvpn_query_time = asyncio.get_event_loop().time()
+
+            # Start a new fetch if the cooldown has elapsed.
+            now = asyncio.get_event_loop().time()
+            if (self._openvpn_task is None
+                    and (now - self._last_openvpn_query_time) >= _OPENVPN_MIN_INTERVAL):
+                self._openvpn_task = asyncio.create_task(
+                    _fetch_gql_openvpn_status(self._service)
+                )
+
+            if self._openvpn_fetched:
+                self._push_to_all({"type": "openvpn-status", "data": build_openvpn_status(self._last_openvpn_status)})
         except Exception:
-            logger.exception("Broadcaster: openvpn-status parse error")
-            self._push_to_all({"type": "error", "data": {"channel": "openvpn-status", "message": "Parse failed"}})
+            logger.exception("Broadcaster: openvpn-status error")
+            self._push_to_all({"type": "error", "data": {"channel": "openvpn-status", "message": "Failed to fetch"}})
 
     def _broadcast_vrrp(self, gql: dict) -> None:
         """Parse live VRRP group state from the shared GraphQL result and push an event."""
@@ -1214,6 +1281,14 @@ class DeviceDataBroadcaster:
             logger.exception("Broadcaster: bgp-status parse error")
             self._push_to_all({"type": "error", "data": {"channel": "bgp-status", "message": "Parse failed"}})
 
+    def _broadcast_ipsec(self, gql: dict) -> None:
+        """Parse live IPSec tunnel state from the shared GraphQL result and push an event."""
+        try:
+            self._push_to_all({"type": "ipsec-status", "data": build_ipsec_status(gql)})
+        except Exception:
+            logger.exception("Broadcaster: ipsec-status parse error")
+            self._push_to_all({"type": "error", "data": {"channel": "ipsec-status", "message": "Parse failed"}})
+
     def _on_task_done(self, fut: asyncio.Future) -> None:
         """Clean up if _run() exits unexpectedly."""
         if fut.cancelled():
@@ -1224,6 +1299,8 @@ class DeviceDataBroadcaster:
             _broadcasters.pop(self._key, None)
             if self._wg_task and not self._wg_task.done():
                 self._wg_task.cancel()
+            if self._openvpn_task and not self._openvpn_task.done():
+                self._openvpn_task.cancel()
 
     # ------------------------------------------------------------------
     # Main loop
@@ -1237,36 +1314,38 @@ class DeviceDataBroadcaster:
                     # Refresh config-derived gates before building the query.
                     await self._refresh_config_state()
                     targets = self._cached_cake_targets
-                    ovpn = self._openvpn_configured
                     vrrp = self._vrrp_configured
                     bgp = self._bgp_configured
-                    # Full query: counters + system info + QoS + OpenVPN + VRRP + BGP + WireGuard
-                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_openvpn=ovpn, include_vrrp=vrrp, include_bgp=bgp)
+                    ipsec = self._ipsec_configured
+                    # Full query: counters + system info + QoS + VRRP + BGP + IPSec + WireGuard
+                    gql = await _fetch_graphql_dashboard(self._service, include_wireguard=True, cake_targets=targets, include_vrrp=vrrp, include_bgp=bgp, include_ipsec=ipsec)
                     if gql is not None:
                         self._broadcast_interface_counters(gql)
                         self._broadcast_system_info(gql)
                         self._handle_wg_cycle(gql)
                         self._broadcast_qos(gql, targets)
-                        if ovpn:
-                            self._broadcast_openvpn(gql)
                         if vrrp:
                             self._broadcast_vrrp(gql)
                         if bgp:
                             self._broadcast_bgp(gql)
+                        if ipsec:
+                            self._broadcast_ipsec(gql)
                     else:
                         self._push_to_all({"type": "error", "data": {"channel": "all", "message": "GraphQL fetch failed"}})
                 else:
-                    # Fast query: interface counters + QoS + OpenVPN status
+                    # Fast query: interface counters + QoS
                     targets = self._cached_cake_targets
-                    ovpn = self._openvpn_configured
-                    gql = await _fetch_graphql_fast(self._service, cake_targets=targets, include_openvpn=ovpn)
+                    gql = await _fetch_graphql_fast(self._service, cake_targets=targets)
                     if gql is not None:
                         self._broadcast_interface_counters(gql)
                         self._broadcast_qos(gql, targets)
-                        if ovpn:
-                            self._broadcast_openvpn(gql)
                     else:
                         self._push_to_all({"type": "error", "data": {"channel": "interface-counters", "message": "GraphQL fast fetch failed"}})
+
+                # OpenVPN runs on its own concurrent task (slow/erratic op) so it
+                # never blocks the shared queries above; driven every cycle.
+                if self._openvpn_configured:
+                    self._handle_openvpn_cycle()
 
                 cycle += 1
                 await asyncio.sleep(_FAST_INTERVAL)
@@ -1275,6 +1354,8 @@ class DeviceDataBroadcaster:
         finally:
             if self._wg_task and not self._wg_task.done():
                 self._wg_task.cancel()
+            if self._openvpn_task and not self._openvpn_task.done():
+                self._openvpn_task.cancel()
 
 
 # Global broadcaster registry: instance_id -> DeviceDataBroadcaster

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -18,6 +18,7 @@ import { QoSStatsCard } from "@/components/dashboard/QoSStatsCard";
 import { OpenVpnCard } from "@/components/dashboard/OpenVpnCard";
 import { VrrpStatusCard } from "@/components/dashboard/VrrpStatusCard";
 import { BgpStatusCard } from "@/components/dashboard/BgpStatusCard";
+import { IpsecCard } from "@/components/dashboard/IpsecCard";
 import { AddCardModal } from "@/components/dashboard/AddCardModal";
 import {
   DndContext,
@@ -371,6 +372,9 @@ export default function Home() {
     if (cardType === "bgp-status") {
       defaultSpan = 2;
     }
+    if (cardType === "ipsec-status") {
+      defaultSpan = 2;
+    }
     // system-info defaults to 1 column (already set above)
 
     // New cards always start at column 0
@@ -500,6 +504,8 @@ export default function Home() {
         return <VrrpStatusCard {...baseProps} />;
       case "bgp-status":
         return <BgpStatusCard {...baseProps} />;
+      case "ipsec-status":
+        return <IpsecCard {...baseProps} />;
       default:
         return null;
     }

--- a/frontend/src/app/vpn/ipsec/page.tsx
+++ b/frontend/src/app/vpn/ipsec/page.tsx
@@ -45,6 +45,7 @@ import {
   type RAConnection,
   type RAPool,
   type AuthPSK,
+  type IPSecStatus,
 } from "@/lib/api/ipsec";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
@@ -111,8 +112,76 @@ function IPSecPageInner() {
     }
   };
 
+  // ---- Live tunnel status (operational, separate from config) ----
+  const [tunnelStatus, setTunnelStatus] = useState<IPSecStatus | null>(null);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [bouncing, setBouncing] = useState<string | null>(null);
+  const [statusMsg, setStatusMsg] = useState<{ type: "ok" | "err"; text: string } | null>(null);
+
+  const refreshStatus = async () => {
+    try {
+      setStatusLoading(true);
+      setTunnelStatus(await ipsecService.getStatus());
+    } catch {
+      // Status is best-effort; leave the last snapshot in place on failure.
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  /** Live tunnels belonging to a peer (names look like "<peer>-tunnel-<n>"). */
+  const peerTunnels = (peerName: string) =>
+    (tunnelStatus?.tunnels ?? []).filter((t) => (t.name ?? "").startsWith(`${peerName}-tunnel-`));
+
+  const bouncePeer = async (peerName: string) => {
+    setBouncing(peerName);
+    setStatusMsg(null);
+    try {
+      await ipsecService.resetPeer(peerName);
+      setStatusMsg({ type: "ok", text: `Bounced peer "${peerName}". Re-checking status…` });
+      // Give strongSwan a moment to re-establish before re-reading state.
+      await new Promise((r) => setTimeout(r, 2000));
+      await refreshStatus();
+    } catch (err) {
+      setStatusMsg({ type: "err", text: err instanceof Error ? err.message : "Failed to bounce peer" });
+    } finally {
+      setBouncing(null);
+    }
+  };
+
+  const resetAllPeers = async () => {
+    setBouncing("__all__");
+    setStatusMsg(null);
+    try {
+      await ipsecService.resetAllPeers();
+      setStatusMsg({ type: "ok", text: "Bounced all peers. Re-checking status…" });
+      await new Promise((r) => setTimeout(r, 2000));
+      await refreshStatus();
+    } catch (err) {
+      setStatusMsg({ type: "err", text: err instanceof Error ? err.message : "Failed to bounce peers" });
+    } finally {
+      setBouncing(null);
+    }
+  };
+
+  const resetRemoteAccess = async () => {
+    setBouncing("__ra__");
+    setStatusMsg(null);
+    try {
+      await ipsecService.resetRemoteAccess();
+      setStatusMsg({ type: "ok", text: "Reset all remote-access sessions." });
+    } catch (err) {
+      setStatusMsg({ type: "err", text: err instanceof Error ? err.message : "Failed to reset sessions" });
+    } finally {
+      setBouncing(null);
+    }
+  };
+
   useEffect(() => {
-    if (hasRead) fetchConfig();
+    if (hasRead) {
+      fetchConfig();
+      refreshStatus();
+    }
   }, [hasRead]);
 
   useEffect(() => {
@@ -258,12 +327,39 @@ function IPSecPageInner() {
                 <TabsContent value="s2s" className="mt-0">
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="font-semibold">Site-to-Site Peers</h3>
-                    {hasWrite && (
-                      <Button size="sm" onClick={() => { setEditingS2S(null); setShowS2SModal(true); }}>
-                        <Plus className="h-4 w-4 mr-1" /> Add Peer
+                    <div className="flex items-center gap-2">
+                      <Button variant="outline" size="sm" onClick={refreshStatus} disabled={statusLoading}>
+                        <RefreshCw className={cn("h-4 w-4 mr-1", statusLoading && "animate-spin")} /> Refresh Status
                       </Button>
-                    )}
+                      {hasWrite && (config?.site_to_site_peers.length ?? 0) > 0 && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={resetAllPeers}
+                          disabled={bouncing !== null}
+                          title="Bounce every site-to-site peer"
+                        >
+                          {bouncing === "__all__" ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Lock className="h-4 w-4 mr-1" />}
+                          Reset All
+                        </Button>
+                      )}
+                      {hasWrite && (
+                        <Button size="sm" onClick={() => { setEditingS2S(null); setShowS2SModal(true); }}>
+                          <Plus className="h-4 w-4 mr-1" /> Add Peer
+                        </Button>
+                      )}
+                    </div>
                   </div>
+                  {statusMsg && (
+                    <div className={cn(
+                      "mb-4 rounded-md border px-3 py-2 text-sm",
+                      statusMsg.type === "ok"
+                        ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-400"
+                        : "border-destructive/30 bg-destructive/10 text-destructive",
+                    )}>
+                      {statusMsg.text}
+                    </div>
+                  )}
                   {(config?.site_to_site_peers.length ?? 0) === 0 ? (
                     <EmptyState icon={Network} label="No site-to-site peers configured" />
                   ) : (
@@ -305,15 +401,46 @@ function IPSecPageInner() {
                             </TableCell>
                             <TableCell><Badge variant="outline">{peer.tunnels.length}</Badge></TableCell>
                             <TableCell>
-                              {peer.disabled ? (
-                                <Badge variant="secondary" className="bg-red-500/10 text-red-600">Disabled</Badge>
-                              ) : (
-                                <Badge variant="secondary" className="bg-green-500/10 text-green-600">Enabled</Badge>
-                              )}
+                              <div className="flex flex-col gap-1">
+                                {peer.disabled ? (
+                                  <Badge variant="secondary" className="bg-red-500/10 text-red-600 w-fit">Disabled</Badge>
+                                ) : (
+                                  <Badge variant="secondary" className="bg-green-500/10 text-green-600 w-fit">Enabled</Badge>
+                                )}
+                                {(() => {
+                                  const lts = peerTunnels(peer.name);
+                                  if (lts.length === 0) return null;
+                                  const up = lts.filter((t) => (t.state ?? "").toLowerCase() === "up").length;
+                                  const allUp = up === lts.length;
+                                  return (
+                                    <Badge
+                                      variant="outline"
+                                      className={cn(
+                                        "text-xs w-fit gap-1",
+                                        allUp ? "border-green-500/30 text-green-600" : "border-amber-500/30 text-amber-600",
+                                      )}
+                                      title="Live tunnel status"
+                                    >
+                                      <span className={cn("inline-block h-1.5 w-1.5 rounded-full", allUp ? "bg-green-500" : "bg-amber-500")} />
+                                      {up}/{lts.length} up
+                                    </Badge>
+                                  );
+                                })()}
+                              </div>
                             </TableCell>
                             {hasWrite && (
                               <TableCell className="text-right">
                                 <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-8 w-8"
+                                    disabled={bouncing !== null}
+                                    onClick={() => bouncePeer(peer.name)}
+                                    title="Bounce tunnel (reset peer)"
+                                  >
+                                    {bouncing === peer.name ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                                  </Button>
                                   <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => { setEditingS2S(peer); setShowS2SModal(true); }}>
                                     <Pencil className="h-4 w-4" />
                                   </Button>
@@ -339,12 +466,36 @@ function IPSecPageInner() {
                 <TabsContent value="ra" className="mt-0">
                   <div className="flex items-center justify-between mb-4">
                     <h3 className="font-semibold">Remote Access Connections</h3>
-                    {hasWrite && (
-                      <Button size="sm" onClick={() => { setEditingRA(null); setShowRAModal(true); }}>
-                        <Plus className="h-4 w-4 mr-1" /> Add Connection
-                      </Button>
-                    )}
+                    <div className="flex items-center gap-2">
+                      {hasWrite && (config?.remote_access.connections.length ?? 0) > 0 && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={resetRemoteAccess}
+                          disabled={bouncing !== null}
+                          title="Reset all remote-access (road-warrior) sessions"
+                        >
+                          {bouncing === "__ra__" ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <RefreshCw className="h-4 w-4 mr-1" />}
+                          Reset Sessions
+                        </Button>
+                      )}
+                      {hasWrite && (
+                        <Button size="sm" onClick={() => { setEditingRA(null); setShowRAModal(true); }}>
+                          <Plus className="h-4 w-4 mr-1" /> Add Connection
+                        </Button>
+                      )}
+                    </div>
                   </div>
+                  {statusMsg && activeTab === "ra" && (
+                    <div className={cn(
+                      "mb-4 rounded-md border px-3 py-2 text-sm",
+                      statusMsg.type === "ok"
+                        ? "border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-400"
+                        : "border-destructive/30 bg-destructive/10 text-destructive",
+                    )}>
+                      {statusMsg.text}
+                    </div>
+                  )}
                   {(config?.remote_access.connections.length ?? 0) === 0 ? (
                     <EmptyState icon={Wifi} label="No remote access connections configured" />
                   ) : (

--- a/frontend/src/components/dashboard/AddCardModal.tsx
+++ b/frontend/src/components/dashboard/AddCardModal.tsx
@@ -77,6 +77,13 @@ const AVAILABLE_CARDS: AvailableCard[] = [
     icon: Route,
     requiredPermission: FeatureGroup.BGP,
   },
+  {
+    type: "ipsec-status",
+    name: "IPSec Tunnels",
+    description: "Live site-to-site IPSec tunnel state (up/down) with traffic selectors, byte counters and the negotiated ESP proposal",
+    icon: Lock,
+    requiredPermission: FeatureGroup.IPSEC,
+  },
 ];
 
 interface AddCardModalProps {

--- a/frontend/src/components/dashboard/IpsecCard.tsx
+++ b/frontend/src/components/dashboard/IpsecCard.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  X,
+  Lock,
+  RefreshCw,
+  Settings,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  ArrowLeftRight,
+  ShieldOff,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import { IPSecStatus, IPSecTunnelStatus } from "@/lib/api/ipsec";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
+
+interface IpsecCardProps {
+  onRemove?: () => void;
+  span?: number;
+  onSpanChange?: (newSpan: number) => void;
+  config?: Record<string, unknown>;
+  onConfigChange?: (config: Record<string, unknown>) => void;
+}
+
+/** strongSwan reports byte counters as raw integer strings — humanize them. */
+function formatBytes(value?: string | null): string {
+  const n = Number(value);
+  if (!value || Number.isNaN(n)) return "0 B";
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+function StatPill({ label, value, tone }: { label: string; value: number; tone: "up" | "down" | "total" }) {
+  const styles = {
+    up: "text-emerald-600 dark:text-emerald-400",
+    down: "text-red-600 dark:text-red-400",
+    total: "text-foreground",
+  }[tone];
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className={cn("text-sm font-semibold tabular-nums", styles)}>{value}</span>
+      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+function TunnelRow({ tunnel }: { tunnel: IPSecTunnelStatus }) {
+  const up = (tunnel.state ?? "").toLowerCase() === "up";
+  const local = tunnel.local_ts.length ? tunnel.local_ts.join(", ") : "any";
+  const remote = tunnel.remote_ts.length ? tunnel.remote_ts.join(", ") : "any";
+  const proposal = tunnel.esp_proposal
+    ? [
+        tunnel.esp_proposal.cipher,
+        tunnel.esp_proposal.key_size,
+        tunnel.esp_proposal.hash,
+      ]
+        .filter(Boolean)
+        .join("/")
+    : null;
+
+  return (
+    <div className="relative px-3.5 py-2.5 border-b last:border-0 transition-colors hover:bg-muted/40">
+      {/* status accent bar */}
+      <span
+        className={cn(
+          "absolute inset-y-0 left-0 w-[3px]",
+          up ? "bg-emerald-500" : "bg-muted-foreground/30",
+        )}
+      />
+
+      {/* line 1: dot + name + state + proposal */}
+      <div className="flex items-center gap-2">
+        <span className="relative flex h-2 w-2 shrink-0">
+          {up && (
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400/60" />
+          )}
+          <span
+            className={cn(
+              "relative inline-flex h-2 w-2 rounded-full",
+              up ? "bg-emerald-500" : "bg-muted-foreground/40",
+            )}
+          />
+        </span>
+        <span className="font-mono text-sm font-medium truncate" title={tunnel.name ?? undefined}>
+          {tunnel.name || "—"}
+        </span>
+        <Badge
+          variant="outline"
+          className={cn(
+            "h-4 px-1 text-[10px] font-semibold tracking-wide shrink-0",
+            up
+              ? "border-emerald-500/30 text-emerald-600 dark:text-emerald-400"
+              : "border-red-500/30 text-red-600 dark:text-red-400",
+          )}
+        >
+          {up ? "UP" : "DOWN"}
+        </Badge>
+      </div>
+
+      {/* line 2: traffic selectors */}
+      <div className="mt-1.5 flex items-center gap-1.5 pl-4 text-xs font-mono">
+        <span className="truncate rounded bg-muted px-1.5 py-0.5 text-foreground/80" title={local}>
+          {local}
+        </span>
+        <ArrowLeftRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        <span className="truncate rounded bg-muted px-1.5 py-0.5 text-foreground/80" title={remote}>
+          {remote}
+        </span>
+      </div>
+
+      {/* line 3: traffic counters + ESP proposal (wraps instead of truncating) */}
+      <div className="mt-1.5 flex flex-wrap items-center justify-between gap-x-4 gap-y-1 pl-4 text-[11px] tabular-nums text-muted-foreground">
+        <div className="flex items-center gap-4">
+          <span className="flex items-center gap-1" title="received">
+            <ArrowDownToLine className="h-3 w-3 text-blue-500" />
+            {formatBytes(tunnel.bytes_in)}
+          </span>
+          <span className="flex items-center gap-1" title="sent">
+            <ArrowUpFromLine className="h-3 w-3 text-orange-500" />
+            {formatBytes(tunnel.bytes_out)}
+          </span>
+        </div>
+        {proposal && (
+          <span
+            className="whitespace-nowrap rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]"
+            title="negotiated ESP proposal"
+          >
+            {proposal}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function IpsecCard({ onRemove, span = 1, onSpanChange }: IpsecCardProps) {
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const { status: sseStatus, data: sseData } = useDashboardData();
+  // Snapshot the stream so "Paused" freezes the displayed status.
+  const [snapshot, setSnapshot] = useState<IPSecStatus | null>(null);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- freeze the last SSE snapshot for the paused view
+    if (autoRefresh && sseData.ipsecStatus) setSnapshot(sseData.ipsecStatus);
+  }, [autoRefresh, sseData.ipsecStatus]);
+
+  const status = snapshot;
+  const loading = status === null;
+  const hasTunnels = !!status && status.tunnels.length > 0;
+
+  return (
+    <Card className="flex flex-col h-[520px]">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+            <Lock className="h-4 w-4 text-primary" />
+          </div>
+          <CardTitle className="text-lg font-medium">IPSec</CardTitle>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant={autoRefresh ? "default" : "outline"}
+            size="sm"
+            onClick={() => setAutoRefresh((v) => !v)}
+            title={autoRefresh ? `Live via dashboard stream (${sseStatus})` : "Paused"}
+          >
+            <RefreshCw className={`h-4 w-4 mr-1 ${autoRefresh && sseStatus === "connected" ? "animate-spin" : ""}`} />
+            {autoRefresh ? "Live" : "Paused"}
+          </Button>
+          {onSpanChange && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <Settings className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {([1, 2, 3] as const).map((n) => (
+                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
+                    <div className="flex items-center justify-between w-full">
+                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
+                      {span === n && <span className="ml-2 text-primary">✓</span>}
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          {onRemove && (
+            <Button variant="ghost" size="sm" onClick={onRemove}>
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+
+      {/* summary stat bar */}
+      {hasTunnels && (
+        <div className="flex items-center gap-5 border-y bg-muted/30 px-4 py-2 shrink-0">
+          <StatPill label="Up" value={status!.up} tone="up" />
+          <StatPill label="Down" value={status!.down} tone="down" />
+          <StatPill label="Total" value={status!.total} tone="total" />
+        </div>
+      )}
+
+      <CardContent className="flex flex-col flex-1 min-h-0 p-0">
+        {loading ? (
+          <div className="px-4 py-6 text-center text-muted-foreground text-sm">Loading…</div>
+        ) : !hasTunnels ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+            <ShieldOff className="h-8 w-8 opacity-40" />
+            No active IPSec tunnels.
+          </div>
+        ) : (
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {status!.tunnels.map((t, i) => (
+              <TunnelRow key={`${t.name ?? "tunnel"}-${i}`} tunnel={t} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/hooks/useDashboardSSE.ts
+++ b/frontend/src/hooks/useDashboardSSE.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { InterfaceCounter } from "@/lib/api/show";
 import { QoSStatsResponse } from "@/lib/api/qos";
 import { OpenVpnStatus } from "@/lib/api/openvpn";
+import { IPSecStatus } from "@/lib/api/ipsec";
 
 // ============================================================================
 // Types
@@ -139,6 +140,7 @@ export interface DashboardSSEData {
   openvpnStatus: OpenVpnStatus | null;
   vrrpStatus: VrrpStatusData | null;
   bgpStatus: BgpStatusData | null;
+  ipsecStatus: IPSecStatus | null;
 }
 
 export interface DashboardSSEState {
@@ -153,7 +155,7 @@ export interface DashboardSSEState {
 
 export function useDashboardSSE(): DashboardSSEState {
   const [status, setStatus] = useState<SSEStatus>("disconnected");
-  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null, vrrpStatus: null, bgpStatus: null });
+  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null, vrrpStatus: null, bgpStatus: null, ipsecStatus: null });
   const [error, setError] = useState<string | null>(null);
   const esRef = useRef<EventSource | null>(null);
 
@@ -227,6 +229,15 @@ export function useDashboardSSE(): DashboardSSEState {
       try {
         const payload = JSON.parse(event.data) as BgpStatusData;
         setData((prev) => ({ ...prev, bgpStatus: payload }));
+      } catch {
+        // Ignore malformed payloads
+      }
+    });
+
+    es.addEventListener("ipsec-status", (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as IPSecStatus;
+        setData((prev) => ({ ...prev, ipsecStatus: payload }));
       } catch {
         // Ignore malformed payloads
       }

--- a/frontend/src/lib/api/ipsec.ts
+++ b/frontend/src/lib/api/ipsec.ts
@@ -12,6 +12,35 @@ export interface IPSecProposal {
   prf?: string | null;
 }
 
+// ---- Live operational status (dashboard SSE + page refresh) ----
+
+export interface IPSecNegotiatedProposal {
+  cipher?: string | null;     // e.g. "AES"
+  mode?: string | null;       // e.g. "CBC"
+  key_size?: string | null;   // e.g. "256"
+  hash?: string | null;       // e.g. "HMAC_SHA2_256_128"
+  dh?: string | null;         // e.g. "MODP_2048"
+}
+
+export interface IPSecTunnelStatus {
+  name: string | null;        // e.g. "peer5-tunnel-0"
+  state: string | null;       // "up" / "down"
+  local_ts: string[];
+  remote_ts: string[];
+  bytes_in?: string | null;
+  bytes_out?: string | null;
+  packets_in?: string | null;
+  packets_out?: string | null;
+  esp_proposal?: IPSecNegotiatedProposal | null;
+}
+
+export interface IPSecStatus {
+  tunnels: IPSecTunnelStatus[];
+  total: number;
+  up: number;
+  down: number;
+}
+
 export interface IKEGroup {
   name: string;
   close_action?: string | null;
@@ -681,6 +710,41 @@ class IPSecService {
 
   async executeBatch(itemName: string, operations: BatchOperation[]): Promise<VyOSResponse> {
     return this.batchConfigure(itemName, operations);
+  }
+
+  // ==========================================================================
+  // Operational commands (live status + reset/bounce)
+  // ==========================================================================
+
+  /** Live site-to-site tunnel status (on-demand refresh). */
+  async getStatus(): Promise<IPSecStatus> {
+    return apiClient.get<IPSecStatus>("/vyos/vpn/ipsec/status");
+  }
+
+  /** Bounce a single site-to-site peer, or just one of its tunnels. */
+  async resetPeer(peer: string, tunnel?: string): Promise<VyOSResponse> {
+    const result = await apiClient.post<VyOSResponse>("/vyos/vpn/ipsec/reset/peer", {
+      peer,
+      ...(tunnel !== undefined ? { tunnel } : {}),
+    });
+    if (!result.success) throw new Error(result.error || "Failed to reset peer");
+    return result;
+  }
+
+  /** Bounce every configured site-to-site peer at once. */
+  async resetAllPeers(): Promise<VyOSResponse> {
+    const result = await apiClient.post<VyOSResponse>("/vyos/vpn/ipsec/reset/all", {});
+    if (!result.success) throw new Error(result.error || "Failed to reset peers");
+    return result;
+  }
+
+  /** Reset remote-access (IKEv2 road-warrior) sessions, optionally for one user. */
+  async resetRemoteAccess(username?: string): Promise<VyOSResponse> {
+    const result = await apiClient.post<VyOSResponse>("/vyos/vpn/ipsec/reset/remote-access", {
+      ...(username !== undefined ? { username } : {}),
+    });
+    if (!result.success) throw new Error(result.error || "Failed to reset remote-access sessions");
+    return result;
   }
 }
 


### PR DESCRIPTION
Backend:
- ipsec_status.py: parse ShowConnectionsSummaryIpsec into per-tunnel up/down state with byte/packet counters and the negotiated ESP proposal
- Stream ipsec-status over the dashboard SSE broadcaster (slow cycle, gated on IPSec being configured)
- IPSec router: operational endpoints via GraphQL (op-mode, not config) — GET /status, POST /reset/peer, /reset/all, /reset/remote-access
- Move ShowOpenvpn off the shared fast/slow queries onto its own concurrent task (30s timeout, 6s cooldown); the op is slow/erratic (2-16s) and was intermittently timing out the whole fast fetch

Frontend:
- IpsecCard dashboard card: summary stat bar, per-tunnel status dots, traffic-selector chips, humanized byte counters and ESP proposal
- IPSec page: per-peer Bounce, Reset All, Refresh Status, live up/down badges; Reset Sessions on the Remote Access tab
- ipsecStatus wired into the dashboard SSE hook; status/reset methods on the ipsec API service