### PR TITLE
feat: add segment routing (SRv6) backend module

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -78,6 +78,7 @@ from routers.pim6 import pim6 as pim6_router
 from routers.rip import rip as rip_router
 from routers.ripng import ripng as ripng_router
 from routers.rpki import rpki as rpki_router
+from routers.segment_routing import segment_routing as segment_routing_router
 from routers.traffic_engineering import traffic_engineering as te_router
 from routers.broadcast_relay import broadcast_relay as broadcast_relay_router
 from routers.lldp import lldp as lldp_router
@@ -403,6 +404,7 @@ app.include_router(pim6_router.router)
 app.include_router(rip_router.router)
 app.include_router(ripng_router.router)
 app.include_router(rpki_router.router)
+app.include_router(segment_routing_router.router)
 app.include_router(te_router.router)
 app.include_router(broadcast_relay_router.router)
 app.include_router(lldp_router.router)

--- a/backend/routers/segment_routing/__init__.py
+++ b/backend/routers/segment_routing/__init__.py
@@ -1,0 +1,3 @@
+from .segment_routing import router
+
+__all__ = ["router"]

--- a/backend/routers/segment_routing/segment_routing.py
+++ b/backend/routers/segment_routing/segment_routing.py
@@ -1,0 +1,216 @@
+"""Segment Routing Protocol Router.
+
+API endpoints for managing VyOS Segment Routing (SRv6) configuration:
+locators and per-interface SRv6 packet acceptance. The configuration tree
+is identical on VyOS 1.4 and 1.5.
+"""
+
+from fastapi import APIRouter, HTTPException, Request
+from starlette.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+from session_vyos_service import get_session_vyos_service
+from vyos_builders import SegmentRoutingBatchBuilder
+from fastapi_permissions import require_read_permission, require_write_permission
+from rbac_permissions import FeatureGroup
+import inspect
+import logging
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/vyos/segment-routing", tags=["segment-routing"])
+
+
+# ============================================================================
+# Pydantic Models
+# ============================================================================
+
+
+class Srv6Locator(BaseModel):
+    name: str
+    prefix: Optional[str] = None
+    block_len: Optional[int] = None
+    node_len: Optional[int] = None
+    func_bits: Optional[int] = None
+    behavior_usid: bool = False
+
+
+class SrInterface(BaseModel):
+    name: str
+    hmac: Optional[str] = None
+
+
+class SegmentRoutingConfig(BaseModel):
+    locators: List[Srv6Locator] = []
+    interfaces: List[SrInterface] = []
+
+
+class SegmentRoutingBatchOperation(BaseModel):
+    op: str = Field(..., description="Builder method name")
+    value: Optional[str] = Field(None, description="Comma-separated arguments")
+
+
+class SegmentRoutingBatchRequest(BaseModel):
+    operations: List[SegmentRoutingBatchOperation]
+
+
+class VyOSResponse(BaseModel):
+    success: bool
+    data: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+
+# ============================================================================
+# Endpoint 1: Capabilities
+# ============================================================================
+
+
+@router.get("/capabilities")
+async def get_segment_routing_capabilities(request: Request):
+    """Return Segment Routing feature capabilities based on the device VyOS version.
+
+    version_info.modify_requires_recreate is true on VyOS 1.4, where FRR
+    rejects any modification of an existing segment-routing tree: clients
+    must delete the tree and recreate it in two separate batches to edit.
+    """
+    await require_read_permission(request, FeatureGroup.SEGMENT_ROUTING)
+
+    try:
+        service = get_session_vyos_service(request)
+        builder = SegmentRoutingBatchBuilder(version=service.get_version())
+        capabilities = builder.get_capabilities()
+
+        if hasattr(request.state, "instance") and request.state.instance:
+            capabilities["instance_name"] = request.state.instance.get("name")
+            capabilities["instance_id"] = request.state.instance.get("id")
+
+        return capabilities
+    except Exception:
+        logger.exception("Unhandled error in get_segment_routing_capabilities")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ============================================================================
+# Endpoint 2: Config
+# ============================================================================
+
+
+@router.get("/config", response_model=SegmentRoutingConfig)
+async def get_segment_routing_config(http_request: Request, refresh: bool = False):
+    """Return the full Segment Routing configuration in a normalized format."""
+    await require_read_permission(http_request, FeatureGroup.SEGMENT_ROUTING)
+
+    try:
+        service = get_session_vyos_service(http_request)
+        full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
+
+        sr_raw = full_config.get("protocols", {}).get("segment-routing", {})
+
+        if not sr_raw:
+            return SegmentRoutingConfig()
+
+        return SegmentRoutingConfig(
+            locators=_parse_locators(sr_raw.get("srv6", {}).get("locator", {})),
+            interfaces=_parse_interfaces(sr_raw.get("interface", {})),
+        )
+    except Exception:
+        logger.exception("Unhandled error in get_segment_routing_config")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ============================================================================
+# Config Parsers
+# ============================================================================
+
+
+def _safe_int(value) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_locators(raw: dict) -> List[Srv6Locator]:
+    if not raw:
+        return []
+
+    locators = []
+    for name, cfg in raw.items():
+        if cfg is None:
+            cfg = {}
+
+        locators.append(Srv6Locator(
+            name=name,
+            prefix=cfg.get("prefix"),
+            block_len=_safe_int(cfg.get("block-len")),
+            node_len=_safe_int(cfg.get("node-len")),
+            func_bits=_safe_int(cfg.get("func-bits")),
+            behavior_usid="behavior-usid" in cfg,
+        ))
+
+    return locators
+
+
+def _parse_interfaces(raw: dict) -> List[SrInterface]:
+    if not raw:
+        return []
+
+    interfaces = []
+    for name, cfg in raw.items():
+        if cfg is None:
+            cfg = {}
+
+        srv6 = cfg.get("srv6", {}) or {}
+        interfaces.append(SrInterface(
+            name=name,
+            hmac=srv6.get("hmac"),
+        ))
+
+    return interfaces
+
+
+# ============================================================================
+# Endpoint 3: Batch Operations
+# ============================================================================
+
+
+@router.post("/batch", response_model=VyOSResponse)
+async def segment_routing_batch_configure(http_request: Request, body: SegmentRoutingBatchRequest):
+    """Execute a batch of Segment Routing configuration operations atomically."""
+    await require_write_permission(http_request, FeatureGroup.SEGMENT_ROUTING)
+
+    try:
+        service = get_session_vyos_service(http_request)
+        builder = SegmentRoutingBatchBuilder(version=service.get_version())
+
+        for operation in body.operations:
+            method = getattr(builder, operation.op)
+            sig = inspect.signature(method)
+            params = [p for p in sig.parameters.keys() if p != "self"]
+
+            if len(params) == 0:
+                method()
+            elif len(params) == 1:
+                if operation.value is not None:
+                    method(operation.value)
+            elif len(params) == 2 and operation.value is not None:
+                values = operation.value.split(",", 1)
+                if len(values) == 2:
+                    method(values[0], values[1])
+                else:
+                    method(operation.value, "")
+
+        response = service.execute_batch(builder)
+
+        return VyOSResponse(
+            success=response.status == 200,
+            data={"message": "Segment Routing configuration updated"},
+            error=response.error if response.error else None,
+        )
+    except AttributeError as e:
+        raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
+    except Exception:
+        logger.exception("Unhandled error in segment_routing_batch_configure")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tests/test_segment_routing.py
+++ b/backend/tests/test_segment_routing.py
@@ -1,0 +1,179 @@
+"""Unit tests for the Segment Routing (SRv6) builder, mapper and config parsers.
+
+The builder and mapper are pure logic: builder operations must translate to
+exact VyOS configuration paths under ``protocols segment-routing``. Fixtures
+mirror the config-dict shape returned by ``get_full_config`` for the
+``protocols segment-routing`` subtree. No VyOS service or router needed.
+"""
+
+from routers.segment_routing.segment_routing import (
+    _parse_locators,
+    _parse_interfaces,
+    _safe_int,
+)
+from vyos_builders import SegmentRoutingBatchBuilder
+
+
+def make_builder(version="1.5"):
+    return SegmentRoutingBatchBuilder(version=version)
+
+
+def paths(builder):
+    return [(op["op"], op["path"]) for op in builder.get_operations()]
+
+
+# ============================================================================
+# Builder → VyOS path translation
+# ============================================================================
+
+
+def test_locator_create_full():
+    b = make_builder()
+    b.set_locator_prefix("loc1", "2001:db8:aaaa::/48")
+    b.set_locator_block_len("loc1", "40")
+    b.set_locator_node_len("loc1", "24")
+    b.set_locator_func_bits("loc1", "16")
+    b.set_locator_behavior_usid("loc1")
+
+    base = ["protocols", "segment-routing", "srv6", "locator", "loc1"]
+    assert paths(b) == [
+        ("set", base + ["prefix", "2001:db8:aaaa::/48"]),
+        ("set", base + ["block-len", "40"]),
+        ("set", base + ["node-len", "24"]),
+        ("set", base + ["func-bits", "16"]),
+        ("set", base + ["behavior-usid"]),
+    ]
+
+
+def test_locator_delete_operations():
+    b = make_builder()
+    b.delete_locator_behavior_usid("loc1")
+    b.delete_locator("loc1")
+
+    base = ["protocols", "segment-routing", "srv6", "locator", "loc1"]
+    assert paths(b) == [
+        ("delete", base + ["behavior-usid"]),
+        ("delete", base),
+    ]
+
+
+def test_interface_hmac_operations():
+    b = make_builder()
+    b.set_interface_hmac("eth0", "drop")
+    b.delete_interface_hmac("eth0")
+    b.set_interface_srv6("eth1")
+    b.delete_interface("eth1")
+
+    assert paths(b) == [
+        ("set", ["protocols", "segment-routing", "interface", "eth0", "srv6", "hmac", "drop"]),
+        ("delete", ["protocols", "segment-routing", "interface", "eth0", "srv6", "hmac"]),
+        ("set", ["protocols", "segment-routing", "interface", "eth1", "srv6"]),
+        ("delete", ["protocols", "segment-routing", "interface", "eth1"]),
+    ]
+
+
+def test_delete_entire_segment_routing():
+    b = make_builder()
+    b.delete_segment_routing()
+    assert paths(b) == [("delete", ["protocols", "segment-routing"])]
+
+
+def test_delete_srv6_subtree():
+    # Removing the last locator leaves an empty srv6 node that VyOS verify()
+    # still treats as "SRv6 configured"; delete_srv6 clears the whole subtree.
+    b = make_builder()
+    b.delete_srv6()
+    assert paths(b) == [("delete", ["protocols", "segment-routing", "srv6"])]
+
+
+def test_modify_requires_recreate_flag():
+    assert make_builder("1.4").get_capabilities()["version_info"]["modify_requires_recreate"] is True
+    assert make_builder("1.5").get_capabilities()["version_info"]["modify_requires_recreate"] is False
+
+
+def test_paths_identical_on_both_versions():
+    ops = []
+    for version in ("1.4", "1.5"):
+        b = make_builder(version)
+        b.set_locator_prefix("loc1", "2001:db8::/48")
+        b.set_interface_hmac("eth0", "ignore")
+        ops.append(paths(b))
+    assert ops[0] == ops[1]
+
+
+def test_capabilities_supported_on_both_versions():
+    for version, key in (("1.4", "is_1_4"), ("1.5", "is_1_5")):
+        caps = make_builder(version).get_capabilities()
+        assert caps["version_info"][key] is True
+        assert all(f["supported"] for f in caps["features"].values())
+
+
+def test_builder_starts_empty():
+    b = make_builder()
+    assert b.is_empty()
+    b.set_locator("loc1")
+    assert not b.is_empty()
+
+
+# ============================================================================
+# Config parsers
+# ============================================================================
+
+# ``protocols segment-routing`` subtree as returned by get_full_config
+SR_CONFIG = {
+    "srv6": {
+        "locator": {
+            "loc1": {
+                "prefix": "2001:db8:aaaa::/48",
+                "block-len": "40",
+                "node-len": "24",
+                "func-bits": "16",
+                "behavior-usid": {},
+            },
+            "loc2": {
+                "prefix": "2001:db8:bbbb::/48",
+            },
+        },
+    },
+    "interface": {
+        "eth0": {"srv6": {"hmac": "drop"}},
+        "eth1": {"srv6": {}},
+    },
+}
+
+
+def test_parse_locators():
+    locators = {l.name: l for l in _parse_locators(SR_CONFIG["srv6"]["locator"])}
+    assert set(locators) == {"loc1", "loc2"}
+
+    loc1 = locators["loc1"]
+    assert loc1.prefix == "2001:db8:aaaa::/48"
+    assert loc1.block_len == 40
+    assert loc1.node_len == 24
+    assert loc1.func_bits == 16
+    assert loc1.behavior_usid is True
+
+    loc2 = locators["loc2"]
+    assert loc2.prefix == "2001:db8:bbbb::/48"
+    assert loc2.block_len is None
+    assert loc2.behavior_usid is False
+
+
+def test_parse_interfaces():
+    interfaces = {i.name: i for i in _parse_interfaces(SR_CONFIG["interface"])}
+    assert set(interfaces) == {"eth0", "eth1"}
+    assert interfaces["eth0"].hmac == "drop"
+    assert interfaces["eth1"].hmac is None
+
+
+def test_parse_empty_inputs():
+    assert _parse_locators({}) == []
+    assert _parse_interfaces({}) == []
+    assert _parse_locators({"bare": None})[0].prefix is None
+    assert _parse_interfaces({"eth9": None})[0].hmac is None
+
+
+def test_safe_int():
+    assert _safe_int("40") == 40
+    assert _safe_int(None) is None
+    assert _safe_int("not-a-number") is None

--- a/backend/vyos_builders/__init__.py
+++ b/backend/vyos_builders/__init__.py
@@ -40,6 +40,7 @@ from .tunnel import TunnelBatchBuilder
 from .rip import RipBatchBuilder
 from .ripng import RipNgBatchBuilder
 from .rpki import RpkiBatchBuilder
+from .segment_routing import SegmentRoutingBatchBuilder
 from .traffic_engineering import TrafficEngineeringBatchBuilder
 from .broadcast_relay import BroadcastRelayBatchBuilder
 from .container import ContainerBatchBuilder
@@ -104,6 +105,7 @@ __all__ = [
     "RipBatchBuilder",
     "RipNgBatchBuilder",
     "RpkiBatchBuilder",
+    "SegmentRoutingBatchBuilder",
     "TrafficEngineeringBatchBuilder",
     "BondingBatchBuilder",
     "GeneveBatchBuilder",

--- a/backend/vyos_builders/segment_routing/__init__.py
+++ b/backend/vyos_builders/segment_routing/__init__.py
@@ -1,0 +1,4 @@
+"""Segment Routing Protocol Batch Builder Package."""
+from .segment_routing_batch_builder import SegmentRoutingBatchBuilder
+
+__all__ = ["SegmentRoutingBatchBuilder"]

--- a/backend/vyos_builders/segment_routing/segment_routing_batch_builder.py
+++ b/backend/vyos_builders/segment_routing/segment_routing_batch_builder.py
@@ -1,0 +1,140 @@
+"""Segment Routing Protocol Batch Builder.
+
+Provides all batch operations for Segment Routing (SRv6) configuration.
+Covers: SRv6 locator management and per-interface SRv6 HMAC policy.
+"""
+
+from typing import List, Dict, Any
+from vyos_mappers import CommandMapperRegistry
+
+
+class SegmentRoutingBatchBuilder:
+    """Complete batch builder for Segment Routing protocol operations."""
+
+    def __init__(self, version: str):
+        self.version = version
+        self._operations: List[Dict[str, Any]] = []
+        self.mappers = CommandMapperRegistry.get_all_mappers(version)
+        self.mapper_key = "segment_routing"
+
+    # ========================================================================
+    # Core Batch Operations
+    # ========================================================================
+
+    def add_set(self, path: List[str]) -> "SegmentRoutingBatchBuilder":
+        if path:
+            self._operations.append({"op": "set", "path": path})
+        return self
+
+    def add_delete(self, path: List[str]) -> "SegmentRoutingBatchBuilder":
+        if path:
+            self._operations.append({"op": "delete", "path": path})
+        return self
+
+    def get_operations(self) -> List[Dict[str, Any]]:
+        return self._operations.copy()
+
+    def is_empty(self) -> bool:
+        return len(self._operations) == 0
+
+    @property
+    def m(self):
+        return self.mappers[self.mapper_key]
+
+    # ========================================================================
+    # Capabilities
+    # ========================================================================
+
+    def get_capabilities(self) -> Dict[str, Any]:
+        is_v14 = "1.4" in self.version
+        is_v15 = "1.5" in self.version or "latest" in self.version
+        return {
+            "version": self.version,
+            "version_info": {
+                "is_1_4": is_v14,
+                "is_1_5": is_v15,
+                # VyOS 1.4 FRR reload rejects any modification of an existing
+                # segment-routing tree; editing requires delete + recreate in
+                # separate commits. Create-from-empty and delete-to-empty work.
+                "modify_requires_recreate": is_v14,
+            },
+            "features": {
+                "locators": {
+                    "supported": True,
+                    "description": "SRv6 locator management (prefix, block/node lengths, function bits, uSID behavior)",
+                },
+                "interface_srv6": {
+                    "supported": True,
+                    "description": "Per-interface SRv6 packet acceptance with HMAC policy (accept/drop/ignore, default accept)",
+                },
+            },
+        }
+
+    # ========================================================================
+    # SRv6 Locators
+    # ========================================================================
+
+    def set_locator(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_locator(name))
+
+    def delete_locator(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_locator_delete(name))
+
+    def set_locator_prefix(self, name: str, prefix: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_locator_prefix(name, prefix))
+
+    def delete_locator_prefix(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_locator_prefix_delete(name))
+
+    def set_locator_block_len(self, name: str, value: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_locator_block_len(name, value))
+
+    def delete_locator_block_len(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_locator_block_len_delete(name))
+
+    def set_locator_node_len(self, name: str, value: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_locator_node_len(name, value))
+
+    def delete_locator_node_len(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_locator_node_len_delete(name))
+
+    def set_locator_func_bits(self, name: str, value: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_locator_func_bits(name, value))
+
+    def delete_locator_func_bits(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_locator_func_bits_delete(name))
+
+    def set_locator_behavior_usid(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_locator_behavior_usid(name))
+
+    def delete_locator_behavior_usid(self, name: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_locator_behavior_usid_delete(name))
+
+    def delete_srv6(self) -> "SegmentRoutingBatchBuilder":
+        # Deleting the last locator leaves an empty srv6 node behind, which
+        # VyOS verify() still counts as "SRv6 configured" — blocking deletion
+        # of the last SRv6 interface. This removes the whole srv6 subtree.
+        return self.add_delete(self.m.get_srv6_delete())
+
+    # ========================================================================
+    # Per-interface SRv6 options
+    # ========================================================================
+
+    def set_interface_hmac(self, interface: str, policy: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_interface_hmac(interface, policy))
+
+    def delete_interface_hmac(self, interface: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_interface_hmac_delete(interface))
+
+    def set_interface_srv6(self, interface: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_set(self.m.get_interface_srv6(interface))
+
+    def delete_interface(self, interface: str) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_interface_delete(interface))
+
+    # ========================================================================
+    # Delete entire Segment Routing configuration
+    # ========================================================================
+
+    def delete_segment_routing(self) -> "SegmentRoutingBatchBuilder":
+        return self.add_delete(self.m.get_segment_routing_delete())

--- a/backend/vyos_mappers/__init__.py
+++ b/backend/vyos_mappers/__init__.py
@@ -107,6 +107,8 @@ from .ripng import RipNgMapper
 from .ripng.ripng_versions import get_ripng_mapper
 from .rpki import RpkiMapper
 from .rpki.rpki_versions import get_rpki_mapper
+from .segment_routing import SegmentRoutingMapper
+from .segment_routing.segment_routing_versions import get_segment_routing_mapper
 from .traffic_engineering import TrafficEngineeringMapper
 from .traffic_engineering.traffic_engineering_versions import get_traffic_engineering_mapper
 from .broadcast_relay import BroadcastRelayMapper
@@ -297,6 +299,8 @@ CommandMapperRegistry.register_feature("rip", get_rip_mapper)
 CommandMapperRegistry.register_feature("ripng", get_ripng_mapper)
 # RPKI uses factory for version-specific mappers
 CommandMapperRegistry.register_feature("rpki", get_rpki_mapper)
+# Segment Routing uses factory for version-specific mappers
+CommandMapperRegistry.register_feature("segment_routing", get_segment_routing_mapper)
 # Traffic Engineering uses factory for version-specific mappers
 CommandMapperRegistry.register_feature("traffic_engineering", get_traffic_engineering_mapper)
 # Broadcast Relay uses factory for version-specific mappers
@@ -406,6 +410,7 @@ __all__ = [
     "PimMapper",
     "Pim6Mapper",
     "RpkiMapper",
+    "SegmentRoutingMapper",
     "TrafficEngineeringMapper",
     "BondingInterfaceMapper",
     "BridgeInterfaceMapper",

--- a/backend/vyos_mappers/segment_routing/__init__.py
+++ b/backend/vyos_mappers/segment_routing/__init__.py
@@ -1,0 +1,4 @@
+"""Segment Routing Protocol Mapper Package."""
+from .segment_routing import SegmentRoutingMapper
+
+__all__ = ["SegmentRoutingMapper"]

--- a/backend/vyos_mappers/segment_routing/segment_routing.py
+++ b/backend/vyos_mappers/segment_routing/segment_routing.py
@@ -1,0 +1,79 @@
+"""Segment Routing Protocol Command Mapper."""
+from typing import List
+from ..base import BaseFeatureMapper
+
+
+class SegmentRoutingMapper(BaseFeatureMapper):
+    """Base mapper for Segment Routing (SRv6) configuration paths."""
+
+    def __init__(self, version: str):
+        super().__init__(version)
+
+    def _sr(self) -> List[str]:
+        return ["protocols", "segment-routing"]
+
+    # ========================================================================
+    # SRv6 locators
+    # ========================================================================
+
+    def get_locator(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name]
+
+    def get_locator_delete(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name]
+
+    def get_locator_prefix(self, name: str, prefix: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "prefix", prefix]
+
+    def get_locator_prefix_delete(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "prefix"]
+
+    def get_locator_block_len(self, name: str, value: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "block-len", value]
+
+    def get_locator_block_len_delete(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "block-len"]
+
+    def get_locator_node_len(self, name: str, value: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "node-len", value]
+
+    def get_locator_node_len_delete(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "node-len"]
+
+    def get_locator_func_bits(self, name: str, value: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "func-bits", value]
+
+    def get_locator_func_bits_delete(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "func-bits"]
+
+    def get_locator_behavior_usid(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "behavior-usid"]
+
+    def get_locator_behavior_usid_delete(self, name: str) -> List[str]:
+        return self._sr() + ["srv6", "locator", name, "behavior-usid"]
+
+    def get_srv6_delete(self) -> List[str]:
+        return self._sr() + ["srv6"]
+
+    # ========================================================================
+    # Per-interface SRv6 options
+    # ========================================================================
+
+    def get_interface_hmac(self, interface: str, policy: str) -> List[str]:
+        return self._sr() + ["interface", interface, "srv6", "hmac", policy]
+
+    def get_interface_hmac_delete(self, interface: str) -> List[str]:
+        return self._sr() + ["interface", interface, "srv6", "hmac"]
+
+    def get_interface_srv6(self, interface: str) -> List[str]:
+        return self._sr() + ["interface", interface, "srv6"]
+
+    def get_interface_delete(self, interface: str) -> List[str]:
+        return self._sr() + ["interface", interface]
+
+    # ========================================================================
+    # Delete entire Segment Routing configuration
+    # ========================================================================
+
+    def get_segment_routing_delete(self) -> List[str]:
+        return self._sr()

--- a/backend/vyos_mappers/segment_routing/segment_routing_versions/__init__.py
+++ b/backend/vyos_mappers/segment_routing/segment_routing_versions/__init__.py
@@ -1,0 +1,24 @@
+"""Factory for version-specific Segment Routing protocol mappers."""
+from ..segment_routing import SegmentRoutingMapper
+from .v1_4 import SegmentRoutingMapperV1_4
+from .v1_5 import SegmentRoutingMapperV1_5
+
+
+def get_segment_routing_mapper(version: str):
+    """Return a version-merged Segment Routing mapper."""
+    base = SegmentRoutingMapper(version)
+
+    if "1.4" in version:
+        version_specific = SegmentRoutingMapperV1_4()
+    elif "1.5" in version or "latest" in version:
+        version_specific = SegmentRoutingMapperV1_5()
+    else:
+        version_specific = SegmentRoutingMapperV1_5()
+
+    class MergedMapper:
+        def __getattr__(self, name):
+            if hasattr(version_specific, name):
+                return getattr(version_specific, name)
+            return getattr(base, name)
+
+    return MergedMapper()

--- a/backend/vyos_mappers/segment_routing/segment_routing_versions/v1_4.py
+++ b/backend/vyos_mappers/segment_routing/segment_routing_versions/v1_4.py
@@ -1,0 +1,9 @@
+"""VyOS 1.4 Segment Routing mapper — no version-specific overrides.
+
+The protocols segment-routing tree (interface srv6 hmac, srv6 locators)
+is identical between VyOS 1.4 and 1.5; the base mapper holds all paths.
+"""
+
+
+class SegmentRoutingMapperV1_4:
+    pass

--- a/backend/vyos_mappers/segment_routing/segment_routing_versions/v1_5.py
+++ b/backend/vyos_mappers/segment_routing/segment_routing_versions/v1_5.py
@@ -1,0 +1,9 @@
+"""VyOS 1.5 Segment Routing mapper — no version-specific overrides.
+
+The protocols segment-routing tree (interface srv6 hmac, srv6 locators)
+is identical between VyOS 1.4 and 1.5; the base mapper holds all paths.
+"""
+
+
+class SegmentRoutingMapperV1_5:
+    pass


### PR DESCRIPTION
Backend half of #434 — the last missing Phase 2 routing module. Frontend follows in two separate PRs per the agreed split.

Implements the standalone `protocols segment-routing` tree: SRv6 locators (prefix, block-len, node-len, func-bits, behavior-usid) and per-interface SRv6 packet acceptance with HMAC policy (accept/drop/ignore). Scope verified against the vyos-1x interface definitions for both versions before implementation: the tree is identical on 1.4 (sagitta) and 1.5 (circinus), so the version pair uses the empty-override pattern (like RPKI/RIP) with all paths in the base mapper. SR-MPLS (`protocols isis/ospf segment-routing`) already lives in the ISIS/OSPF modules and is not part of this tree.

New: router (`/vyos/segment-routing/{capabilities,config,batch}`), batch builder, mapper + version factory, app registration. RBAC enforces `FeatureGroup.SEGMENT_ROUTING`, which was already wired into the hierarchy (#428 fallback covers ROUTING_INFRASTRUCTURE-only roles).

Two additions derived from live-router testing:
- `version_info.modify_requires_recreate` in capabilities — true on 1.4, where FRR reload rejects any in-place modification of an existing segment-routing tree; clients must delete + recreate in two commits.
- `delete_srv6` operation — deleting the last locator leaves an empty `srv6` node that VyOS verify() still counts as "SRv6 configured", blocking deletion of the last SRv6 interface; this clears the subtree.

## Testing

**Verified end-to-end against real routers: VyOS 1.4.4 LTS and rolling 2026.05.21** (no 1.5 LTS image exists; the `verify()` constraint code is confirmed identical in sagitta/circinus sources).

- Full lifecycle on rolling: one-batch create (interface SRv6 + locator with prefix/behavior-usid), attribute updates (block-len/node-len/func-bits), interface HMAC policy, partial deletes (flag only, locator only), full-tree delete — every commit verified on-router via `show configuration commands` and round-tripped through `GET /config` field-correct.
- On 1.4.4: create-from-empty, full-tree delete, capabilities, config parsing and RBAC all verified working. **Known VyOS 1.4.4 platform limitation (not a VyManager defect):** any modification of an existing `protocols segment-routing` tree fails at FRR reload (`% Unknown command: segment-routing`); editing on 1.4 requires delete + recreate in separate commits. The identical command sequences pass on rolling. Exposed as `modify_requires_recreate` so clients can adapt.
- VyOS constraints exercised deliberately: a locator without an SRv6-enabled interface is rejected (`SRv6 should be enabled on at least one interface!`) — clients must bundle both in one batch; FRR requires locator prefix length = block-len + node-len (violations surface as a bare commit failure). The new `delete_srv6` operation is unit-tested at the path level; its on-router necessity and effect are established by the live-router probe evidence from this test cycle.
- Negative path: out-of-range `block-len 99` → API returns `success:false` with the VyOS validation error verbatim; router config unchanged (atomic commit).
- RBAC live-verified on both routers: dedicated `SEGMENT_ROUTING` grant → allowed; `ROUTING_INFRASTRUCTURE`-only grant → allowed via the #428 hierarchy fallback; unrelated grant → 403.
- Unit tests: 13 new (builder→path translation for every operation incl. `delete_srv6`, version parity, capabilities incl. `modify_requires_recreate`, config parsers, edge cases); full backend suite 41 passed.
- Test hygiene: both lab routers restored to their pre-test config (zero diff against backups), test API keys and HTTPS service reverted, local test database dropped.