### PR TITLE
fix: enforce dedicated feature groups on six interface routers

### DIFF
--- a/backend/rbac_permissions.py
+++ b/backend/rbac_permissions.py
@@ -1020,7 +1020,11 @@ def _apply_parent_child_permissions(permissions: Dict[FeatureGroup, PermissionLe
             elif network_perm == PermissionLevel.READ and current == PermissionLevel.NONE:
                 permissions[child] = PermissionLevel.READ
 
-    # INTERFACES grants permissions to all interface sub-types
+    # INTERFACES grants permissions to all interface sub-types.
+    # Load-bearing fallback: the interface routers with dedicated groups
+    # (PSEUDO_ETHERNET, VIRTUAL_ETHERNET, VPP, VTI, WIRELESS, WWAN) enforce
+    # their own group, and this propagation is what keeps INTERFACES-only
+    # roles working on them. Removing a child here revokes that fallback.
     interfaces_perm = permissions.get(FeatureGroup.INTERFACES, PermissionLevel.NONE)
     if interfaces_perm != PermissionLevel.NONE:
         interface_children = [

--- a/backend/routers/interfaces/pseudo_ethernet.py
+++ b/backend/routers/interfaces/pseudo_ethernet.py
@@ -233,7 +233,7 @@ class PseudoEthernetConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for pseudo-ethernet interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.PSEUDO_ETHERNET)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.pseudo_ethernet import PseudoEthernetInterfaceBuilderMixin
     builder = PseudoEthernetInterfaceBuilderMixin(version=service.get_version())
@@ -243,7 +243,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=PseudoEthernetConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> PseudoEthernetConfigResponse:
     """Get all pseudo-ethernet interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.PSEUDO_ETHERNET)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -267,7 +267,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     the interface name + one value, encode extras in `value` using colon-separated
     components (e.g., `vif_id:address`, `s_vlan_id:c_vlan_id`, `pd_id:length`).
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.PSEUDO_ETHERNET)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/virtual_ethernet.py
+++ b/backend/routers/interfaces/virtual_ethernet.py
@@ -219,7 +219,7 @@ class VirtualEthernetConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for virtual-ethernet interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.VIRTUAL_ETHERNET)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.virtual_ethernet import VirtualEthernetInterfaceBuilderMixin
     builder = VirtualEthernetInterfaceBuilderMixin(version=service.get_version())
@@ -229,7 +229,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=VirtualEthernetConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> VirtualEthernetConfigResponse:
     """Get all virtual-ethernet interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.VIRTUAL_ETHERNET)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -253,7 +253,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     the interface name + one value, encode extras in `value` using colon-separated
     components (e.g., `vlan_id:address`, `s_vlan_id:c_vlan_id`, `pd_id:length`).
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.VIRTUAL_ETHERNET)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/vpp.py
+++ b/backend/routers/interfaces/vpp.py
@@ -151,7 +151,7 @@ class VppConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for VPP interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.VPP)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.vpp import VppInterfaceBuilderMixin
     builder = VppInterfaceBuilderMixin(version=service.get_version())
@@ -161,7 +161,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=VppConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> VppConfigResponse:
     """Get all VPP interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.VPP)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -189,7 +189,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
       set_bonding_vif_mtu      → value="100:1500"            (vlan_id:mtu)
       set_loopback_vif_address → value="10:10.0.0.1/24"      (vlan_id:address)
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.VPP)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/vti.py
+++ b/backend/routers/interfaces/vti.py
@@ -97,7 +97,7 @@ class VtiInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for VTI interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.VTI)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.vti import VtiInterfaceBuilderMixin
     builder = VtiInterfaceBuilderMixin(version=service.get_version())
@@ -107,7 +107,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=VtiInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> VtiInterfacesConfigResponse:
     """Get all VTI interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.VTI)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -190,7 +190,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `set_ipv6_source_validation` | Yes | IPv6 source validation (strict/loose/disable) |
     | `delete_ipv6_source_validation` | No | Remove IPv6 source validation |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.VTI)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/wireless.py
+++ b/backend/routers/interfaces/wireless.py
@@ -202,7 +202,7 @@ class WirelessInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for wireless interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.WIRELESS)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.wireless import WirelessInterfaceBuilderMixin
     builder = WirelessInterfaceBuilderMixin(version=service.get_version())
@@ -212,7 +212,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=WirelessInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> WirelessInterfacesConfigResponse:
     """Get all wireless interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.WIRELESS)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -598,7 +598,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `set_bssid` | Yes | Target BSSID (MAC) for station mode |
     | `delete_bssid` | No | Remove BSSID |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.WIRELESS)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/wwan.py
+++ b/backend/routers/interfaces/wwan.py
@@ -132,7 +132,7 @@ class WwanInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for WWAN interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.WWAN)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.wwan import WwanInterfaceBatchBuilder
     builder = WwanInterfaceBatchBuilder(version=service.get_version())
@@ -142,7 +142,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=WwanInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> WwanInterfacesConfigResponse:
     """Get all WWAN interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.WWAN)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -366,7 +366,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `set_ipv6_address_interface_identifier` | Yes | SLAAC interface identifier (::h:h:h:h) |
     | `delete_ipv6_address_interface_identifier` | No | Remove interface identifier |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.WWAN)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/tests/test_rbac_interface_groups.py
+++ b/backend/tests/test_rbac_interface_groups.py
@@ -1,0 +1,120 @@
+"""Unit tests for the interface feature-group fallback (issue #428).
+
+The six interface routers with dedicated feature groups (PSEUDO_ETHERNET,
+VIRTUAL_ETHERNET, VPP, VTI, WIRELESS, WWAN) enforce their own group, and
+``_apply_parent_child_permissions`` propagates an INTERFACES grant to those
+groups. Together that gives the "dedicated group first, INTERFACES as
+fallback" behavior: a dedicated grant works on its own, an INTERFACES-only
+role keeps access, and a role with neither is denied.
+
+These tests exercise the pure permission-dict logic only — no database or
+FastAPI app needed.
+"""
+
+from pathlib import Path
+
+from rbac_permissions import (
+    FeatureGroup,
+    PermissionLevel,
+    _apply_parent_child_permissions,
+)
+
+
+DEDICATED_INTERFACE_GROUPS = [
+    FeatureGroup.PSEUDO_ETHERNET,
+    FeatureGroup.VIRTUAL_ETHERNET,
+    FeatureGroup.VPP,
+    FeatureGroup.VTI,
+    FeatureGroup.WIRELESS,
+    FeatureGroup.WWAN,
+]
+
+ROUTER_FILES = {
+    FeatureGroup.PSEUDO_ETHERNET: "pseudo_ethernet.py",
+    FeatureGroup.VIRTUAL_ETHERNET: "virtual_ethernet.py",
+    FeatureGroup.VPP: "vpp.py",
+    FeatureGroup.VTI: "vti.py",
+    FeatureGroup.WIRELESS: "wireless.py",
+    FeatureGroup.WWAN: "wwan.py",
+}
+
+
+def all_none():
+    """Fresh permission dict, everything NONE — the state before grants apply."""
+    return {feature: PermissionLevel.NONE for feature in FeatureGroup}
+
+
+def effective(permissions, feature, required):
+    """Mirror check_permission's level comparison on a computed dict."""
+    level = permissions.get(feature, PermissionLevel.NONE)
+    if required == PermissionLevel.READ:
+        return level in (PermissionLevel.READ, PermissionLevel.WRITE)
+    return level == PermissionLevel.WRITE
+
+
+def test_dedicated_grant_alone_grants_access():
+    for group in DEDICATED_INTERFACE_GROUPS:
+        permissions = all_none()
+        permissions[group] = PermissionLevel.WRITE
+        _apply_parent_child_permissions(permissions)
+
+        assert effective(permissions, group, PermissionLevel.WRITE)
+        # The dedicated grant must not leak upward or sideways
+        assert permissions[FeatureGroup.INTERFACES] == PermissionLevel.NONE
+        for other in DEDICATED_INTERFACE_GROUPS:
+            if other != group:
+                assert permissions[other] == PermissionLevel.NONE
+
+
+def test_interfaces_only_grant_still_covers_all_six():
+    permissions = all_none()
+    permissions[FeatureGroup.INTERFACES] = PermissionLevel.WRITE
+    _apply_parent_child_permissions(permissions)
+
+    for group in DEDICATED_INTERFACE_GROUPS:
+        assert effective(permissions, group, PermissionLevel.WRITE), group
+
+
+def test_interfaces_read_only_gives_read_not_write():
+    permissions = all_none()
+    permissions[FeatureGroup.INTERFACES] = PermissionLevel.READ
+    _apply_parent_child_permissions(permissions)
+
+    for group in DEDICATED_INTERFACE_GROUPS:
+        assert effective(permissions, group, PermissionLevel.READ), group
+        assert not effective(permissions, group, PermissionLevel.WRITE), group
+
+
+def test_neither_grant_is_denied():
+    permissions = all_none()
+    _apply_parent_child_permissions(permissions)
+
+    for group in DEDICATED_INTERFACE_GROUPS:
+        assert not effective(permissions, group, PermissionLevel.READ), group
+
+
+def test_dedicated_write_survives_interfaces_read():
+    permissions = all_none()
+    permissions[FeatureGroup.INTERFACES] = PermissionLevel.READ
+    permissions[FeatureGroup.VTI] = PermissionLevel.WRITE
+    _apply_parent_child_permissions(permissions)
+
+    assert effective(permissions, FeatureGroup.VTI, PermissionLevel.WRITE)
+
+
+def test_interfaces_write_upgrades_dedicated_read():
+    permissions = all_none()
+    permissions[FeatureGroup.INTERFACES] = PermissionLevel.WRITE
+    permissions[FeatureGroup.WIRELESS] = PermissionLevel.READ
+    _apply_parent_child_permissions(permissions)
+
+    assert effective(permissions, FeatureGroup.WIRELESS, PermissionLevel.WRITE)
+
+
+def test_routers_enforce_their_dedicated_group():
+    """Guard against a router regressing to the generic INTERFACES check."""
+    routers_dir = Path(__file__).resolve().parents[1] / "routers" / "interfaces"
+    for group, filename in ROUTER_FILES.items():
+        source = (routers_dir / filename).read_text()
+        assert f"FeatureGroup.{group.name}" in source, filename
+        assert "FeatureGroup.INTERFACES" not in source, filename

--- a/docs-site/docs/architecture/rbac.md
+++ b/docs-site/docs/architecture/rbac.md
@@ -34,6 +34,8 @@ For OPERATOR and VIEWER grants, `user_feature_permissions` rows list the allowed
 
 Parents propagate to children: granting `ROUTING` grants `BGP`, `OSPF`, `STATIC_ROUTES` and the rest of the routing subtree at the same level. Permission levels are `NONE`, `READ`, `WRITE`.
 
+For interface types with their own feature group (`PSEUDO_ETHERNET`, `VIRTUAL_ETHERNET`, `VPP`, `VTI`, `WIRELESS`, `WWAN`), the endpoint checks the dedicated group, and `INTERFACES` acts as a fallback: a role holding either the dedicated grant or `INTERFACES` gets access, so granting only `INTERFACES` still covers every interface type.
+
 ## Enforcement
 
 Every feature endpoint calls `require_read_permission` or `require_write_permission` with its feature group before doing anything. The check order is:


### PR DESCRIPTION
Fixes #428 (option C).

The pseudo-ethernet, virtual-ethernet, VPP, VTI, wireless and WWAN routers enforced the generic `INTERFACES` feature group instead of their dedicated groups, so per-feature grants for those six groups had no effect.

The routers now check their own group. **No existing grant changes behavior**: the permission resolver has always propagated an `INTERFACES` grant to all six dedicated groups (`_apply_parent_child_permissions`), so a role holding only `INTERFACES` keeps exactly the access it has today — the fallback lives in that one existing helper, not per-router. What changes is that dedicated grants now work: "can manage wireless but not VTI" is finally expressible.

Also: a code comment marking the propagation as load-bearing, the one-sentence fallback rule on the docs-site RBAC page, and unit tests.

SEGMENT_ROUTING (the other orphan group) is deliberately untouched: no router enforces it yet, and the hierarchy already covers it under `ROUTING_INFRASTRUCTURE`, so the segment-routing module can adopt the same pattern from day one when it's built.

Follow-up candidate: the interfaces page gates some tabs on `INTERFACES` only; dedicated-only roles have backend access but reduced UI visibility. The same `canRead(X) || canRead(INTERFACES)` pattern the page already uses for PPPOE/SSTPC applies.

## Testing

- New `backend/tests/test_rbac_interface_groups.py` (7 tests): dedicated-only grant works, INTERFACES-only covers all six, neither is denied, READ doesn't grant WRITE, dedicated WRITE survives INTERFACES READ, INTERFACES WRITE upgrades dedicated READ, plus a source-scan guard that fails if a router regresses to the generic check.
- Full backend suite: 28 passed, 0 failed.
- Pure permission-dict logic — no database or router needed to test.