### PR TITLE
docs: document onboarding skip path and zero-instance dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 - **Check the issue tracker first.** If you're building something that doesn't have an issue yet, open one. Even a quick "I'm going to work on X" issue helps avoid duplicate effort and gives others a chance to weigh in on approach before you write code.
 - **One feature per PR.** Don't bundle a firewall fix, a sidebar tweak, and a new DHCP field into one PR. Keep them separate. Smaller PRs get reviewed faster and are easier to roll back if something goes wrong.
-- **Branch from `main`.** Name your branch something descriptive: `feat/openvpn-support`, `fix/nat-modal-width`, `refactor/sidebar-responsive`. Not `my-changes` or `update`.
+- **Branch from `beta`.** Name your branch something descriptive: `feat/openvpn-support`, `fix/nat-modal-width`, `refactor/sidebar-responsive`. Not `my-changes` or `update`.
 
 ### What a good PR looks like
 

--- a/docs-site/docs/getting-started/first-run.md
+++ b/docs-site/docs/getting-started/first-run.md
@@ -20,6 +20,8 @@ Name and optional description for your first site, for example "Headquarters". S
 
 ## Step 3: first VyOS instance
 
+This step is optional. If you do not have a router ready, click **Skip for now** below the form — your admin account and site are still created, and you can add a router later in Site Manager. See [Finishing without a router](#finishing-without-a-router).
+
 The router VyManager connects to:
 
 | Field | Notes |
@@ -34,6 +36,14 @@ The router VyManager connects to:
 | Verify SSL | Off by default. Enable only if the router presents a certificate the backend trusts |
 
 Submitting this step creates the admin account, signs you in, creates the site and the instance, then redirects you to the Sites page. Before writing anything, the wizard re-checks the onboarding status; if someone else completed onboarding while your form was open, it aborts and sends you to the login page.
+
+## Finishing without a router
+
+Clicking **Skip for now** on step 3 completes onboarding without an instance: the admin account and the site are created and you are signed in, exactly as with a full run — only the instance is skipped. You land on the Sites page.
+
+While no instance exists anywhere you can see, the dashboard (`/`) shows a **Connect your first VyOS instance** panel with a shortcut to Site Manager instead of dashboard cards. All administration pages — Site Manager, user management, API tokens, backup and restore — work normally without a router. Feature pages that manage router configuration stay unavailable until you connect to an instance.
+
+Once at least one instance exists but you are not connected to it, the dashboard goes back to redirecting you to the Sites page so you can connect.
 
 ## After onboarding
 

--- a/docs-site/docs/operations/troubleshooting.md
+++ b/docs-site/docs/operations/troubleshooting.md
@@ -22,6 +22,13 @@ The backend verifies session cookies with `BETTER_AUTH_SECRET`. If the value dif
 
 `DATABASE_URL` is missing or PostgreSQL is unreachable. The API deliberately starts anyway and answers 503 on authenticated routes. Check `docker compose ps postgres` and that the hostname in `DATABASE_URL` is `postgres` (the compose service name), not `localhost`.
 
+## Stuck on the Sites page, cannot reach the dashboard
+
+Which case you are in depends on whether any instance exists:
+
+- **Fresh install, no instance added yet** — this is normal, not a fault. Onboarding's instance step can be skipped, and the dashboard shows a "Connect your first VyOS instance" panel until you add and connect one. Add the router in Site Manager when it is ready (see [Finishing without a router](../getting-started/first-run#finishing-without-a-router)).
+- **Instances exist but Connect fails** — connecting runs a live connectivity test against the router and returns 503 if it fails; you stay on the Sites page by design. Work through [Cannot connect to a VyOS instance](#cannot-connect-to-a-vyos-instance) below.
+
 ## Cannot connect to a VyOS instance
 
 1. Verify the API key on the router matches the instance settings.

--- a/docs-site/docs/user-guide/dashboard.md
+++ b/docs-site/docs/user-guide/dashboard.md
@@ -8,6 +8,8 @@ sidebar_position: 1
 
 The dashboard is the landing page after connecting to an instance. It is a three-column grid of cards fed by a live stream: the backend queries the router's GraphQL API and pushes updates to the browser over server-sent events, so counters move without reloading.
 
+If no VyOS instance exists yet (for example after skipping the instance step during onboarding), the dashboard instead shows a "Connect your first VyOS instance" panel linking to Site Manager.
+
 Nine card types are available:
 
 | Card | Shows |

--- a/docs-site/docs/user-guide/sites.md
+++ b/docs-site/docs/user-guide/sites.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 # Sites
 
-Site Manager is the entry hub: whenever you are not connected to an instance, VyManager sends you here. It has its own left rail with four sections — Sites, User Management, Authentication and API Tokens (the last three are covered in [Settings and administration](settings)).
+Site Manager is the entry hub: whenever you are not connected to an instance, VyManager sends you here. (The one exception: on a fresh install with no instances at all, the dashboard shows a "Connect your first VyOS instance" panel instead of redirecting.) It has its own left rail with four sections — Sites, User Management, Authentication and API Tokens (the last three are covered in [Settings and administration](settings)).
 
 ## Sites and instances
 


### PR DESCRIPTION
Follow-up to #426 (closes the documentation half of #425). The docs described onboarding as it existed before the skip path landed.

- **first-run**: step 3 is now marked optional, with a new "Finishing without a router" section covering the Skip-for-now button, what gets created anyway, the dashboard's "Connect your first VyOS instance" panel while zero instances exist, and what works without a router (all administration pages) vs what doesn't (router configuration pages).
- **troubleshooting**: new "Stuck on the Sites page" entry distinguishing the fresh-install case (expected — add a router in Site Manager when ready) from the connect-failure case (503 connectivity test, points to the existing "Cannot connect" checklist).
- **user-guide/sites + dashboard**: corrected the claim that a disconnected user is always redirected to Site Manager; noted the zero-instance dashboard panel.
- **CONTRIBUTING**: fixed "Branch from `main`" to "Branch from `beta`" to match the actual default branch.

All statements were verified against the merged code in #426, not the original proposal.

## Testing

- `npm run build` in docs-site passes (Docusaurus fails the build on broken internal links, so the new cross-page anchors are validated).
- Behavior claims cross-checked against `onboarding/page.tsx` (skip handler, redirect to /sites), `app/page.tsx` (zero-instance detection, fallback redirect), `ConnectFirstInstance.tsx`, and `AppLayout.tsx` (`allowWithoutInstance`).
- Docs-only change, no runtime surface.