### PR TITLE
Fixed tables calling delete and rule reorder

### DIFF
--- a/backend/routers/as_path_list/as_path_list.py
+++ b/backend/routers/as_path_list/as_path_list.py
@@ -72,7 +72,7 @@ class AsPathListBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule in a reorder request"""
     old_number: int = Field(..., description="Original rule number")
-    new_number: int = Field(..., description="New rule number after reorder")
+    new_number: Optional[int] = Field(None, description="New rule number after reorder; None = delete-only")
     rule_data: AsPathListRule = Field(..., description="Complete rule configuration")
 
 
@@ -284,6 +284,8 @@ async def reorder_as_path_list_rules(http_request: Request, body: ReorderAsPathL
         # Step 2: Recreate rules with new numbers
         for rule_item in body.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule

--- a/backend/routers/community_list/community_list.py
+++ b/backend/routers/community_list/community_list.py
@@ -72,7 +72,7 @@ class CommunityListBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule in a reorder request"""
     old_number: int = Field(..., description="Original rule number")
-    new_number: int = Field(..., description="New rule number after reorder")
+    new_number: Optional[int] = Field(None, description="New rule number after reorder; None = delete-only")
     rule_data: CommunityListRule = Field(..., description="Complete rule configuration")
 
 
@@ -284,6 +284,8 @@ async def reorder_community_list_rules(http_request: Request, body: ReorderCommu
         # Step 2: Recreate rules with new numbers
         for rule_item in body.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule

--- a/backend/routers/extcommunity_list/extcommunity_list.py
+++ b/backend/routers/extcommunity_list/extcommunity_list.py
@@ -72,7 +72,7 @@ class ExtCommunityListBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule in a reorder request"""
     old_number: int = Field(..., description="Original rule number")
-    new_number: int = Field(..., description="New rule number after reorder")
+    new_number: Optional[int] = Field(None, description="New rule number after reorder; None = delete-only")
     rule_data: ExtCommunityListRule = Field(..., description="Complete rule configuration")
 
 
@@ -284,6 +284,8 @@ async def reorder_extcommunity_list_rules(http_request: Request, body: ReorderEx
         # Step 2: Recreate rules with new numbers
         for rule_item in body.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule

--- a/backend/routers/firewall/ipv4.py
+++ b/backend/routers/firewall/ipv4.py
@@ -244,7 +244,7 @@ class FirewallBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule item for reordering."""
     old_number: int
-    new_number: int
+    new_number: Optional[int] = None  # None = delete-only (removed, not recreated)
     rule_data: Dict[str, Any]
 
 
@@ -322,6 +322,8 @@ async def get_firewall_ipv4_capabilities(request: Request):
             capabilities["instance_id"] = request.state.instance.get("id")
 
         return capabilities
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -826,6 +828,8 @@ async def get_firewall_ipv4_config(http_request: Request, refresh: bool = False)
             prerouting_raw=prerouting_raw,
             total_rules=total_rules
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -897,6 +901,8 @@ async def firewall_ipv4_batch_configure(http_request: Request, request: Firewall
             data={"message": "Firewall configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -935,6 +941,8 @@ async def firewall_ipv4_reorder_rules(http_request: Request, request: ReorderFir
         # Step 2: Recreate rules with new numbers
         for rule_item in request.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule
@@ -1263,6 +1271,8 @@ async def firewall_ipv4_reorder_rules(http_request: Request, request: ReorderFir
             data={"message": "Rules reordered successfully"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/firewall/ipv6.py
+++ b/backend/routers/firewall/ipv6.py
@@ -244,7 +244,7 @@ class FirewallBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule item for reordering."""
     old_number: int
-    new_number: int
+    new_number: Optional[int] = None  # None = delete-only (removed, not recreated)
     rule_data: Dict[str, Any]
 
 
@@ -313,6 +313,8 @@ async def get_firewall_ipv6_capabilities(request: Request):
             capabilities["instance_id"] = request.state.instance.get("id")
 
         return capabilities
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -792,6 +794,8 @@ async def get_firewall_ipv6_config(http_request: Request, refresh: bool = False)
             custom_chains=custom_chains,
             total_rules=total_rules
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -863,6 +867,8 @@ async def firewall_ipv6_batch_configure(http_request: Request, request: Firewall
             data={"message": "Firewall configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -901,6 +907,8 @@ async def firewall_ipv6_reorder_rules(http_request: Request, request: ReorderFir
         # Step 2: Recreate rules with new numbers
         for rule_item in request.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule
@@ -1229,6 +1237,8 @@ async def firewall_ipv6_reorder_rules(http_request: Request, request: ReorderFir
             data={"message": "Rules reordered successfully"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/large_community_list/large_community_list.py
+++ b/backend/routers/large_community_list/large_community_list.py
@@ -72,7 +72,7 @@ class LargeCommunityListBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule in a reorder request"""
     old_number: int = Field(..., description="Original rule number")
-    new_number: int = Field(..., description="New rule number after reorder")
+    new_number: Optional[int] = Field(None, description="New rule number after reorder; None = delete-only")
     rule_data: LargeCommunityListRule = Field(..., description="Complete rule configuration")
 
 
@@ -284,6 +284,8 @@ async def reorder_large_community_list_rules(http_request: Request, body: Reorde
         # Step 2: Recreate rules with new numbers
         for rule_item in body.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule

--- a/backend/routers/nat/nat.py
+++ b/backend/routers/nat/nat.py
@@ -77,7 +77,7 @@ class VyOSResponse(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule item for reordering."""
     old_number: int
-    new_number: int
+    new_number: Optional[int] = None  # None = delete-only (removed, not recreated)
     rule_data: Dict[str, Any]
 
 
@@ -750,6 +750,8 @@ async def reorder_nat_rules(http_request: Request, request: ReorderNATRequest):
         # Step 2: Create all rules with new numbers
         for rule_item in request.rules:
             new_num = rule_item.new_number
+            if new_num is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             if request.nat_type == "source":

--- a/backend/routers/nat64/nat64.py
+++ b/backend/routers/nat64/nat64.py
@@ -99,7 +99,7 @@ class NAT64ConfigResponse(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule item for reordering."""
     old_number: int
-    new_number: int
+    new_number: Optional[int] = None  # None = delete-only (removed, not recreated)
     rule_data: Dict[str, Any]
 
 
@@ -323,6 +323,8 @@ async def reorder_nat64_rules(http_request: Request, request: ReorderNAT64Reques
         # Step 2: Recreate rules with new numbers
         for rule_item in request.rules:
             new_num = rule_item.new_number
+            if new_num is None:
+                continue  # delete-only item: removed above, not recreated
             rd = rule_item.rule_data
 
             batch.set_source_rule(new_num)

--- a/backend/routers/nat66/nat66.py
+++ b/backend/routers/nat66/nat66.py
@@ -133,7 +133,7 @@ class NAT66ConfigResponse(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule item for reordering."""
     old_number: int
-    new_number: int
+    new_number: Optional[int] = None  # None = delete-only (removed, not recreated)
     rule_data: Dict[str, Any]
 
 
@@ -429,6 +429,8 @@ async def reorder_nat66_rules(http_request: Request, request: ReorderNAT66Reques
         # Step 2: Recreate rules with new numbers
         for rule_item in request.rules:
             new_num = rule_item.new_number
+            if new_num is None:
+                continue  # delete-only item: removed above, not recreated
             rd = rule_item.rule_data
 
             if is_source:

--- a/backend/routers/route_map/route_map.py
+++ b/backend/routers/route_map/route_map.py
@@ -169,7 +169,7 @@ class RouteMapBatchRequest(BaseModel):
 class ReorderRuleItem(BaseModel):
     """Single rule in a reorder request"""
     old_number: int = Field(..., description="Original rule number")
-    new_number: int = Field(..., description="New rule number after reorder")
+    new_number: Optional[int] = Field(None, description="New rule number after reorder; None = delete-only")
     rule_data: RouteMapRule = Field(..., description="Complete rule configuration")
 
 
@@ -561,6 +561,8 @@ async def reorder_route_map_rules(http_request: Request, body: ReorderRouteMapRe
         # Step 2: Recreate rules with new numbers
         for rule_item in body.rules:
             new_number = rule_item.new_number
+            if new_number is None:
+                continue  # delete-only item: removed above, not recreated
             rule_data = rule_item.rule_data
 
             # Create the rule

--- a/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
+++ b/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
@@ -957,30 +957,24 @@ export function ZoneRulePanel({
     try {
       const service = ipVersion === "ipv4" ? firewallIPv4Service : firewallIPv6Service;
 
-      // Step 1: delete just the rule (bypass the service's auto-renumber)
-      await service.batchConfigure({
-        chain: resolvedChain,
-        rule_number: rule.rule_number,
-        is_custom_chain: true,
-        operations: [{ op: "delete_custom_chain_rule" }],
-      });
-
-      // Step 2: full compact — renumber remaining rules from 10 sequentially
+      // Delete + full compact in a SINGLE commit. The deleted rule is sent with
+      // new_number=null (removed, not recreated); remaining rules renumber from 10
+      // sequentially. Splitting this into two requests breaks under commit-confirm,
+      // which only allows one un-confirmed change at a time.
       const remaining = chainRules
         .filter((r) => r.rule_number !== rule.rule_number)
         .sort((a, b) => a.rule_number - b.rule_number);
 
-      if (remaining.length > 0) {
-        const reorderItems = remaining.map((r, i) => ({
+      const reorderItems = [
+        { old_number: rule.rule_number, new_number: null, rule_data: rule },
+        ...remaining.map((r, i) => ({
           old_number: r.rule_number,
           new_number: 10 + i,
           rule_data: r,
-        }));
-        const needsCompact = reorderItems.some((x) => x.old_number !== x.new_number);
-        if (needsCompact) {
-          await service.reorderRules({ chain: resolvedChain, is_custom_chain: true, rules: reorderItems });
-        }
-      }
+        })),
+      ];
+
+      await service.reorderRules({ chain: resolvedChain, is_custom_chain: true, rules: reorderItems });
 
       onOpenChange(false);
       onSuccess();

--- a/frontend/src/lib/api/as-path-list.ts
+++ b/frontend/src/lib/api/as-path-list.ts
@@ -110,51 +110,28 @@ class AsPathListService {
       throw new Error(`AS path list ${name} not found`);
     }
 
-    // Get remaining rules (excluding the one being deleted)
-    const remainingRules = asPathList.rules.filter(r => r.rule_number !== ruleNumber);
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); remaining rules
+    // renumber sequentially from the lowest existing number to close the gap.
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      asPathList.rules.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as AsPathListRule); // rule_data unused for delete-only
+    const sortedRules = asPathList.rules
+      .filter(r => r.rule_number !== ruleNumber)
+      .sort((a, b) => a.rule_number - b.rule_number);
+    const startingNumber = sortedRules.length > 0 ? sortedRules[0].rule_number : ruleNumber;
 
-    if (remainingRules.length === 0) {
-      // If no rules left, just delete the rule
-      const operations: AsPathListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
+    const reorderRules: Array<{ old_number: number; new_number: number | null; rule_data: AsPathListRule }> = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...sortedRules.map((rule, index) => ({
+        old_number: rule.rule_number,
+        new_number: startingNumber + index,
+        rule_data: rule,
+      })),
+    ];
 
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Sort remaining rules by their current number
-    const sortedRules = remainingRules.sort((a, b) => a.rule_number - b.rule_number);
-
-    // Renumber sequentially starting from the lowest existing number
-    // This closes gaps: if you have 105, 106, 107, 108 and delete 106,
-    // result will be 105, 106 (was 107), 107 (was 108)
-    const startingNumber = sortedRules[0].rule_number;
-    const reorderRules = sortedRules.map((rule, index) => ({
-      old_number: rule.rule_number,
-      new_number: startingNumber + index,
-      rule_data: rule,
-    }));
-
-    // Check if any rule actually needs renumbering
-    const needsReorder = reorderRules.some(r => r.old_number !== r.new_number);
-
-    if (!needsReorder) {
-      // No gaps to close, just delete the rule directly
-      const operations: AsPathListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
-
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Use reorder endpoint which will delete all rules (including the one we want to delete)
-    // and recreate them with new sequential numbers
     return this.reorderRules(name, reorderRules);
   }
 
@@ -323,7 +300,7 @@ class AsPathListService {
   /**
    * Reorder AS path list rules
    */
-  async reorderRules(asPathListName: string, rules: Array<{ old_number: number; new_number: number; rule_data: AsPathListRule }>): Promise<VyOSResponse> {
+  async reorderRules(asPathListName: string, rules: Array<{ old_number: number; new_number: number | null; rule_data: AsPathListRule }>): Promise<VyOSResponse> {
     const result = await apiClient.post<VyOSResponse>("/vyos/as-path-list/reorder", {
       as_path_list_name: asPathListName,
       rules: rules,

--- a/frontend/src/lib/api/community-list.ts
+++ b/frontend/src/lib/api/community-list.ts
@@ -110,51 +110,28 @@ class CommunityListService {
       throw new Error(`Community list ${name} not found`);
     }
 
-    // Get remaining rules (excluding the one being deleted)
-    const remainingRules = communityList.rules.filter(r => r.rule_number !== ruleNumber);
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); remaining rules
+    // renumber sequentially from the lowest existing number to close the gap.
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      communityList.rules.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as CommunityListRule); // rule_data unused for delete-only
+    const sortedRules = communityList.rules
+      .filter(r => r.rule_number !== ruleNumber)
+      .sort((a, b) => a.rule_number - b.rule_number);
+    const startingNumber = sortedRules.length > 0 ? sortedRules[0].rule_number : ruleNumber;
 
-    if (remainingRules.length === 0) {
-      // If no rules left, just delete the rule
-      const operations: CommunityListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
+    const reorderRules: Array<{ old_number: number; new_number: number | null; rule_data: CommunityListRule }> = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...sortedRules.map((rule, index) => ({
+        old_number: rule.rule_number,
+        new_number: startingNumber + index,
+        rule_data: rule,
+      })),
+    ];
 
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Sort remaining rules by their current number
-    const sortedRules = remainingRules.sort((a, b) => a.rule_number - b.rule_number);
-
-    // Renumber sequentially starting from the lowest existing number
-    // This closes gaps: if you have 105, 106, 107, 108 and delete 106,
-    // result will be 105, 106 (was 107), 107 (was 108)
-    const startingNumber = sortedRules[0].rule_number;
-    const reorderRules = sortedRules.map((rule, index) => ({
-      old_number: rule.rule_number,
-      new_number: startingNumber + index,
-      rule_data: rule,
-    }));
-
-    // Check if any rule actually needs renumbering
-    const needsReorder = reorderRules.some(r => r.old_number !== r.new_number);
-
-    if (!needsReorder) {
-      // No gaps to close, just delete the rule directly
-      const operations: CommunityListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
-
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Use reorder endpoint which will delete all rules (including the one we want to delete)
-    // and recreate them with new sequential numbers
     return this.reorderRules(name, reorderRules);
   }
 
@@ -323,7 +300,7 @@ class CommunityListService {
   /**
    * Reorder community list rules
    */
-  async reorderRules(communityListName: string, rules: Array<{ old_number: number; new_number: number; rule_data: CommunityListRule }>): Promise<VyOSResponse> {
+  async reorderRules(communityListName: string, rules: Array<{ old_number: number; new_number: number | null; rule_data: CommunityListRule }>): Promise<VyOSResponse> {
     const result = await apiClient.post<VyOSResponse>("/vyos/community-list/reorder", {
       community_list_name: communityListName,
       rules: rules,

--- a/frontend/src/lib/api/extcommunity-list.ts
+++ b/frontend/src/lib/api/extcommunity-list.ts
@@ -110,51 +110,28 @@ class ExtCommunityListService {
       throw new Error(`ExtCommunity list ${name} not found`);
     }
 
-    // Get remaining rules (excluding the one being deleted)
-    const remainingRules = communityList.rules.filter(r => r.rule_number !== ruleNumber);
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); remaining rules
+    // renumber sequentially from the lowest existing number to close the gap.
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      communityList.rules.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as ExtCommunityListRule); // rule_data unused for delete-only
+    const sortedRules = communityList.rules
+      .filter(r => r.rule_number !== ruleNumber)
+      .sort((a, b) => a.rule_number - b.rule_number);
+    const startingNumber = sortedRules.length > 0 ? sortedRules[0].rule_number : ruleNumber;
 
-    if (remainingRules.length === 0) {
-      // If no rules left, just delete the rule
-      const operations: ExtCommunityListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
+    const reorderRules: Array<{ old_number: number; new_number: number | null; rule_data: ExtCommunityListRule }> = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...sortedRules.map((rule, index) => ({
+        old_number: rule.rule_number,
+        new_number: startingNumber + index,
+        rule_data: rule,
+      })),
+    ];
 
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Sort remaining rules by their current number
-    const sortedRules = remainingRules.sort((a, b) => a.rule_number - b.rule_number);
-
-    // Renumber sequentially starting from the lowest existing number
-    // This closes gaps: if you have 105, 106, 107, 108 and delete 106,
-    // result will be 105, 106 (was 107), 107 (was 108)
-    const startingNumber = sortedRules[0].rule_number;
-    const reorderRules = sortedRules.map((rule, index) => ({
-      old_number: rule.rule_number,
-      new_number: startingNumber + index,
-      rule_data: rule,
-    }));
-
-    // Check if any rule actually needs renumbering
-    const needsReorder = reorderRules.some(r => r.old_number !== r.new_number);
-
-    if (!needsReorder) {
-      // No gaps to close, just delete the rule directly
-      const operations: ExtCommunityListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
-
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Use reorder endpoint which will delete all rules (including the one we want to delete)
-    // and recreate them with new sequential numbers
     return this.reorderRules(name, reorderRules);
   }
 
@@ -323,7 +300,7 @@ class ExtCommunityListService {
   /**
    * Reorder extcommunity list rules
    */
-  async reorderRules(extcommunityListName: string, rules: Array<{ old_number: number; new_number: number; rule_data: ExtCommunityListRule }>): Promise<VyOSResponse> {
+  async reorderRules(extcommunityListName: string, rules: Array<{ old_number: number; new_number: number | null; rule_data: ExtCommunityListRule }>): Promise<VyOSResponse> {
     const result = await apiClient.post<VyOSResponse>("/vyos/extcommunity-list/reorder", {
       extcommunity_list_name: extcommunityListName,
       rules: rules,

--- a/frontend/src/lib/api/firewall-ipv4.ts
+++ b/frontend/src/lib/api/firewall-ipv4.ts
@@ -244,7 +244,7 @@ export interface FirewallBatchRequest {
 
 export interface ReorderRuleItem {
   old_number: number;
-  new_number: number;
+  new_number: number | null; // null = delete-only (removed, not recreated)
   rule_data: FirewallRule;
 }
 
@@ -1557,41 +1557,31 @@ class FirewallIPv4Service {
       }
     }
 
-    // Delete the rule
-    const operations: FirewallBatchOperation[] = [
-      isCustomChain
-        ? { op: "delete_custom_chain_rule" }
-        : { op: "delete_base_chain_rule" },
-    ];
-
-    await this.batchConfigure({
-      chain,
-      rule_number: ruleNumber,
-      is_custom_chain: isCustomChain,
-      operations,
-    });
-
-    // Find all rules with numbers greater than the deleted rule
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); the rules below
+    // it shift down by one. Doing this as two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      rulesInChain.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as FirewallRule); // rule_data unused for delete-only
     const rulesToRenumber = rulesInChain
       .filter(r => r.rule_number > ruleNumber)
       .sort((a, b) => a.rule_number - b.rule_number);
 
-    // If there are rules to renumber, trigger a reorder
-    if (rulesToRenumber.length > 0) {
-      const reorderRequest: ReorderFirewallRequest = {
-        chain,
-        is_custom_chain: isCustomChain,
-        rules: rulesToRenumber.map(rule => ({
-          old_number: rule.rule_number,
-          new_number: rule.rule_number - 1, // Shift down by 1
-          rule_data: rule
-        }))
-      };
+    const reorderRules: ReorderRuleItem[] = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...rulesToRenumber.map(rule => ({
+        old_number: rule.rule_number,
+        new_number: rule.rule_number - 1, // Shift down by 1
+        rule_data: rule,
+      })),
+    ];
 
-      await this.reorderRules(reorderRequest);
-    }
-
-    return { success: true };
+    return this.reorderRules({
+      chain,
+      is_custom_chain: isCustomChain,
+      rules: reorderRules,
+    });
   }
 
   /**

--- a/frontend/src/lib/api/firewall-ipv6.ts
+++ b/frontend/src/lib/api/firewall-ipv6.ts
@@ -230,7 +230,7 @@ export interface FirewallBatchRequest {
 
 export interface ReorderRuleItem {
   old_number: number;
-  new_number: number;
+  new_number: number | null; // null = delete-only (removed, not recreated)
   rule_data: FirewallRule;
 }
 
@@ -1535,41 +1535,31 @@ class FirewallIPv6Service {
       }
     }
 
-    // Delete the rule
-    const operations: FirewallBatchOperation[] = [
-      isCustomChain
-        ? { op: "delete_custom_chain_rule" }
-        : { op: "delete_base_chain_rule" },
-    ];
-
-    await this.batchConfigure({
-      chain,
-      rule_number: ruleNumber,
-      is_custom_chain: isCustomChain,
-      operations,
-    });
-
-    // Find all rules with numbers greater than the deleted rule
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); the rules below
+    // it shift down by one. Doing this as two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      rulesInChain.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as FirewallRule); // rule_data unused for delete-only
     const rulesToRenumber = rulesInChain
       .filter(r => r.rule_number > ruleNumber)
       .sort((a, b) => a.rule_number - b.rule_number);
 
-    // If there are rules to renumber, trigger a reorder
-    if (rulesToRenumber.length > 0) {
-      const reorderRequest: ReorderFirewallRequest = {
-        chain,
-        is_custom_chain: isCustomChain,
-        rules: rulesToRenumber.map(rule => ({
-          old_number: rule.rule_number,
-          new_number: rule.rule_number - 1, // Shift down by 1
-          rule_data: rule
-        }))
-      };
+    const reorderRules: ReorderRuleItem[] = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...rulesToRenumber.map(rule => ({
+        old_number: rule.rule_number,
+        new_number: rule.rule_number - 1, // Shift down by 1
+        rule_data: rule,
+      })),
+    ];
 
-      await this.reorderRules(reorderRequest);
-    }
-
-    return { success: true };
+    return this.reorderRules({
+      chain,
+      is_custom_chain: isCustomChain,
+      rules: reorderRules,
+    });
   }
 
   /**

--- a/frontend/src/lib/api/large-community-list.ts
+++ b/frontend/src/lib/api/large-community-list.ts
@@ -110,51 +110,28 @@ class LargeCommunityListService {
       throw new Error(`Large community list ${name} not found`);
     }
 
-    // Get remaining rules (excluding the one being deleted)
-    const remainingRules = communityList.rules.filter(r => r.rule_number !== ruleNumber);
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); remaining rules
+    // renumber sequentially from the lowest existing number to close the gap.
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      communityList.rules.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as LargeCommunityListRule); // rule_data unused for delete-only
+    const sortedRules = communityList.rules
+      .filter(r => r.rule_number !== ruleNumber)
+      .sort((a, b) => a.rule_number - b.rule_number);
+    const startingNumber = sortedRules.length > 0 ? sortedRules[0].rule_number : ruleNumber;
 
-    if (remainingRules.length === 0) {
-      // If no rules left, just delete the rule
-      const operations: LargeCommunityListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
+    const reorderRules: Array<{ old_number: number; new_number: number | null; rule_data: LargeCommunityListRule }> = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...sortedRules.map((rule, index) => ({
+        old_number: rule.rule_number,
+        new_number: startingNumber + index,
+        rule_data: rule,
+      })),
+    ];
 
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Sort remaining rules by their current number
-    const sortedRules = remainingRules.sort((a, b) => a.rule_number - b.rule_number);
-
-    // Renumber sequentially starting from the lowest existing number
-    // This closes gaps: if you have 105, 106, 107, 108 and delete 106,
-    // result will be 105, 106 (was 107), 107 (was 108)
-    const startingNumber = sortedRules[0].rule_number;
-    const reorderRules = sortedRules.map((rule, index) => ({
-      old_number: rule.rule_number,
-      new_number: startingNumber + index,
-      rule_data: rule,
-    }));
-
-    // Check if any rule actually needs renumbering
-    const needsReorder = reorderRules.some(r => r.old_number !== r.new_number);
-
-    if (!needsReorder) {
-      // No gaps to close, just delete the rule directly
-      const operations: LargeCommunityListBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
-
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Use reorder endpoint which will delete all rules (including the one we want to delete)
-    // and recreate them with new sequential numbers
     return this.reorderRules(name, reorderRules);
   }
 
@@ -323,7 +300,7 @@ class LargeCommunityListService {
   /**
    * Reorder large community list rules
    */
-  async reorderRules(largeCommunityListName: string, rules: Array<{ old_number: number; new_number: number; rule_data: LargeCommunityListRule }>): Promise<VyOSResponse> {
+  async reorderRules(largeCommunityListName: string, rules: Array<{ old_number: number; new_number: number | null; rule_data: LargeCommunityListRule }>): Promise<VyOSResponse> {
     const result = await apiClient.post<VyOSResponse>("/vyos/large-community-list/reorder", {
       large_community_list_name: largeCommunityListName,
       rules: rules,

--- a/frontend/src/lib/api/nat.ts
+++ b/frontend/src/lib/api/nat.ts
@@ -1318,47 +1318,40 @@ class NATService {
     natType: "source" | "destination" | "static",
     ruleNumber: number
   ): Promise<VyOSResponse> {
-    // Step 1: Delete the rule
-    if (natType === "source") {
-      await this.deleteSourceRule(ruleNumber);
-    } else if (natType === "destination") {
-      await this.deleteDestinationRule(ruleNumber);
-    } else {
-      await this.deleteStaticRule(ruleNumber);
-    }
-
-    // Step 2: Fetch fresh config to see remaining rules
+    // Fetch config BEFORE deleting so the delete + compaction happen in ONE commit
+    // via the reorder endpoint. The deleted rule is sent with new_number=null
+    // (removed, not recreated); remaining rules compact to [100, 101, 102, ...].
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
     const config = await this.getConfig(true);
 
     let remainingRules: Array<{ rule_number: number; data: Record<string, unknown> }> = [];
 
     if (natType === "source") {
       remainingRules = (config.source_rules ?? [])
+        .filter(r => r.rule_number !== ruleNumber)
         .sort((a, b) => a.rule_number - b.rule_number)
         .map(r => ({ rule_number: r.rule_number, data: this.flattenSourceRule(r) }));
     } else if (natType === "destination") {
       remainingRules = (config.destination_rules ?? [])
+        .filter(r => r.rule_number !== ruleNumber)
         .sort((a, b) => a.rule_number - b.rule_number)
         .map(r => ({ rule_number: r.rule_number, data: this.flattenDestinationRule(r) }));
     } else {
       remainingRules = (config.static_rules ?? [])
+        .filter(r => r.rule_number !== ruleNumber)
         .sort((a, b) => a.rule_number - b.rule_number)
         .map(r => ({ rule_number: r.rule_number, data: this.flattenStaticRule(r) }));
     }
 
-    // Step 3: Check if compaction is needed
-    const needsCompaction = remainingRules.some((r, idx) => r.rule_number !== 100 + idx);
-
-    if (!needsCompaction || remainingRules.length === 0) {
-      return { success: true };
-    }
-
-    // Step 4: Build reorder request to compact to sequential [100, 101, 102, ...]
-    const reorderItems = remainingRules.map((r, idx) => ({
-      old_number: r.rule_number,
-      new_number: 100 + idx,
-      rule_data: r.data,
-    }));
+    const reorderItems = [
+      { old_number: ruleNumber, new_number: null, rule_data: {} as Record<string, unknown> },
+      ...remainingRules.map((r, idx) => ({
+        old_number: r.rule_number,
+        new_number: 100 + idx,
+        rule_data: r.data,
+      })),
+    ];
 
     return this.reorderRules(natType, reorderItems);
   }
@@ -1367,29 +1360,24 @@ class NATService {
    * Delete a CGNAT rule and compact remaining CGNAT rules sequentially from 100.
    */
   async deleteAndCompactCGNATRules(ruleNumber: number): Promise<VyOSResponse> {
-    // Step 1: Delete the rule
-    await this.deleteCGNATRule(ruleNumber);
-
-    // Step 2: Fetch fresh config
+    // Fetch config BEFORE deleting so the delete + compaction happen in ONE commit
+    // (see deleteAndCompactRules). The deleted rule is sent with new_number=null;
+    // remaining rules compact to [100, 101, 102, ...].
     const config = await this.getConfig(true);
 
     const remainingRules = (config.cgnat?.rules ?? [])
+      .filter(r => r.rule_number !== ruleNumber)
       .sort((a, b) => a.rule_number - b.rule_number)
       .map(r => ({ rule_number: r.rule_number, data: this.flattenCGNATRule(r) }));
 
-    // Step 3: Check if compaction is needed
-    const needsCompaction = remainingRules.some((r, idx) => r.rule_number !== 100 + idx);
-
-    if (!needsCompaction || remainingRules.length === 0) {
-      return { success: true };
-    }
-
-    // Step 4: Build reorder request
-    const reorderItems = remainingRules.map((r, idx) => ({
-      old_number: r.rule_number,
-      new_number: 100 + idx,
-      rule_data: r.data,
-    }));
+    const reorderItems = [
+      { old_number: ruleNumber, new_number: null, rule_data: {} as Record<string, unknown> },
+      ...remainingRules.map((r, idx) => ({
+        old_number: r.rule_number,
+        new_number: 100 + idx,
+        rule_data: r.data,
+      })),
+    ];
 
     return this.reorderRules("cgnat", reorderItems);
   }
@@ -1401,7 +1389,7 @@ class NATService {
     natType: "source" | "destination" | "static" | "cgnat",
     rules: Array<{
       old_number: number;
-      new_number: number;
+      new_number: number | null;
       rule_data: Record<string, unknown>;
     }>
   ): Promise<VyOSResponse> {

--- a/frontend/src/lib/api/nat64.ts
+++ b/frontend/src/lib/api/nat64.ts
@@ -55,7 +55,7 @@ export interface NAT64BatchOperation {
 
 interface ReorderRuleItem {
   old_number: number;
-  new_number: number;
+  new_number: number | null; // null = delete-only (removed, not recreated)
   rule_data: Record<string, unknown>;
 }
 
@@ -318,21 +318,21 @@ class NAT64Service {
   // ==================== Delete + Compact ====================
 
   async deleteAndCompactRules(ruleNumber: number): Promise<VyOSResponse> {
-    await this.deleteRule(ruleNumber);
+    // Fetch config BEFORE deleting so the delete + compaction happen in ONE commit
+    // via the reorder endpoint. The deleted rule is sent with new_number=null
+    // (removed, not recreated); remaining rules compact to [100, 101, 102, ...].
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
     const config = await this.getConfig(true);
-    const remaining = config.source_rules;
-    if (remaining.length === 0) {
-      return { success: true, data: { message: "All rules deleted" } };
-    }
-    const reorderItems = remaining.map((rule, i) => ({
-      old_number: rule.rule_number,
-      new_number: 100 + i,
-      rule_data: this.flattenRule(rule),
-    }));
-    const needsReorder = reorderItems.some((item) => item.old_number !== item.new_number);
-    if (!needsReorder) {
-      return { success: true, data: { message: "Rule deleted, no compaction needed" } };
-    }
+    const remaining = (config.source_rules ?? []).filter(r => r.rule_number !== ruleNumber);
+    const reorderItems: ReorderRuleItem[] = [
+      { old_number: ruleNumber, new_number: null, rule_data: {} },
+      ...remaining.map((rule, i) => ({
+        old_number: rule.rule_number,
+        new_number: 100 + i,
+        rule_data: this.flattenRule(rule),
+      })),
+    ];
     return this.reorderRules(reorderItems);
   }
 

--- a/frontend/src/lib/api/nat66.ts
+++ b/frontend/src/lib/api/nat66.ts
@@ -85,7 +85,7 @@ export interface NAT66BatchOperation {
 
 interface ReorderRuleItem {
   old_number: number;
-  new_number: number;
+  new_number: number | null; // null = delete-only (removed, not recreated)
   rule_data: Record<string, unknown>;
 }
 
@@ -489,40 +489,38 @@ class NAT66Service {
   // ==================== Delete + Compact ====================
 
   async deleteAndCompactSourceRules(ruleNumber: number): Promise<VyOSResponse> {
-    await this.deleteSourceRule(ruleNumber);
+    // Fetch config BEFORE deleting so the delete + compaction happen in ONE commit
+    // via the reorder endpoint. The deleted rule is sent with new_number=null
+    // (removed, not recreated); remaining rules compact to [100, 101, 102, ...].
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
     const config = await this.getConfig(true);
-    const remaining = config.source_rules;
-    if (remaining.length === 0) {
-      return { success: true, data: { message: "All source rules deleted" } };
-    }
-    const reorderItems = remaining.map((rule, i) => ({
-      old_number: rule.rule_number,
-      new_number: 100 + i,
-      rule_data: this.flattenSourceRule(rule),
-    }));
-    const needsReorder = reorderItems.some((item) => item.old_number !== item.new_number);
-    if (!needsReorder) {
-      return { success: true, data: { message: "Rule deleted, no compaction needed" } };
-    }
+    const remaining = (config.source_rules ?? []).filter(r => r.rule_number !== ruleNumber);
+    const reorderItems: ReorderRuleItem[] = [
+      { old_number: ruleNumber, new_number: null, rule_data: {} },
+      ...remaining.map((rule, i) => ({
+        old_number: rule.rule_number,
+        new_number: 100 + i,
+        rule_data: this.flattenSourceRule(rule),
+      })),
+    ];
     return this.reorderRules("source", reorderItems);
   }
 
   async deleteAndCompactDestinationRules(ruleNumber: number): Promise<VyOSResponse> {
-    await this.deleteDestinationRule(ruleNumber);
+    // Fetch config BEFORE deleting so the delete + compaction happen in ONE commit
+    // (see deleteAndCompactSourceRules). The deleted rule is sent with new_number=null;
+    // remaining rules compact to [100, 101, 102, ...].
     const config = await this.getConfig(true);
-    const remaining = config.destination_rules;
-    if (remaining.length === 0) {
-      return { success: true, data: { message: "All destination rules deleted" } };
-    }
-    const reorderItems = remaining.map((rule, i) => ({
-      old_number: rule.rule_number,
-      new_number: 100 + i,
-      rule_data: this.flattenDestinationRule(rule),
-    }));
-    const needsReorder = reorderItems.some((item) => item.old_number !== item.new_number);
-    if (!needsReorder) {
-      return { success: true, data: { message: "Rule deleted, no compaction needed" } };
-    }
+    const remaining = (config.destination_rules ?? []).filter(r => r.rule_number !== ruleNumber);
+    const reorderItems: ReorderRuleItem[] = [
+      { old_number: ruleNumber, new_number: null, rule_data: {} },
+      ...remaining.map((rule, i) => ({
+        old_number: rule.rule_number,
+        new_number: 100 + i,
+        rule_data: this.flattenDestinationRule(rule),
+      })),
+    ];
     return this.reorderRules("destination", reorderItems);
   }
 

--- a/frontend/src/lib/api/route-map.ts
+++ b/frontend/src/lib/api/route-map.ts
@@ -213,51 +213,28 @@ class RouteMapService {
       throw new Error(`Route-map ${name} not found`);
     }
 
-    // Get remaining rules (excluding the one being deleted)
-    const remainingRules = routeMap.rules.filter(r => r.rule_number !== ruleNumber);
+    // Delete + renumber in a SINGLE commit via the reorder endpoint. The deleted
+    // rule is sent with new_number=null (removed, not recreated); remaining rules
+    // renumber sequentially from the lowest existing number to close the gap.
+    // Splitting delete and reorder into two requests breaks under commit-confirm,
+    // which only allows one un-confirmed change at a time.
+    const deletedRule =
+      routeMap.rules.find(r => r.rule_number === ruleNumber) ??
+      ({ rule_number: ruleNumber } as RouteMapRule); // rule_data unused for delete-only
+    const sortedRules = routeMap.rules
+      .filter(r => r.rule_number !== ruleNumber)
+      .sort((a, b) => a.rule_number - b.rule_number);
+    const startingNumber = sortedRules.length > 0 ? sortedRules[0].rule_number : ruleNumber;
 
-    if (remainingRules.length === 0) {
-      // If no rules left, just delete the rule
-      const operations: RouteMapBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
+    const reorderRules: Array<{ old_number: number; new_number: number | null; rule_data: RouteMapRule }> = [
+      { old_number: ruleNumber, new_number: null, rule_data: deletedRule },
+      ...sortedRules.map((rule, index) => ({
+        old_number: rule.rule_number,
+        new_number: startingNumber + index,
+        rule_data: rule,
+      })),
+    ];
 
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Sort remaining rules by their current number
-    const sortedRules = remainingRules.sort((a, b) => a.rule_number - b.rule_number);
-
-    // Renumber sequentially starting from the lowest existing number
-    // This closes gaps: if you have 105, 106, 107, 108 and delete 106,
-    // result will be 105, 106 (was 107), 107 (was 108)
-    const startingNumber = sortedRules[0].rule_number;
-    const reorderRules = sortedRules.map((rule, index) => ({
-      old_number: rule.rule_number,
-      new_number: startingNumber + index,
-      rule_data: rule,
-    }));
-
-    // Check if any rule actually needs renumbering
-    const needsReorder = reorderRules.some(r => r.old_number !== r.new_number);
-
-    if (!needsReorder) {
-      // No gaps to close, just delete the rule directly
-      const operations: RouteMapBatchOperation[] = [];
-      operations.push({ op: "delete_rule" });
-
-      return this.batchConfigure({
-        name,
-        rule_number: ruleNumber,
-        operations,
-      });
-    }
-
-    // Use reorder endpoint which will delete all rules (including the one we want to delete)
-    // and recreate them with new sequential numbers
     return this.reorderRules(name, reorderRules);
   }
 
@@ -695,7 +672,7 @@ class RouteMapService {
   /**
    * Reorder route-map rules
    */
-  async reorderRules(routeMapName: string, rules: Array<{ old_number: number; new_number: number; rule_data: RouteMapRule }>): Promise<VyOSResponse> {
+  async reorderRules(routeMapName: string, rules: Array<{ old_number: number; new_number: number | null; rule_data: RouteMapRule }>): Promise<VyOSResponse> {
     const result = await apiClient.post<VyOSResponse>("/vyos/route-map/reorder", {
       route_map_name: routeMapName,
       rules: rules,


### PR DESCRIPTION
- We need only a single batch call because commit confirm will block the reorder.