### PR TITLE
Re-anchor firewall separators when rules are renumbered

### DIFF
--- a/frontend/src/app/firewall/policies/page.tsx
+++ b/frontend/src/app/firewall/policies/page.tsx
@@ -683,6 +683,15 @@ function FirewallPoliciesPageInner() {
           rules: reorderItems,
         });
 
+        // Re-anchor separators so each bar follows its rule to its new number.
+        setSeparators(
+          await firewallSeparatorsService.applyRenumber(
+            "ipv4",
+            selectedChain as string,
+            reorderItems.map((it) => ({ old_number: it.old_number, new_number: it.new_number }))
+          )
+        );
+
         // Refresh config and reset state
         await fetchConfig(true);
       } catch (err) {
@@ -715,6 +724,15 @@ function FirewallPoliciesPageInner() {
           is_custom_chain: isCustomChainIPv6,
           rules: reorderItems,
         });
+
+        // Re-anchor separators so each bar follows its rule to its new number.
+        setSeparators(
+          await firewallSeparatorsService.applyRenumber(
+            "ipv6",
+            selectedChainIPv6 as string,
+            reorderItems.map((it) => ({ old_number: it.old_number, new_number: it.new_number }))
+          )
+        );
 
         // Refresh config and reset state
         await fetchConfigIPv6(true);
@@ -1567,7 +1585,30 @@ function FirewallPoliciesPageInner() {
         <DeleteFirewallRuleModal
           open={!!deletingRule}
           onOpenChange={(open) => !open && setDeletingRule(null)}
-          onSuccess={() => selectedProtocol === "ipv4" ? fetchConfig(true) : fetchConfigIPv6(true)}
+          onSuccess={async () => {
+            // Deleting a rule renumbers the ones below it (shift down by one), so
+            // re-anchor this chain's separators to the same rules they sat above.
+            const deleted = deletingRule;
+            if (deleted) {
+              const mapping = currentRules.map((r) => ({
+                old_number: r.rule_number,
+                new_number:
+                  r.rule_number === deleted.rule_number
+                    ? null
+                    : r.rule_number > deleted.rule_number
+                    ? r.rule_number - 1
+                    : r.rule_number,
+              }));
+              try {
+                setSeparators(
+                  await firewallSeparatorsService.applyRenumber(currentFamily, currentChain, mapping)
+                );
+              } catch (err) {
+                console.error("Error re-anchoring separators after delete:", err);
+              }
+            }
+            await (selectedProtocol === "ipv4" ? fetchConfig(true) : fetchConfigIPv6(true));
+          }}
           rule={deletingRule}
           protocol={selectedProtocol}
         />

--- a/frontend/src/app/firewall/zones/page.tsx
+++ b/frontend/src/app/firewall/zones/page.tsx
@@ -753,6 +753,13 @@ export default function FirewallZonesPage() {
     }));
     try {
       await service.reorderRules({ chain: chainName, is_custom_chain: true, rules: reorderItems });
+      // Re-anchor this chain's separators to follow their rules' new numbers.
+      // loadData() below refetches separators, so persisting to the DB suffices.
+      await firewallSeparatorsService.applyRenumber(
+        currentFamily,
+        chainName,
+        reorderItems.map((it) => ({ old_number: it.old_number, new_number: it.new_number }))
+      );
       setIsReordering(false);
       setReorderedRows([]);
       await loadData(true);

--- a/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
+++ b/frontend/src/components/firewall/zones/ZoneRulePanel.tsx
@@ -35,6 +35,7 @@ import {
   type FirewallCapabilitiesResponse,
 } from "@/lib/api/firewall-ipv4";
 import { firewallIPv6Service } from "@/lib/api/firewall-ipv6";
+import { firewallSeparatorsService } from "@/lib/api/firewall-separators";
 import { firewallGroupsService, type FirewallGroup } from "@/lib/api/firewall-groups";
 import { flowtablesService, type Flowtable } from "@/lib/api/firewall-flowtables";
 import { CountryMultiSelect } from "../CountryMultiSelect";
@@ -975,6 +976,14 @@ export function ZoneRulePanel({
       ];
 
       await service.reorderRules({ chain: resolvedChain, is_custom_chain: true, rules: reorderItems });
+
+      // Deleting compacts the chain's rule numbers, so re-anchor its separators
+      // to the rules they sat above. The page reloads separators in onSuccess().
+      await firewallSeparatorsService.applyRenumber(
+        ipVersion,
+        resolvedChain,
+        reorderItems.map((it) => ({ old_number: it.old_number, new_number: it.new_number }))
+      );
 
       onOpenChange(false);
       onSuccess();

--- a/frontend/src/lib/api/firewall-separators.ts
+++ b/frontend/src/lib/api/firewall-separators.ts
@@ -37,6 +37,17 @@ export interface SeparatorBatchRequest {
   deletes?: string[];
 }
 
+/**
+ * One entry of a chain renumber: a rule's old number and the number it became.
+ * `new_number === null` means the rule was deleted (not recreated). This is the
+ * same shape the firewall reorder endpoint receives, so callers can reuse the
+ * mapping they already built for the reorder request.
+ */
+export interface RuleRenumber {
+  old_number: number;
+  new_number: number | null;
+}
+
 interface SeparatorListResponse {
   separators: FirewallSeparator[];
 }
@@ -69,6 +80,59 @@ class FirewallSeparatorsService {
   /** Convenience: delete a single separator by id. */
   async delete(id: string): Promise<FirewallSeparator[]> {
     return this.batch({ deletes: [id] });
+  }
+
+  /**
+   * Re-anchor a chain's separators after its rules were renumbered (by a delete
+   * or a reorder) so each bar stays above the same rule it was placed before.
+   *
+   * A bar at position P sits above the first rule whose number >= P. After a
+   * renumber we move it to the new number of that same rule — the first rule at
+   * or below it that survives the renumber. If the rule it anchored to was
+   * deleted, it falls through to the next surviving rule; if nothing survives
+   * below it, it trails the (renumbered) last rule.
+   *
+   * `mapping` must be the COMPLETE old→new map for the chain (every original
+   * rule), which is exactly what the reorder endpoint receives. Fetches the
+   * current separators itself, so callers need not hold separator state.
+   * Returns the instance's full separator list afterwards.
+   */
+  async applyRenumber(
+    family: SeparatorFamily,
+    chain: string,
+    mapping: RuleRenumber[]
+  ): Promise<FirewallSeparator[]> {
+    const all = await this.list();
+    const affected = all.filter((s) => s.family === family && s.chain === chain);
+    if (!affected.length) return all;
+
+    const sorted = [...mapping].sort((a, b) => a.old_number - b.old_number);
+    const keptNumbers = sorted
+      .map((m) => m.new_number)
+      .filter((n): n is number => n !== null);
+    const trailingPosition = (keptNumbers.length ? Math.max(...keptNumbers) : 0) + 1;
+
+    const newPositionFor = (position: number): number => {
+      for (const m of sorted) {
+        if (m.old_number >= position && m.new_number !== null) return m.new_number;
+      }
+      return trailingPosition;
+    };
+
+    const upserts: SeparatorUpsert[] = affected
+      .map((s) => ({ sep: s, position: newPositionFor(s.position) }))
+      .filter(({ sep, position }) => position !== sep.position)
+      .map(({ sep, position }) => ({
+        id: sep.id,
+        family: sep.family,
+        chain: sep.chain,
+        position,
+        label: sep.label,
+        color: sep.color,
+      }));
+
+    if (!upserts.length) return all;
+    return this.batch({ upserts });
   }
 }
 


### PR DESCRIPTION
Colored separators store an absolute rule number, but deleting or reordering rules renumbers the rules beneath them, leaving each bar above the wrong rule. Add firewallSeparatorsService.applyRenumber, which re-anchors every bar to the new number of the first surviving rule at or below it, and call it from all four renumber paths: policies delete/reorder and zones delete/reorder.