### PR TITLE
Add adjustable dashboard card heights and widths

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,13 @@ import { Github, Globe, MessageCircle, Sparkles, ArrowUpCircle, Tag } from "luci
 import { useSession } from "@/lib/auth-client";
 import { useSessionStore } from "@/store/session-store";
 import { dashboardService, DashboardCard, DashboardLayout } from "@/lib/api/dashboard";
+import {
+  compactLayout,
+  cardPixelHeight,
+  DEFAULT_HEIGHT,
+  GRID_COLUMNS,
+  ROW_UNIT,
+} from "@/lib/dashboard-layout";
 import { versionService, VersionCheckResponse } from "@/lib/api/version";
 import { InterfaceStatisticsCard } from "@/components/dashboard/InterfaceStatisticsCard";
 import { SystemInfoCard } from "@/components/dashboard/SystemInfoCard";
@@ -62,7 +69,7 @@ function SortableCard({ card, children }: { card: DashboardCard; children: React
     <div
       ref={setNodeRef}
       style={style}
-      className={`${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
+      className={`h-full ${isDragging ? "cursor-grabbing" : "cursor-grab"} ${
         isOver ? "ring-2 ring-primary ring-offset-2" : ""
       }`}
       {...attributes}
@@ -140,18 +147,16 @@ export default function Home() {
     try {
       const response = await dashboardService.getLayout();
       if (response.exists && response.layout) {
-        // Ensure all cards have a span property (backward compatibility)
-        const cardsWithSpan = (response.layout.cards || []).map((card) => {
-          if (card.span === undefined) {
-            // Set default span based on card type
-            if (card.type === "interface-statistics" || card.type === "network-speed") {
-              return { ...card, span: 2 };
-            }
-            return { ...card, span: 1 };
-          }
-          return card;
+        // Backfill span/height for cards saved before those fields existed,
+        // then compact so legacy row-index positions reflow into the row-unit grid.
+        const normalized = (response.layout.cards || []).map((card) => {
+          const span =
+            card.span ??
+            (card.type === "interface-statistics" || card.type === "network-speed" ? 2 : 1);
+          const height = card.height ?? DEFAULT_HEIGHT;
+          return { ...card, span, height };
         });
-        setCards(cardsWithSpan);
+        setCards(compactLayout(normalized));
       } else {
         setCards([]);
       }
@@ -253,18 +258,19 @@ export default function Home() {
 
     const cardSpan = activeCard.span || 1;
     let targetColumn = 0;
-    let targetPosition = 0;
+    // Tentative vertical position that steers compaction: a card dropped onto
+    // another takes a slot just above it; a column-overlay drop goes to the top.
+    let tentativePosition = 0;
 
     // Check if dropped on a column zone
     const columnMatch = over.id.toString().match(/^column-(\d+)$/);
     if (columnMatch) {
       targetColumn = parseInt(columnMatch[1]);
-      console.log(`[Drag] Dropped on Column ${targetColumn + 1} overlay`);
+      tentativePosition = -1; // top of the column
     } else {
       // Check if dropped on another card
       const overCard = cards.find((c) => c.id === over.id);
       if (!overCard) {
-        console.log(`[Drag] Dropped on unknown target: ${over.id}`);
         return;
       }
 
@@ -273,81 +279,20 @@ export default function Home() {
         return;
       }
 
-      // Use the overCard's column and position as target
+      // Take the target card's column and insert just above its position.
       targetColumn = overCard.column;
-      targetPosition = overCard.position;
-      console.log(`[Drag] Dropped on card at column=${targetColumn}, position=${targetPosition}`);
+      tentativePosition = overCard.position - 0.5;
     }
 
-    // SMART VALIDATION: Adjust column if span would overflow
-    // A card can only start at a column where it won't exceed column 2
-    const maxStartColumn = 3 - cardSpan; // span 1: max col 2, span 2: max col 1, span 3: max col 0
-    if (targetColumn > maxStartColumn) {
-      targetColumn = maxStartColumn;
-    }
+    // Clamp the start column so the card's span fits within the grid width.
+    const maxStartColumn = GRID_COLUMNS - cardSpan;
+    targetColumn = Math.min(Math.max(targetColumn, 0), maxStartColumn);
 
-    // Build occupancy map from all existing cards (excluding the one being moved)
-    const rowOccupancy: Map<number, Set<number>> = new Map();
-    for (const card of cards) {
-      if (card.id === activeCard.id) continue;
+    const updatedCards = cards.map((c) =>
+      c.id === activeCard.id ? { ...c, column: targetColumn, position: tentativePosition } : c
+    );
 
-      const span = card.span || 1;
-      const startCol = card.column;
-      const endCol = Math.min(startCol + span - 1, 2);
-
-      if (!rowOccupancy.has(card.position)) {
-        rowOccupancy.set(card.position, new Set());
-      }
-
-      for (let col = startCol; col <= endCol; col++) {
-        rowOccupancy.get(card.position)!.add(col);
-      }
-    }
-
-    // If dropped on a column overlay, find next available row
-    // If dropped on a card, try to use that card's position first
-    if (columnMatch) {
-      targetPosition = 0; // Start from top for column drops
-    }
-
-    // Find first available row where this card can fit
-    const endCol = targetColumn + cardSpan - 1;
-    let finalPosition = targetPosition;
-
-    while (finalPosition < 100) {
-      const occupied = rowOccupancy.get(finalPosition);
-      if (!occupied) {
-        // Row is completely empty
-        break;
-      }
-
-      // Check if columns needed for this card are free
-      let allFree = true;
-      for (let col = targetColumn; col <= endCol; col++) {
-        if (occupied.has(col)) {
-          allFree = false;
-          break;
-        }
-      }
-
-      if (allFree) {
-        // Found a free spot
-        break;
-      }
-
-      finalPosition++;
-    }
-
-    const updatedCards = cards.map((c) => {
-      if (c.id === activeCard.id) {
-        return { ...c, column: targetColumn, position: finalPosition };
-      }
-      return c;
-    });
-
-    console.log(`[Drag] Placed card: column=${targetColumn}, position=${finalPosition}, span=${cardSpan}`);
-
-    setCards(updatedCards);
+    setCards(compactLayout(updatedCards));
     setHasUnsavedChanges(true);
   };
 
@@ -377,76 +322,41 @@ export default function Home() {
     }
     // system-info defaults to 1 column (already set above)
 
-    // New cards always start at column 0
-    const targetColumn = 0;
-
-    // Build occupancy map from existing cards
-    const rowOccupancy: Map<number, Set<number>> = new Map();
-    for (const card of cards) {
-      const span = card.span || 1;
-      const startCol = card.column;
-      const endCol = Math.min(startCol + span - 1, 2);
-
-      if (!rowOccupancy.has(card.position)) {
-        rowOccupancy.set(card.position, new Set());
-      }
-
-      for (let col = startCol; col <= endCol; col++) {
-        rowOccupancy.get(card.position)!.add(col);
-      }
-    }
-
-    // Find first available row where this card can fit
-    let targetPosition = 0;
-    const endCol = targetColumn + defaultSpan - 1;
-
-    while (targetPosition < 100) {
-      const occupied = rowOccupancy.get(targetPosition);
-      if (!occupied) {
-        // Row is completely empty
-        break;
-      }
-
-      // Check if columns needed for this card are free
-      let allFree = true;
-      for (let col = targetColumn; col <= endCol; col++) {
-        if (occupied.has(col)) {
-          allFree = false;
-          break;
-        }
-      }
-
-      if (allFree) {
-        break;
-      }
-
-      targetPosition++;
-    }
-
+    // Append at the bottom of column 0 (large tentative position) and let
+    // compaction settle it into the first free slot.
     const newCard: DashboardCard = {
       id: `card-${Date.now()}`,
       type: cardType,
-      column: targetColumn,
-      position: targetPosition,
+      column: 0,
+      position: Number.MAX_SAFE_INTEGER,
       span: defaultSpan,
+      height: DEFAULT_HEIGHT,
     };
 
-    setCards([...cards, newCard]);
+    setCards(compactLayout([...cards, newCard]));
     setHasUnsavedChanges(true);
   };
 
   const handleRemoveCard = (cardId: string) => {
-    setCards(cards.filter((c) => c.id !== cardId));
+    setCards(compactLayout(cards.filter((c) => c.id !== cardId)));
     setHasUnsavedChanges(true);
   };
 
   const handleCardSpanChange = (cardId: string, newSpan: number) => {
-    setCards(cards.map((c) => {
-      if (c.id === cardId) {
-        return { ...c, span: newSpan };
-      }
-      return c;
-    }));
+    setCards(
+      compactLayout(
+        cards.map((c) => (c.id === cardId ? { ...c, span: newSpan } : c))
+      )
+    );
+    setHasUnsavedChanges(true);
+  };
+
+  const handleCardHeightChange = (cardId: string, newHeight: number) => {
+    setCards(
+      compactLayout(
+        cards.map((c) => (c.id === cardId ? { ...c, height: newHeight } : c))
+      )
+    );
     setHasUnsavedChanges(true);
   };
 
@@ -482,6 +392,8 @@ export default function Home() {
       onRemove: editMode ? () => handleRemoveCard(card.id) : undefined,
       span: card.span || 1,
       onSpanChange: editMode ? (newSpan: number) => handleCardSpanChange(card.id, newSpan) : undefined,
+      height: card.height ?? DEFAULT_HEIGHT,
+      onHeightChange: editMode ? (newHeight: number) => handleCardHeightChange(card.id, newHeight) : undefined,
       onConfigChange: editMode
         ? (config: Record<string, unknown>) => handleCardConfigChange(card.id, config)
         : undefined,
@@ -511,26 +423,13 @@ export default function Home() {
     }
   };
 
-  // Get grid placement classes and styles for explicit positioning
-  const getGridClasses = (card: DashboardCard) => {
-    const span = card.span || 1;
-    let classes = "";
-
-    // Column span
-    if (span === 2) classes += "col-span-2 ";
-    if (span === 3) classes += "col-span-3 ";
-
-    // Column start position
-    if (card.column === 1) classes += "col-start-2 ";
-    if (card.column === 2) classes += "col-start-3 ";
-
-    return classes.trim();
-  };
-
+  // Explicit grid placement: a card occupies a rectangle of columns × row-units.
   const getGridStyle = (card: DashboardCard) => {
-    // Explicit row placement
+    const span = card.span || 1;
+    const height = card.height ?? DEFAULT_HEIGHT;
     return {
-      gridRow: card.position + 1
+      gridColumn: `${card.column + 1} / span ${span}`,
+      gridRow: `${card.position + 1} / span ${height}`,
     };
   };
 
@@ -686,7 +585,10 @@ export default function Home() {
             {/* Wrapper for grid and overlays */}
             <div className="relative">
               {/* Main grid with explicit card placement */}
-              <div className="grid grid-cols-3 gap-6 auto-rows-min relative z-0">
+              <div
+                className="grid grid-cols-3 gap-6 relative z-0"
+                style={{ gridAutoRows: `${ROW_UNIT}px` }}
+              >
                 <SortableContext
                   items={cards.map((c) => c.id)}
                   strategy={verticalListSortingStrategy}
@@ -698,13 +600,12 @@ export default function Home() {
                         {renderCard(card)}
                       </SortableCard>
                     ) : (
-                      <div key={card.id}>{renderCard(card)}</div>
+                      <div key={card.id} className="h-full">{renderCard(card)}</div>
                     );
 
                     return (
                       <div
                         key={card.id}
-                        className={getGridClasses(card)}
                         style={getGridStyle(card)}
                       >
                         {cardElement}
@@ -742,7 +643,14 @@ export default function Home() {
             {/* Drag Overlay - Shows the card being dragged */}
             <DragOverlay>
               {activeId ? (
-                <div className="opacity-80 cursor-grabbing">
+                <div
+                  className="opacity-80 cursor-grabbing"
+                  style={{
+                    height: cardPixelHeight(
+                      cards.find((c) => c.id === activeId)?.height ?? DEFAULT_HEIGHT
+                    ),
+                  }}
+                >
                   {renderCard(cards.find((c) => c.id === activeId)!)}
                 </div>
               ) : null}

--- a/frontend/src/components/dashboard/BgpStatusCard.tsx
+++ b/frontend/src/components/dashboard/BgpStatusCard.tsx
@@ -4,15 +4,8 @@ import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { X, Route, RefreshCw, Settings, Clock, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { X, Route, RefreshCw, Clock, ArrowDownToLine, ArrowUpFromLine } from "lucide-react";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { BgpStatusData, BgpAddressFamilyData, BgpPeerData } from "@/hooks/useDashboardSSE";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 
@@ -20,6 +13,8 @@ interface BgpStatusCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -95,7 +90,7 @@ function FamilySection({ family }: { family: BgpAddressFamilyData }) {
   );
 }
 
-export function BgpStatusCard({ onRemove, span = 1, onSpanChange }: BgpStatusCardProps) {
+export function BgpStatusCard({ onRemove, span = 1, onSpanChange, height, onHeightChange }: BgpStatusCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { status: sseStatus, data: sseData } = useDashboardData();
   // Snapshot the stream so "Paused" freezes the displayed status.
@@ -110,7 +105,7 @@ export function BgpStatusCard({ onRemove, span = 1, onSpanChange }: BgpStatusCar
   const families = status?.address_families ?? [];
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <Route className="h-5 w-5 text-primary" />
@@ -132,25 +127,12 @@ export function BgpStatusCard({ onRemove, span = 1, onSpanChange }: BgpStatusCar
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/CardSizeMenu.tsx
+++ b/frontend/src/components/dashboard/CardSizeMenu.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { DEFAULT_HEIGHT, HEIGHT_PRESETS } from "@/lib/dashboard-layout";
+
+const WIDTH_PRESETS: { label: string; value: number }[] = [
+  { label: "Small (1 column)", value: 1 },
+  { label: "Medium (2 columns)", value: 2 },
+  { label: "Large (3 columns)", value: 3 },
+];
+
+interface CardSizeMenuProps {
+  span?: number;
+  onSpanChange: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
+}
+
+/**
+ * Shared gear-icon dropdown for choosing a dashboard card's width and height.
+ * Rendered only in edit mode (callers gate on `onSpanChange` being defined).
+ */
+export function CardSizeMenu({
+  span = 1,
+  onSpanChange,
+  height = DEFAULT_HEIGHT,
+  onHeightChange,
+}: CardSizeMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm">
+          <Settings className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Card Width</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {WIDTH_PRESETS.map((preset) => (
+          <DropdownMenuItem key={preset.value} onClick={() => onSpanChange(preset.value)}>
+            <div className="flex items-center justify-between w-full">
+              <span>{preset.label}</span>
+              {span === preset.value && <span className="ml-2 text-primary">✓</span>}
+            </div>
+          </DropdownMenuItem>
+        ))}
+
+        {onHeightChange && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Card Height</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {HEIGHT_PRESETS.map((preset) => (
+              <DropdownMenuItem key={preset.value} onClick={() => onHeightChange(preset.value)}>
+                <div className="flex items-center justify-between w-full">
+                  <span>{preset.label}</span>
+                  {height === preset.value && <span className="ml-2 text-primary">✓</span>}
+                </div>
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/dashboard/InterfaceStatisticsCard.tsx
+++ b/frontend/src/components/dashboard/InterfaceStatisticsCard.tsx
@@ -9,7 +9,6 @@ import {
   X,
   Network,
   RefreshCw,
-  Settings,
   ChevronLeft,
   ChevronRight,
   ChevronDown,
@@ -20,14 +19,7 @@ import {
 import { InterfaceCounter } from "@/lib/api/show";
 import { getInterfaceType, formatBytes } from "@/lib/utils";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { ethernetService } from "@/lib/api/ethernet";
 
 // ============================================================================
@@ -48,6 +40,8 @@ interface InterfaceStatisticsCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -262,6 +256,8 @@ export function InterfaceStatisticsCard({
   onRemove,
   span = 1,
   onSpanChange,
+  height,
+  onHeightChange,
 }: InterfaceStatisticsCardProps) {
   const [interfaces, setInterfaces] = useState<InterfaceWithType[]>([]);
   const [loading, setLoading] = useState(true);
@@ -402,7 +398,7 @@ export function InterfaceStatisticsCard({
   const isConnected = sseStatus === "connected";
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <Network className="h-5 w-5 text-primary" />
@@ -427,27 +423,12 @@ export function InterfaceStatisticsCard({
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>
-                        {n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}
-                      </span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/IpsecCard.tsx
+++ b/frontend/src/components/dashboard/IpsecCard.tsx
@@ -8,20 +8,12 @@ import {
   X,
   Lock,
   RefreshCw,
-  Settings,
   ArrowDownToLine,
   ArrowUpFromLine,
   ArrowLeftRight,
   ShieldOff,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { cn } from "@/lib/utils";
 import { IPSecStatus, IPSecTunnelStatus } from "@/lib/api/ipsec";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
@@ -30,6 +22,8 @@ interface IpsecCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -152,7 +146,7 @@ function TunnelRow({ tunnel }: { tunnel: IPSecTunnelStatus }) {
   );
 }
 
-export function IpsecCard({ onRemove, span = 1, onSpanChange }: IpsecCardProps) {
+export function IpsecCard({ onRemove, span = 1, onSpanChange, height, onHeightChange }: IpsecCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { status: sseStatus, data: sseData } = useDashboardData();
   // Snapshot the stream so "Paused" freezes the displayed status.
@@ -167,7 +161,7 @@ export function IpsecCard({ onRemove, span = 1, onSpanChange }: IpsecCardProps) 
   const hasTunnels = !!status && status.tunnels.length > 0;
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
@@ -186,25 +180,12 @@ export function IpsecCard({ onRemove, span = 1, onSpanChange }: IpsecCardProps) 
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/NetworkSpeedCard.tsx
+++ b/frontend/src/components/dashboard/NetworkSpeedCard.tsx
@@ -17,7 +17,6 @@ import {
   X,
   TrendingUp,
   RefreshCw,
-  Settings,
   ArrowDown,
   ArrowUp,
   Network,
@@ -30,6 +29,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import Link from "next/link";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 import { ethernetService } from "@/lib/api/ethernet";
@@ -69,6 +69,8 @@ interface NetworkSpeedCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -150,6 +152,8 @@ export function NetworkSpeedCard({
   onRemove,
   span = 1,
   onSpanChange,
+  height,
+  onHeightChange,
   config,
   onConfigChange,
 }: NetworkSpeedCardProps) {
@@ -268,7 +272,7 @@ export function NetworkSpeedCard({
   const isLoading = !sseData.interfaceCounters && sseStatus === "connecting";
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3 shrink-0">
         <div className="flex flex-col min-w-0 flex-1">
           <div className="flex items-center gap-2">
@@ -360,31 +364,12 @@ export function NetworkSpeedCard({
           </Button>
 
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>
-                        {n === 1
-                          ? "Small (1 column)"
-                          : n === 2
-                          ? "Medium (2 columns)"
-                          : "Large (3 columns)"}
-                      </span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
 
           {onRemove && (

--- a/frontend/src/components/dashboard/OpenVpnCard.tsx
+++ b/frontend/src/components/dashboard/OpenVpnCard.tsx
@@ -8,19 +8,11 @@ import {
   X,
   ShieldCheck,
   RefreshCw,
-  Settings,
   ArrowDown,
   ArrowUp,
   Clock,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { OpenVpnStatus, OpenVpnTunnel } from "@/lib/api/openvpn";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 
@@ -28,6 +20,8 @@ interface OpenVpnCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -118,7 +112,7 @@ function TunnelGroup({ title, tunnels }: { title: string; tunnels: OpenVpnTunnel
   );
 }
 
-export function OpenVpnCard({ onRemove, span = 1, onSpanChange }: OpenVpnCardProps) {
+export function OpenVpnCard({ onRemove, span = 1, onSpanChange, height, onHeightChange }: OpenVpnCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { status: sseStatus, data: sseData } = useDashboardData();
   // Snapshot the stream so "Paused" freezes the displayed status.
@@ -135,7 +129,7 @@ export function OpenVpnCard({ onRemove, span = 1, onSpanChange }: OpenVpnCardPro
     : 0;
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <ShieldCheck className="h-5 w-5 text-primary" />
@@ -152,25 +146,12 @@ export function OpenVpnCard({ onRemove, span = 1, onSpanChange }: OpenVpnCardPro
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/QoSStatsCard.tsx
+++ b/frontend/src/components/dashboard/QoSStatsCard.tsx
@@ -8,18 +8,10 @@ import {
   X,
   Gauge,
   RefreshCw,
-  Settings,
   AlertTriangle,
   CheckCircle2,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { QoSClassStats } from "@/lib/api/qos";
 import { formatBytes } from "@/lib/utils";
 import { formatBitrate, qosCakeKey, qosSampleKey, useQoSRates } from "@/hooks/useQoSRates";
@@ -31,6 +23,8 @@ interface QoSStatsCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -40,7 +34,7 @@ function classLabel(c: QoSClassStats): string {
   return `class ${c.class_name}`;
 }
 
-export function QoSStatsCard({ onRemove, span = 1, onSpanChange, config, onConfigChange }: QoSStatsCardProps) {
+export function QoSStatsCard({ onRemove, span = 1, onSpanChange, height, onHeightChange, config, onConfigChange }: QoSStatsCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   // Watched interface; "" = all. Seeded from saved card config, editable live.
   const [selected, setSelected] = useState<string>(() => (config?.interface as string) || "");
@@ -73,7 +67,7 @@ export function QoSStatsCard({ onRemove, span = 1, onSpanChange, config, onConfi
   };
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <Gauge className="h-5 w-5 text-primary" />
@@ -97,27 +91,12 @@ export function QoSStatsCard({ onRemove, span = 1, onSpanChange, config, onConfi
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>
-                        {n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}
-                      </span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/SystemInfoCard.tsx
+++ b/frontend/src/components/dashboard/SystemInfoCard.tsx
@@ -8,19 +8,11 @@ import {
   X,
   Server,
   RefreshCw,
-  Settings,
   MemoryStick,
   HardDrive,
   Activity,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 import { LoadData, DiskPartition } from "@/hooks/useDashboardSSE";
 
@@ -79,6 +71,8 @@ interface SystemInfoCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
 }
 
@@ -90,6 +84,8 @@ export function SystemInfoCard({
   onRemove,
   span = 1,
   onSpanChange,
+  height,
+  onHeightChange,
 }: SystemInfoCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { status: sseStatus, data: sseData } = useDashboardData();
@@ -109,7 +105,7 @@ export function SystemInfoCard({
   const isConnected = sseStatus === "connected";
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4 shrink-0">
         <div className="flex items-center gap-2">
           <Server className="h-5 w-5 text-primary" />
@@ -128,35 +124,12 @@ export function SystemInfoCard({
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => onSpanChange(1)}>
-                  <div className="flex items-center justify-between w-full">
-                    <span>Small (1 column)</span>
-                    {span === 1 && <span className="ml-2 text-primary">✓</span>}
-                  </div>
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onSpanChange(2)}>
-                  <div className="flex items-center justify-between w-full">
-                    <span>Medium (2 columns)</span>
-                    {span === 2 && <span className="ml-2 text-primary">✓</span>}
-                  </div>
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onSpanChange(3)}>
-                  <div className="flex items-center justify-between w-full">
-                    <span>Large (3 columns)</span>
-                    {span === 3 && <span className="ml-2 text-primary">✓</span>}
-                  </div>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/VrrpStatusCard.tsx
+++ b/frontend/src/components/dashboard/VrrpStatusCard.tsx
@@ -4,15 +4,8 @@ import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { X, Network, RefreshCw, Settings, Clock } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { X, Network, RefreshCw, Clock } from "lucide-react";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { VrrpStatusData, VrrpGroupData } from "@/hooks/useDashboardSSE";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 
@@ -20,6 +13,8 @@ interface VrrpStatusCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
   onConfigChange?: (config: Record<string, unknown>) => void;
 }
@@ -72,7 +67,7 @@ function GroupRow({ group }: { group: VrrpGroupData }) {
   );
 }
 
-export function VrrpStatusCard({ onRemove, span = 1, onSpanChange }: VrrpStatusCardProps) {
+export function VrrpStatusCard({ onRemove, span = 1, onSpanChange, height, onHeightChange }: VrrpStatusCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { status: sseStatus, data: sseData } = useDashboardData();
   // Snapshot the stream so "Paused" freezes the displayed status.
@@ -87,7 +82,7 @@ export function VrrpStatusCard({ onRemove, span = 1, onSpanChange }: VrrpStatusC
   const groups = status?.groups ?? [];
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <Network className="h-5 w-5 text-primary" />
@@ -104,25 +99,12 @@ export function VrrpStatusCard({ onRemove, span = 1, onSpanChange }: VrrpStatusC
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>{n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}</span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/components/dashboard/WireGuardPeersCard.tsx
+++ b/frontend/src/components/dashboard/WireGuardPeersCard.tsx
@@ -4,15 +4,8 @@ import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { X, Shield, RefreshCw, Settings } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { X, Shield, RefreshCw } from "lucide-react";
+import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
 import { useDashboardData } from "@/contexts/DashboardDataContext";
 import { WireGuardPeerData, WireGuardInterfaceData } from "@/hooks/useDashboardSSE";
 
@@ -149,6 +142,8 @@ interface WireGuardPeersCardProps {
   onRemove?: () => void;
   span?: number;
   onSpanChange?: (newSpan: number) => void;
+  height?: number;
+  onHeightChange?: (newHeight: number) => void;
   config?: Record<string, unknown>;
 }
 
@@ -160,6 +155,8 @@ export function WireGuardPeersCard({
   onRemove,
   span = 1,
   onSpanChange,
+  height,
+  onHeightChange,
 }: WireGuardPeersCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { status: sseStatus, data: sseData } = useDashboardData();
@@ -175,7 +172,7 @@ export function WireGuardPeersCard({
   ) ?? 0;
 
   return (
-    <Card className="flex flex-col h-[520px]">
+    <Card className="flex flex-col h-full">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 shrink-0">
         <div className="flex items-center gap-2">
           <Shield className="h-5 w-5 text-primary" />
@@ -202,27 +199,12 @@ export function WireGuardPeersCard({
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm">
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>Card Width</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {([1, 2, 3] as const).map((n) => (
-                  <DropdownMenuItem key={n} onClick={() => onSpanChange(n)}>
-                    <div className="flex items-center justify-between w-full">
-                      <span>
-                        {n === 1 ? "Small (1 column)" : n === 2 ? "Medium (2 columns)" : "Large (3 columns)"}
-                      </span>
-                      {span === n && <span className="ml-2 text-primary">✓</span>}
-                    </div>
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <CardSizeMenu
+              span={span}
+              onSpanChange={onSpanChange}
+              height={height}
+              onHeightChange={onHeightChange}
+            />
           )}
           {onRemove && (
             <Button variant="ghost" size="sm" onClick={onRemove}>

--- a/frontend/src/lib/api/dashboard.ts
+++ b/frontend/src/lib/api/dashboard.ts
@@ -11,6 +11,7 @@ export interface DashboardCard {
   column: number; // 0, 1, or 2
   position: number; // position within column
   span?: number; // how many columns this card spans (1, 2, or 3) - defaults to 1
+  height?: number; // how many row-units tall this card is - defaults to standard
   config?: Record<string, unknown>; // card-specific configuration
 }
 

--- a/frontend/src/lib/dashboard-layout.ts
+++ b/frontend/src/lib/dashboard-layout.ts
@@ -1,0 +1,110 @@
+import { DashboardCard } from "./api/dashboard";
+
+// ============================================================================
+// Grid geometry
+// ============================================================================
+
+/** Number of columns in the dashboard grid. */
+export const GRID_COLUMNS = 3;
+
+/** Height (px) of a single grid row-unit. Cards span an integer number of these. */
+export const ROW_UNIT = 46;
+
+/** Gap (px) between grid tracks — must match the `gap-6` class on the grid. */
+export const GRID_GAP = 24;
+
+/**
+ * Height presets, expressed as a count of row-units. Rendered pixel height of a
+ * card is `n*ROW_UNIT + (n-1)*GRID_GAP`, so:
+ *   compact  ≈ 6*46 + 5*24  = 396px
+ *   standard ≈ 8*46 + 7*24  = 536px  (≈ the old fixed 520px height)
+ *   tall     ≈ 11*46 + 10*24 = 746px
+ */
+export const CARD_HEIGHTS = {
+  compact: 6,
+  standard: 8,
+  tall: 12,
+} as const;
+
+/** Default height for new cards and legacy cards that predate the height field. */
+export const DEFAULT_HEIGHT = CARD_HEIGHTS.standard;
+
+/** Ordered presets for the card size menu. */
+export const HEIGHT_PRESETS: { label: string; value: number }[] = [
+  { label: "Compact", value: CARD_HEIGHTS.compact },
+  { label: "Standard", value: CARD_HEIGHTS.standard },
+  { label: "Tall", value: CARD_HEIGHTS.tall },
+];
+
+/** Resolved pixel height of a card given its row-unit height. */
+export function cardPixelHeight(height: number): number {
+  const h = Math.max(height, 1);
+  return h * ROW_UNIT + (h - 1) * GRID_GAP;
+}
+
+// ============================================================================
+// Placement engine
+// ============================================================================
+
+/**
+ * Pack cards into the grid with no overlaps, pulling everything upward
+ * (column-respecting vertical compaction, like react-grid-layout's vertical
+ * compactType). Each card occupies a rectangle of columns
+ * `[column .. column+span-1]` × row-units `[position .. position+height-1]`.
+ *
+ * A card's column is preserved (clamped to fit the grid width); its vertical
+ * position is recomputed as the lowest free row in that column range. Process
+ * order — and therefore who claims the top slots — follows each card's current
+ * `(position, column)`, so callers steer placement by setting a tentative
+ * `position` before calling (e.g. a fractional value to insert above a target).
+ *
+ * Returns new card objects; inputs are not mutated.
+ */
+export function compactLayout(cards: DashboardCard[]): DashboardCard[] {
+  // Occupancy: row-unit index -> set of occupied columns.
+  const occ: Map<number, Set<number>> = new Map();
+
+  const isFree = (col: number, row: number, span: number, height: number): boolean => {
+    const endCol = col + span - 1;
+    for (let r = row; r < row + height; r++) {
+      const set = occ.get(r);
+      if (!set) continue;
+      for (let c = col; c <= endCol; c++) {
+        if (set.has(c)) return false;
+      }
+    }
+    return true;
+  };
+
+  const mark = (col: number, row: number, span: number, height: number): void => {
+    const endCol = col + span - 1;
+    for (let r = row; r < row + height; r++) {
+      let set = occ.get(r);
+      if (!set) {
+        set = new Set();
+        occ.set(r, set);
+      }
+      for (let c = col; c <= endCol; c++) set.add(c);
+    }
+  };
+
+  const ordered = [...cards].sort((a, b) => {
+    const pa = a.position ?? 0;
+    const pb = b.position ?? 0;
+    if (pa !== pb) return pa - pb;
+    return (a.column ?? 0) - (b.column ?? 0);
+  });
+
+  return ordered.map((card) => {
+    const span = Math.min(Math.max(card.span ?? 1, 1), GRID_COLUMNS);
+    const height = Math.max(card.height ?? DEFAULT_HEIGHT, 1);
+    // Clamp the start column so the card fits within the grid width.
+    const col = Math.min(Math.max(card.column ?? 0, 0), GRID_COLUMNS - span);
+
+    let row = 0;
+    while (!isFree(col, row, span, height)) row++;
+    mark(col, row, span, height);
+
+    return { ...card, span, height, column: col, position: row };
+  });
+}


### PR DESCRIPTION
Introduce per-card height presets (Compact/Standard/Tall) alongside the existing width presets, both chosen from each card's gear menu.

- Add a fixed row-unit grid with 2D compaction (compactLayout) so cards of differing heights pack without overlap and reflow on resize/drag/add
- New shared CardSizeMenu component replaces the per-card width dropdowns
- Add height field to DashboardCard; backfill + migrate legacy layouts on load
- Cards switch from a fixed h-[520px] to h-full so the grid cell drives height