### PR TITLE
chore: remove XFRM suffix from VTI interface labels

### DIFF
--- a/frontend/src/app/network/interfaces/page.tsx
+++ b/frontend/src/app/network/interfaces/page.tsx
@@ -1799,7 +1799,7 @@ function InterfacesPageInner() {
                                       : selectedType === "vpp"
                                         ? "VPP (Vector Packet Processing) interfaces — bonding, bridge, GRE, IPIP, loopback, VXLAN, and XConnect types"
                                         : selectedType === "vti"
-                                          ? "Virtual Tunnel Interfaces (XFRM) — kernel-side endpoint for IPsec tunnels"
+                                          ? "Virtual Tunnel Interfaces (VTI) — routable endpoints for IPsec tunnels"
                                           : selectedType === "wireless"
                                             ? "Wireless (802.11) interfaces — access point, station, and monitor mode"
                                             : selectedType === "wwan"

--- a/frontend/src/components/vti/CreateVtiModal.tsx
+++ b/frontend/src/components/vti/CreateVtiModal.tsx
@@ -248,7 +248,7 @@ export function CreateVtiModal({
             Create VTI Interface
           </DialogTitle>
           <DialogDescription>
-            Create a new Virtual Tunnel Interface (XFRM) for use with IPsec.
+            Create a new Virtual Tunnel Interface for use with IPsec.
           </DialogDescription>
         </DialogHeader>
 


### PR DESCRIPTION
VyOS 1.4 and 1.5 have no `interfaces xfrm` type — VTI is the only IPsec tunnel-interface type, implemented in the kernel as an XFRM interface (`ip link add ... type xfrm` in vyos-1x `ifconfig/vti.py`). The "(XFRM)" suffix in two UI strings implied a distinct interface type and doesn't match VyOS documentation terminology, so users cross-referencing docs.vyos.io found nothing under that name.

Verified against the interfaces index and VTI pages for both [1.4 (sagitta)](https://docs.vyos.io/en/sagitta/configuration/interfaces/index.html) and [1.5 (circinus)](https://docs.vyos.io/en/circinus/configuration/interfaces/index.html): no xfrm entry exists in either version, and the site-to-site IPsec docs bind peers exclusively with `vti bind`.

This drops the suffix from the interface-type description and the create-modal subtitle. Backend docstrings, which correctly describe the kernel implementation detail, are unchanged. No functional change.

## Testing

- `npx tsc --noEmit` passes.
- String-only change in two components; no logic touched.