### PR TITLE
feat: allow onboarding and running without a connected router

### DIFF
--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -148,6 +148,15 @@ export default function OnboardingPage() {
       return;
     }
 
+    await completeOnboarding(true);
+  };
+
+  const handleSkipInstance = async () => {
+    setError("");
+    await completeOnboarding(false);
+  };
+
+  const completeOnboarding = async (withInstance: boolean) => {
     setLoading(true);
     setIsSubmitting(true); // Prevent going back once submission starts
 
@@ -228,22 +237,26 @@ export default function OnboardingPage() {
 
       console.log("[Onboarding] ✓ Site created");
 
-      // Step 3: Create instance
-      console.log("[Onboarding] Step 3/3: Creating VyOS instance...");
-      await sessionService.createInstance({
-        site_id: createdSite.id,
-        name: instanceData.name,
-        description: instanceData.description || undefined,
-        host: instanceData.host,
-        port: instanceData.port,
-        api_key: instanceData.apiKey,
-        vyos_version: instanceData.vyosVersion,
-        protocol: instanceData.protocol,
-        verify_ssl: instanceData.verifySsl,
-        is_active: true,
-      });
+      if (withInstance) {
+        // Step 3: Create instance
+        console.log("[Onboarding] Step 3/3: Creating VyOS instance...");
+        await sessionService.createInstance({
+          site_id: createdSite.id,
+          name: instanceData.name,
+          description: instanceData.description || undefined,
+          host: instanceData.host,
+          port: instanceData.port,
+          api_key: instanceData.apiKey,
+          vyos_version: instanceData.vyosVersion,
+          protocol: instanceData.protocol,
+          verify_ssl: instanceData.verifySsl,
+          is_active: true,
+        });
 
-      console.log("[Onboarding] ✓ Instance created");
+        console.log("[Onboarding] ✓ Instance created");
+      } else {
+        console.log("[Onboarding] Instance step skipped - add a router later in Site Manager");
+      }
       console.log("[Onboarding] Setup complete! Redirecting to sites...");
 
       // Note: Site ADMIN users (which the first user is) automatically have access
@@ -599,6 +612,21 @@ export default function OnboardingPage() {
                     "Complete Setup"
                   )}
                 </Button>
+              </div>
+
+              <div className="text-center mt-4">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="text-sm text-muted-foreground"
+                  onClick={handleSkipInstance}
+                  disabled={loading || isSubmitting}
+                >
+                  Skip for now
+                </Button>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Your account and site are still created. You can add a router later in Site Manager.
+                </p>
               </div>
             </form>
           )}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Github, Globe, MessageCircle, Sparkles, ArrowUpCircle, Tag } from "lucide-react";
 import { useSession } from "@/lib/auth-client";
 import { useSessionStore } from "@/store/session-store";
+import { sessionService } from "@/lib/api/session";
 import { dashboardService, DashboardCard, DashboardLayout } from "@/lib/api/dashboard";
 import {
   compactLayout,
@@ -27,6 +28,7 @@ import { VrrpStatusCard } from "@/components/dashboard/VrrpStatusCard";
 import { BgpStatusCard } from "@/components/dashboard/BgpStatusCard";
 import { IpsecCard } from "@/components/dashboard/IpsecCard";
 import { AddCardModal } from "@/components/dashboard/AddCardModal";
+import { ConnectFirstInstance } from "@/components/dashboard/ConnectFirstInstance";
 import {
   DndContext,
   DragEndEvent,
@@ -122,7 +124,9 @@ export default function Home() {
   const router = useRouter();
   const [isChecking, setIsChecking] = useState(true);
   const { data: session, isPending } = useSession();
-  const { loadSession } = useSessionStore();
+  const { activeSession, loadSession } = useSessionStore();
+  // null = not determined yet; true = no instance exists anywhere the user can see
+  const [noInstances, setNoInstances] = useState<boolean | null>(null);
 
   // Dashboard state
   const [cards, setCards] = useState<DashboardCard[]>([]);
@@ -202,6 +206,36 @@ export default function Home() {
       }
 
       await loadSession();
+
+      const currentSession = useSessionStore.getState().activeSession;
+      if (!currentSession) {
+        // Disconnected. Distinguish "no instance exists anywhere" (render the
+        // zero-instance panel) from "instances exist but none is connected"
+        // (send the user to the site manager to pick one).
+        try {
+          const sites = await sessionService.listSites();
+          let instanceCount = 0;
+          if (sites.length > 0) {
+            const instanceLists = await Promise.all(
+              sites.map((site) => sessionService.listInstances(site.id).catch(() => []))
+            );
+            instanceCount = instanceLists.reduce((sum, list) => sum + list.length, 0);
+          }
+          if (instanceCount === 0) {
+            setNoInstances(true);
+          } else {
+            setNoInstances(false);
+            router.push("/sites");
+          }
+        } catch {
+          // Cannot determine - fall back to the site manager as before
+          setNoInstances(false);
+          router.push("/sites");
+        }
+        setIsChecking(false);
+        return;
+      }
+
       // Always try to load dashboard - the API will return empty if no layout exists
       await loadDashboard();
 
@@ -226,6 +260,22 @@ export default function Home() {
   }, [router, session, isPending, loadSession]);
 
   if (isPending || isChecking) {
+    return (
+      <div className="min-h-screen w-full flex items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!activeSession) {
+    if (noInstances) {
+      return (
+        <AppLayout allowWithoutInstance>
+          <ConnectFirstInstance />
+        </AppLayout>
+      );
+    }
+    // Instances exist but none is connected - redirect to /sites is in flight
     return (
       <div className="min-h-screen w-full flex items-center justify-center bg-background">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />

--- a/frontend/src/components/dashboard/ConnectFirstInstance.tsx
+++ b/frontend/src/components/dashboard/ConnectFirstInstance.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { Router, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+/**
+ * Zero-instance dashboard state: shown when the user is logged in but no
+ * VyOS instance exists yet anywhere they can see. Users who do have
+ * instances but are simply disconnected are redirected to the site manager
+ * instead (see app/page.tsx).
+ */
+export function ConnectFirstInstance() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-4 sm:p-8">
+      <Card className="w-full max-w-lg">
+        <CardContent className="flex flex-col items-center gap-4 p-8 text-center sm:p-10">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+            <Router className="h-7 w-7 text-primary" />
+          </div>
+          <h2 className="text-xl font-semibold">Connect your first VyOS instance</h2>
+          <p className="text-sm text-muted-foreground">
+            VyManager is running, but no router has been added yet. Add a VyOS
+            instance in the Site Manager and connect to it to start managing
+            your network. You will need the router&apos;s address and its HTTP
+            API key.
+          </p>
+          <Button asChild className="mt-2">
+            <Link href="/sites">
+              Open Site Manager
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -15,7 +15,17 @@ import { ErrorBoundary } from "../error/ErrorBoundary";
 import { installGlobalErrorCapture } from "@/lib/error-capture";
 
 
-function AppLayoutInner({ children }: { children: React.ReactNode }) {
+interface AppLayoutProps {
+  children: React.ReactNode;
+  /**
+   * Render the layout even when no VyOS instance session is active instead of
+   * redirecting to the site manager. Used by pages that provide their own
+   * disconnected state (currently the dashboard's zero-instance panel).
+   */
+  allowWithoutInstance?: boolean;
+}
+
+function AppLayoutInner({ children, allowWithoutInstance = false }: AppLayoutProps) {
   const router = useRouter();
   const { activeSession, loadSession } = useSessionStore();
   const [isChecking, setIsChecking] = useState(true);
@@ -39,10 +49,10 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
 
   // Redirect to sites page if no active instance
   useEffect(() => {
-    if (!isChecking && !activeSession) {
+    if (!isChecking && !activeSession && !allowWithoutInstance) {
       router.push("/sites");
     }
-  }, [isChecking, activeSession, router]);
+  }, [isChecking, activeSession, allowWithoutInstance, router]);
 
   // Show loading while checking session
   if (isChecking) {
@@ -57,7 +67,7 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
   }
 
   // Show nothing while redirecting (when no active session)
-  if (!activeSession) {
+  if (!activeSession && !allowWithoutInstance) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
         <div className="flex flex-col items-center gap-3">
@@ -97,6 +107,6 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function AppLayout({ children }: { children: React.ReactNode }) {
-  return <AppLayoutInner>{children}</AppLayoutInner>;
+export function AppLayout({ children, allowWithoutInstance }: AppLayoutProps) {
+  return <AppLayoutInner allowWithoutInstance={allowWithoutInstance}>{children}</AppLayoutInner>;
 }


### PR DESCRIPTION
Closes #425.

Onboarding step 3 now has a "Skip for now" action: the admin account and
site are created, instance creation is skipped, and the user lands in the
Site Manager. The submit path with an instance is unchanged.

The dashboard now distinguishes two disconnected states. With zero
instances anywhere, it renders a "connect your first instance" panel
linking to the Site Manager. When instances exist but none is connected,
it redirects to the Site Manager as before. AppLayout gained an opt-in
`allowWithoutInstance` prop used only by the dashboard; all other pages
keep the existing redirect.

No backend changes.

## Testing

Verified on a fresh production build (next build + next start, uvicorn,
PostgreSQL) with no router available: skip path completes onboarding,
sign-up is closed afterwards, the zero-instance panel renders, and adding
a (disconnected) instance switches the dashboard back to the /sites
redirect. Also verified the normal onboarding path with instance details
still completes.
