### PR TITLE
feat: add segment routing UI — locators section

### DIFF
--- a/frontend/src/app/routing/infrastructure/page.tsx
+++ b/frontend/src/app/routing/infrastructure/page.tsx
@@ -10,6 +10,7 @@ import { BfdContent } from "@/components/bfd/BfdContent";
 import { MplsContent } from "@/components/mpls/MplsContent";
 import { NhrpContent } from "@/components/nhrp/NhrpContent";
 import { RpkiContent } from "@/components/rpki/RpkiContent";
+import { SegmentRoutingContent } from "@/components/segment-routing/SegmentRoutingContent";
 import { TrafficEngineeringContent } from "@/components/traffic-engineering/TrafficEngineeringContent";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -168,6 +169,8 @@ function InfrastructurePageInner() {
             <NhrpContent />
           ) : selectedInfra === "rpki" ? (
             <RpkiContent />
+          ) : selectedInfra === "segment-routing" ? (
+            <SegmentRoutingContent />
           ) : selectedInfra === "traffic-engineering" ? (
             <TrafficEngineeringContent />
           ) : (

--- a/frontend/src/components/segment-routing/DeleteLocatorModal.tsx
+++ b/frontend/src/components/segment-routing/DeleteLocatorModal.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+
+interface DeleteLocatorModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  locatorName: string;
+  /** True on VyOS 1.4: deletion rewrites the whole segment-routing tree. */
+  requiresRecreate: boolean;
+  onConfirm: () => Promise<void>;
+}
+
+export function DeleteLocatorModal({
+  open,
+  onOpenChange,
+  locatorName,
+  requiresRecreate,
+  onConfirm,
+}: DeleteLocatorModalProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await onConfirm();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete SRv6 Locator</AlertDialogTitle>
+          <AlertDialogDescription>
+            Remove locator{" "}
+            <span className="font-mono font-semibold">{locatorName}</span>?
+            IGPs referencing this locator will stop advertising its SIDs.
+            {requiresRecreate && (
+              <>
+                {" "}This router runs VyOS 1.4, which cannot modify existing
+                Segment Routing configuration in place: the whole
+                segment-routing tree is removed and recreated without this
+                locator, in two commits.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={loading}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              "Delete Locator"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/segment-routing/LocatorModal.tsx
+++ b/frontend/src/components/segment-routing/LocatorModal.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { AlertCircle, AlertTriangle, Loader2 } from "lucide-react";
+import { InterfaceSelect } from "@/components/ui/interface-select";
+import type { Srv6Locator } from "@/lib/api/segment-routing";
+
+interface LocatorModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (locator: Srv6Locator, enableInterface?: string) => Promise<void>;
+  existingLocator?: Srv6Locator | null;
+  existingNames: string[];
+  /**
+   * True when no interface has SRv6 enabled yet. VyOS refuses to commit a
+   * locator unless at least one interface has SRv6 enabled in the same
+   * commit, so creation must bundle an interface enable.
+   */
+  needsInterfaceEnable: boolean;
+  /** True on VyOS 1.4: saving rewrites the whole segment-routing tree. */
+  requiresRecreate: boolean;
+}
+
+const DEFAULT_BLOCK_LEN = 40;
+const DEFAULT_NODE_LEN = 24;
+
+export function LocatorModal({
+  open,
+  onOpenChange,
+  onSubmit,
+  existingLocator,
+  existingNames,
+  needsInterfaceEnable,
+  requiresRecreate,
+}: LocatorModalProps) {
+  const isEditMode = !!existingLocator;
+
+  const [name, setName] = useState("");
+  const [prefix, setPrefix] = useState("");
+  const [blockLen, setBlockLen] = useState("");
+  const [nodeLen, setNodeLen] = useState("");
+  const [funcBits, setFuncBits] = useState("");
+  const [behaviorUsid, setBehaviorUsid] = useState(false);
+  const [enableInterface, setEnableInterface] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setName("");
+    setPrefix("");
+    setBlockLen("");
+    setNodeLen("");
+    setFuncBits("");
+    setBehaviorUsid(false);
+    setEnableInterface("");
+    setError(null);
+  };
+
+  useEffect(() => {
+    if (open) {
+      if (existingLocator) {
+        setName(existingLocator.name);
+        setPrefix(existingLocator.prefix ?? "");
+        setBlockLen(existingLocator.block_len != null ? String(existingLocator.block_len) : "");
+        setNodeLen(existingLocator.node_len != null ? String(existingLocator.node_len) : "");
+        setFuncBits(existingLocator.func_bits != null ? String(existingLocator.func_bits) : "");
+        setBehaviorUsid(existingLocator.behavior_usid);
+        setEnableInterface("");
+        setError(null);
+      } else {
+        resetForm();
+      }
+    }
+  }, [open, existingLocator]);
+
+  const validateForm = (): string | null => {
+    if (!name.trim()) return "Locator name is required";
+    if (!/^[a-zA-Z0-9\-_]+$/.test(name.trim())) {
+      return "Locator name may contain only letters, digits, hyphens and underscores";
+    }
+    if (!isEditMode && existingNames.includes(name.trim())) {
+      return `Locator ${name.trim()} already exists`;
+    }
+
+    if (!prefix.trim()) return "Locator prefix is required";
+    const prefixMatch = prefix.trim().match(/^([0-9a-fA-F:]+)\/(\d{1,3})$/);
+    if (!prefixMatch) return "Prefix must be an IPv6 network, e.g. 2001:db8:aaaa:bbbb::/64";
+    const prefixLen = parseInt(prefixMatch[2], 10);
+    if (prefixLen < 1 || prefixLen > 128) return "Prefix length must be between 1 and 128";
+
+    let block = DEFAULT_BLOCK_LEN;
+    if (blockLen) {
+      block = parseInt(blockLen, 10);
+      if (isNaN(block) || block < 16 || block > 64) return "Block length must be between 16 and 64";
+    }
+    let node = DEFAULT_NODE_LEN;
+    if (nodeLen) {
+      node = parseInt(nodeLen, 10);
+      if (isNaN(node) || node < 16 || node > 64) return "Node length must be between 16 and 64";
+    }
+    if (funcBits) {
+      const func = parseInt(funcBits, 10);
+      if (isNaN(func) || func < 0 || func > 64) return "Function bits must be between 0 and 64";
+    }
+
+    // FRR requires this equality but VyOS reports only a bare "Commit
+    // failed" when it is violated, so enforce it client-side.
+    if (prefixLen !== block + node) {
+      return `Prefix length must equal block length + node length (${block} + ${node} = ${block + node}, but the prefix is /${prefixLen})`;
+    }
+
+    if (!isEditMode && needsInterfaceEnable && !enableInterface) {
+      return "Select an interface to enable SRv6 on";
+    }
+
+    return null;
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validateForm();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const locator: Srv6Locator = {
+      name: name.trim(),
+      prefix: prefix.trim(),
+      block_len: blockLen ? parseInt(blockLen, 10) : null,
+      node_len: nodeLen ? parseInt(nodeLen, 10) : null,
+      func_bits: funcBits ? parseInt(funcBits, 10) : null,
+      behavior_usid: behaviorUsid,
+    };
+
+    try {
+      await onSubmit(
+        locator,
+        !isEditMode && needsInterfaceEnable ? enableInterface : undefined
+      );
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Operation failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>{isEditMode ? "Edit Locator" : "Add Locator"}</DialogTitle>
+          <DialogDescription>
+            Configure an SRv6 locator — the IPv6 prefix this router advertises
+            for Segment Routing segments.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[60vh] pr-4">
+          <div className="space-y-5 py-2">
+            {/* Name */}
+            <div className="space-y-1.5">
+              <Label htmlFor="sr-locator-name">Locator Name</Label>
+              <Input
+                id="sr-locator-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. main"
+                disabled={isEditMode}
+                className={isEditMode ? "bg-muted" : ""}
+              />
+            </div>
+
+            {/* Prefix */}
+            <div className="space-y-1.5">
+              <Label htmlFor="sr-locator-prefix">Prefix</Label>
+              <Input
+                id="sr-locator-prefix"
+                value={prefix}
+                onChange={(e) => setPrefix(e.target.value)}
+                placeholder="e.g. 2001:db8:aaaa:bbbb::/64"
+              />
+              <p className="text-xs text-muted-foreground">
+                IPv6 network. The prefix length must equal block length + node
+                length (defaults 40 + 24 → /64).
+              </p>
+            </div>
+
+            {/* Lengths */}
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="sr-block-len">Block Length</Label>
+                <Input
+                  id="sr-block-len"
+                  type="number"
+                  min={16}
+                  max={64}
+                  value={blockLen}
+                  onChange={(e) => setBlockLen(e.target.value)}
+                  placeholder="Default: 40"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="sr-node-len">Node Length</Label>
+                <Input
+                  id="sr-node-len"
+                  type="number"
+                  min={16}
+                  max={64}
+                  value={nodeLen}
+                  onChange={(e) => setNodeLen(e.target.value)}
+                  placeholder="Default: 24"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="sr-func-bits">Function Bits</Label>
+                <Input
+                  id="sr-func-bits"
+                  type="number"
+                  min={0}
+                  max={64}
+                  value={funcBits}
+                  onChange={(e) => setFuncBits(e.target.value)}
+                  placeholder="Default: 16"
+                />
+              </div>
+            </div>
+
+            {/* uSID */}
+            <div className="flex items-start gap-3">
+              <Checkbox
+                id="sr-behavior-usid"
+                checked={behaviorUsid}
+                onCheckedChange={(checked) => setBehaviorUsid(checked === true)}
+              />
+              <div className="space-y-0.5">
+                <Label htmlFor="sr-behavior-usid" className="cursor-pointer">
+                  uSID Behavior
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Use compressed micro-segment (uSID) behavior for this locator
+                </p>
+              </div>
+            </div>
+
+            {/* Interface enable — bundled into the same commit */}
+            {!isEditMode && needsInterfaceEnable && (
+              <div className="rounded-md border border-border p-4 space-y-3">
+                <div className="space-y-0.5">
+                  <Label>Enable SRv6 on Interface</Label>
+                  <p className="text-xs text-muted-foreground">
+                    VyOS requires SRv6 to be enabled on at least one interface
+                    before a locator can be committed. No interface has SRv6
+                    enabled yet, so this change is applied together with the
+                    locator in a single commit.
+                  </p>
+                </div>
+                <InterfaceSelect
+                  value={enableInterface}
+                  onValueChange={setEnableInterface}
+                  placeholder="Select an interface"
+                />
+              </div>
+            )}
+
+            {/* 1.4 recreate warning */}
+            {isEditMode && requiresRecreate && (
+              <div className="flex items-start gap-2 rounded-md bg-amber-500/10 border border-amber-500/20 p-3">
+                <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+                <p className="text-sm text-muted-foreground">
+                  This router runs VyOS 1.4, which cannot modify existing
+                  Segment Routing configuration in place. Saving removes the
+                  whole segment-routing tree and recreates it with your change,
+                  in two commits. If the second commit fails, the tree is left
+                  empty — refresh and re-apply from this page.
+                </p>
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-3">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {isEditMode ? "Saving..." : "Creating..."}
+              </>
+            ) : isEditMode ? (
+              requiresRecreate ? "Rewrite & Save" : "Save Changes"
+            ) : (
+              "Add Locator"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/segment-routing/SegmentRoutingContent.tsx
+++ b/frontend/src/components/segment-routing/SegmentRoutingContent.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Waypoints,
+  MapPin,
+  Network,
+  Plus,
+  RefreshCw,
+  Pencil,
+  Trash2,
+  AlertCircle,
+  Info,
+} from "lucide-react";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import {
+  segmentRoutingService,
+  SegmentRoutingConfig,
+  SegmentRoutingCapabilities,
+  Srv6Locator,
+} from "@/lib/api/segment-routing";
+import { LocatorModal } from "./LocatorModal";
+import { DeleteLocatorModal } from "./DeleteLocatorModal";
+import { usePermissions } from "@/hooks/usePermissions";
+import { FeatureGroup } from "@/lib/api/user-management";
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function SegmentRoutingContent() {
+  const { canWrite } = usePermissions();
+  const hasWritePermission = canWrite(FeatureGroup.SEGMENT_ROUTING);
+
+  const [config, setConfig] = useState<SegmentRoutingConfig | null>(null);
+  const [capabilities, setCapabilities] = useState<SegmentRoutingCapabilities | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [locatorModalOpen, setLocatorModalOpen] = useState(false);
+  const [editingLocator, setEditingLocator] = useState<Srv6Locator | null>(null);
+  const [deletingLocator, setDeletingLocator] = useState<string | null>(null);
+
+  const requiresRecreate =
+    capabilities?.version_info.modify_requires_recreate === true;
+  const treeIsEmpty =
+    (config?.locators.length ?? 0) === 0 && (config?.interfaces.length ?? 0) === 0;
+  const hasSrv6Interface = (config?.interfaces.length ?? 0) > 0;
+
+  // ============================================================================
+  // Data Loading
+  // ============================================================================
+
+  const loadData = useCallback(async (refresh = false) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [configData, capData] = await Promise.all([
+        segmentRoutingService.getConfig(refresh),
+        segmentRoutingService.getCapabilities(),
+      ]);
+      setConfig(configData);
+      setCapabilities(capData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load Segment Routing configuration");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // ============================================================================
+  // Stats
+  // ============================================================================
+
+  const locatorCount = config?.locators.length ?? 0;
+  const usidCount = config?.locators.filter((l) => l.behavior_usid).length ?? 0;
+  const srv6InterfaceCount = config?.interfaces.length ?? 0;
+
+  // ============================================================================
+  // CRUD Handlers
+  // ============================================================================
+
+  const handleCreateLocator = async (locator: Srv6Locator, enableInterface?: string) => {
+    if (requiresRecreate && !treeIsEmpty && config) {
+      // VyOS 1.4 cannot modify an existing tree in place: rebuild the whole
+      // desired state (current config + the new locator) via delete+recreate.
+      const desired: SegmentRoutingConfig = {
+        locators: [...config.locators, locator],
+        interfaces: enableInterface
+          ? [...config.interfaces, { name: enableInterface, hmac: null }]
+          : config.interfaces,
+      };
+      await segmentRoutingService.applyViaRecreate(desired);
+    } else {
+      await segmentRoutingService.createLocator(locator, enableInterface);
+    }
+    await loadData(true);
+  };
+
+  const handleUpdateLocator = async (locator: Srv6Locator) => {
+    if (!editingLocator || !config) return;
+    if (requiresRecreate) {
+      const desired: SegmentRoutingConfig = {
+        locators: config.locators.map((l) =>
+          l.name === editingLocator.name ? locator : l
+        ),
+        interfaces: config.interfaces,
+      };
+      await segmentRoutingService.applyViaRecreate(desired);
+    } else {
+      await segmentRoutingService.updateLocator(editingLocator, locator);
+    }
+    setEditingLocator(null);
+    await loadData(true);
+  };
+
+  const handleDeleteLocator = async () => {
+    if (!deletingLocator || !config) return;
+    if (requiresRecreate) {
+      const desired: SegmentRoutingConfig = {
+        locators: config.locators.filter((l) => l.name !== deletingLocator),
+        interfaces: config.interfaces,
+      };
+      await segmentRoutingService.applyViaRecreate(desired);
+    } else {
+      await segmentRoutingService.deleteLocator(deletingLocator);
+    }
+    setDeletingLocator(null);
+    await loadData(true);
+  };
+
+  // ============================================================================
+  // Render
+  // ============================================================================
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (error && !config) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <p className="text-destructive">{error}</p>
+        <Button variant="outline" onClick={() => loadData()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col h-full">
+        {/* Header */}
+        <div className="p-6 pb-4 border-b border-border">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <div className="flex items-center gap-2">
+                <Waypoints className="h-6 w-6 text-primary" />
+                <h1 className="text-2xl font-bold text-foreground">Segment Routing</h1>
+                {!hasWritePermission && (
+                  <Badge variant="secondary" className="text-xs">Read Only</Badge>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground mt-1">
+                SRv6 locators and interface configuration
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => loadData(true)}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
+
+          {error && (
+            <div className="mb-4 flex items-start gap-2 rounded-md bg-destructive/10 p-3">
+              <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          {requiresRecreate && (
+            <div className="mb-4 flex items-start gap-2 rounded-md bg-blue-500/10 border border-blue-500/20 p-3">
+              <Info className="h-5 w-5 text-blue-500 shrink-0 mt-0.5" />
+              <p className="text-sm text-muted-foreground">
+                VyOS 1.4 cannot modify existing Segment Routing configuration in
+                place. Changes on this router are applied by removing and
+                recreating the whole segment-routing tree in two commits.
+              </p>
+            </div>
+          )}
+
+          {/* Stats */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="rounded-md p-2 bg-primary/10">
+                    <MapPin className="h-4 w-4 text-primary" />
+                  </div>
+                  <div>
+                    <p className="text-2xl font-bold">{locatorCount}</p>
+                    <p className="text-xs text-muted-foreground">SRv6 Locators</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="rounded-md p-2 bg-blue-500/10">
+                    <Waypoints className="h-4 w-4 text-blue-500" />
+                  </div>
+                  <div>
+                    <p className="text-2xl font-bold">{usidCount}</p>
+                    <p className="text-xs text-muted-foreground">uSID Behavior</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3">
+                  <div className="rounded-md p-2 bg-green-500/10">
+                    <Network className="h-4 w-4 text-green-500" />
+                  </div>
+                  <div>
+                    <p className="text-2xl font-bold">{srv6InterfaceCount}</p>
+                    <p className="text-xs text-muted-foreground">SRv6 Interfaces</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Locators Section */}
+        <div className="flex-1 overflow-auto p-6">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Locators define the IPv6 prefix a router advertises for SRv6
+                segments. IGPs such as IS-IS allocate SIDs from them.
+              </p>
+              {hasWritePermission && (
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    setEditingLocator(null);
+                    setLocatorModalOpen(true);
+                  }}
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Locator
+                </Button>
+              )}
+            </div>
+
+            {locatorCount === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                <MapPin className="h-12 w-12 mb-4 opacity-50" />
+                <p className="text-lg font-medium">No SRv6 locators configured</p>
+                <p className="text-sm mt-1">Add a locator to start using Segment Routing over IPv6</p>
+                {hasWritePermission && (
+                  <Button
+                    className="mt-4"
+                    onClick={() => {
+                      setEditingLocator(null);
+                      setLocatorModalOpen(true);
+                    }}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add Locator
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <Card>
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Prefix</TableHead>
+                        <TableHead>Block Len</TableHead>
+                        <TableHead>Node Len</TableHead>
+                        <TableHead>Func Bits</TableHead>
+                        <TableHead>uSID</TableHead>
+                        {hasWritePermission && <TableHead className="w-20" />}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {config?.locators.map((locator) => (
+                        <TableRow key={locator.name}>
+                          <TableCell className="font-medium">{locator.name}</TableCell>
+                          <TableCell className="font-mono">{locator.prefix ?? "—"}</TableCell>
+                          <TableCell>{locator.block_len ?? <span className="text-muted-foreground">40 (default)</span>}</TableCell>
+                          <TableCell>{locator.node_len ?? <span className="text-muted-foreground">24 (default)</span>}</TableCell>
+                          <TableCell>{locator.func_bits ?? <span className="text-muted-foreground">16 (default)</span>}</TableCell>
+                          <TableCell>
+                            {locator.behavior_usid ? (
+                              <Badge variant="secondary" className="text-xs">uSID</Badge>
+                            ) : (
+                              "—"
+                            )}
+                          </TableCell>
+                          {hasWritePermission && (
+                            <TableCell>
+                              <div className="flex gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7"
+                                  onClick={() => {
+                                    setEditingLocator(locator);
+                                    setLocatorModalOpen(true);
+                                  }}
+                                >
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7 text-destructive hover:text-destructive"
+                                  onClick={() => setDeletingLocator(locator.name)}
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </div>
+                            </TableCell>
+                          )}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </Card>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Modals */}
+      <LocatorModal
+        open={locatorModalOpen}
+        onOpenChange={(open) => {
+          setLocatorModalOpen(open);
+          if (!open) setEditingLocator(null);
+        }}
+        onSubmit={editingLocator ? handleUpdateLocator : handleCreateLocator}
+        existingLocator={editingLocator}
+        existingNames={config?.locators.map((l) => l.name) ?? []}
+        needsInterfaceEnable={!hasSrv6Interface}
+        requiresRecreate={requiresRecreate}
+      />
+
+      <DeleteLocatorModal
+        open={deletingLocator !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingLocator(null);
+        }}
+        locatorName={deletingLocator ?? ""}
+        requiresRecreate={requiresRecreate}
+        onConfirm={handleDeleteLocator}
+      />
+    </>
+  );
+}

--- a/frontend/src/lib/api/segment-routing.ts
+++ b/frontend/src/lib/api/segment-routing.ts
@@ -1,0 +1,196 @@
+import { apiClient } from "./client";
+
+// ============================================================================
+// TypeScript Interfaces
+// ============================================================================
+
+export interface Srv6Locator {
+  name: string;
+  prefix: string | null;
+  block_len: number | null;
+  node_len: number | null;
+  func_bits: number | null;
+  behavior_usid: boolean;
+}
+
+export interface SrInterface {
+  name: string;
+  hmac: string | null;
+}
+
+export interface SegmentRoutingConfig {
+  locators: Srv6Locator[];
+  interfaces: SrInterface[];
+}
+
+export interface SegmentRoutingCapabilities {
+  version: string;
+  version_info: {
+    is_1_4: boolean;
+    is_1_5: boolean;
+    /**
+     * True on VyOS 1.4, where FRR rejects any in-place modification of an
+     * existing segment-routing tree: edits must delete the tree and recreate
+     * it in two separate commits.
+     */
+    modify_requires_recreate: boolean;
+  };
+  features: {
+    locators: { supported: boolean; description: string };
+    interface_srv6: { supported: boolean; description: string };
+  };
+  instance_name?: string;
+  instance_id?: string;
+}
+
+export interface SegmentRoutingBatchOperation {
+  op: string;
+  value?: string;
+}
+
+export interface VyOSResponse {
+  success: boolean;
+  data?: Record<string, unknown> | null;
+  error?: string | null;
+}
+
+// ============================================================================
+// API Service
+// ============================================================================
+
+class SegmentRoutingService {
+  async getCapabilities(): Promise<SegmentRoutingCapabilities> {
+    return apiClient.get<SegmentRoutingCapabilities>("/vyos/segment-routing/capabilities");
+  }
+
+  async getConfig(refresh = false): Promise<SegmentRoutingConfig> {
+    return apiClient.get<SegmentRoutingConfig>("/vyos/segment-routing/config", {
+      refresh: refresh.toString(),
+    });
+  }
+
+  private async batch(ops: SegmentRoutingBatchOperation[]): Promise<VyOSResponse> {
+    const result = await apiClient.post<VyOSResponse>("/vyos/segment-routing/batch", {
+      operations: ops,
+    });
+    if (!result.success) throw new Error(result.error || "Segment Routing operation failed");
+    return result;
+  }
+
+  private locatorOps(locator: Srv6Locator): SegmentRoutingBatchOperation[] {
+    const ops: SegmentRoutingBatchOperation[] = [];
+    if (locator.prefix) {
+      ops.push({ op: "set_locator_prefix", value: `${locator.name},${locator.prefix}` });
+    }
+    if (locator.block_len != null) {
+      ops.push({ op: "set_locator_block_len", value: `${locator.name},${locator.block_len}` });
+    }
+    if (locator.node_len != null) {
+      ops.push({ op: "set_locator_node_len", value: `${locator.name},${locator.node_len}` });
+    }
+    if (locator.func_bits != null) {
+      ops.push({ op: "set_locator_func_bits", value: `${locator.name},${locator.func_bits}` });
+    }
+    if (locator.behavior_usid) {
+      ops.push({ op: "set_locator_behavior_usid", value: locator.name });
+    }
+    return ops;
+  }
+
+  /** All operations that reproduce a full desired config from an empty tree. */
+  private fullConfigOps(config: SegmentRoutingConfig): SegmentRoutingBatchOperation[] {
+    const ops: SegmentRoutingBatchOperation[] = [];
+    // Interfaces first: VyOS rejects a locator commit unless at least one
+    // interface has SRv6 enabled in the same commit.
+    for (const iface of config.interfaces) {
+      if (iface.hmac) {
+        ops.push({ op: "set_interface_hmac", value: `${iface.name},${iface.hmac}` });
+      } else {
+        ops.push({ op: "set_interface_srv6", value: iface.name });
+      }
+    }
+    for (const locator of config.locators) {
+      ops.push(...this.locatorOps(locator));
+    }
+    return ops;
+  }
+
+  /**
+   * Create a locator. When the config has no SRv6-enabled interface yet,
+   * pass enableInterface to bundle the interface enable into the same
+   * commit — VyOS rejects a locator without one.
+   */
+  async createLocator(locator: Srv6Locator, enableInterface?: string): Promise<VyOSResponse> {
+    const ops: SegmentRoutingBatchOperation[] = [];
+    if (enableInterface) {
+      ops.push({ op: "set_interface_srv6", value: enableInterface });
+    }
+    ops.push(...this.locatorOps(locator));
+    return this.batch(ops);
+  }
+
+  /** In-place locator update (works on VyOS 1.5/rolling). */
+  async updateLocator(original: Srv6Locator, updated: Srv6Locator): Promise<VyOSResponse> {
+    const ops: SegmentRoutingBatchOperation[] = [];
+    const name = original.name;
+
+    if (original.prefix !== updated.prefix && updated.prefix) {
+      ops.push({ op: "set_locator_prefix", value: `${name},${updated.prefix}` });
+    }
+    if (original.block_len !== updated.block_len) {
+      if (updated.block_len != null) {
+        ops.push({ op: "set_locator_block_len", value: `${name},${updated.block_len}` });
+      } else {
+        ops.push({ op: "delete_locator_block_len", value: name });
+      }
+    }
+    if (original.node_len !== updated.node_len) {
+      if (updated.node_len != null) {
+        ops.push({ op: "set_locator_node_len", value: `${name},${updated.node_len}` });
+      } else {
+        ops.push({ op: "delete_locator_node_len", value: name });
+      }
+    }
+    if (original.func_bits !== updated.func_bits) {
+      if (updated.func_bits != null) {
+        ops.push({ op: "set_locator_func_bits", value: `${name},${updated.func_bits}` });
+      } else {
+        ops.push({ op: "delete_locator_func_bits", value: name });
+      }
+    }
+    if (original.behavior_usid !== updated.behavior_usid) {
+      if (updated.behavior_usid) {
+        ops.push({ op: "set_locator_behavior_usid", value: name });
+      } else {
+        ops.push({ op: "delete_locator_behavior_usid", value: name });
+      }
+    }
+
+    if (ops.length === 0) {
+      return { success: true, data: { message: "No changes" } };
+    }
+    return this.batch(ops);
+  }
+
+  /** In-place locator delete (works on VyOS 1.5/rolling). */
+  async deleteLocator(name: string): Promise<VyOSResponse> {
+    return this.batch([{ op: "delete_locator", value: name }]);
+  }
+
+  /**
+   * VyOS 1.4 mutation path: FRR rejects in-place changes to an existing
+   * segment-routing tree, so apply the desired end state by deleting the
+   * whole tree (commit 1) and recreating it (commit 2). If the second
+   * commit fails, the tree is left empty — callers must warn the user.
+   */
+  async applyViaRecreate(desired: SegmentRoutingConfig): Promise<VyOSResponse> {
+    await this.batch([{ op: "delete_segment_routing" }]);
+    const ops = this.fullConfigOps(desired);
+    if (ops.length === 0) {
+      return { success: true, data: { message: "Segment Routing configuration removed" } };
+    }
+    return this.batch(ops);
+  }
+}
+
+export const segmentRoutingService = new SegmentRoutingService();


### PR DESCRIPTION
Frontend part 1 of #434, stacked on #435 (backend — this PR targets that branch so the diff shows only UI changes; it retargets to beta automatically when #435 merges). Replaces the Segment Routing `<InProgress />` placeholder on the routing-infrastructure page with a working locators section; the interface/HMAC section and docs follow in part 2.

- API client (`lib/api/segment-routing.ts`) and `SegmentRoutingContent` following the RPKI module's patterns (stats header, table, create/edit/delete modals, permission gating on `FeatureGroup.SEGMENT_ROUTING`).
- Three behaviors derived from the live-router test cycle behind #435:
  1. **Interface bundling** — VyOS refuses a locator commit unless an interface has SRv6 enabled in the same commit; when none exists, the create modal requires an interface pick and sends both changes in one batch, with copy explaining why.
  2. **Client-side prefix validation** — FRR requires locator prefix length = block-len + node-len but VyOS reports only a bare "Commit failed"; the modal validates the equality (honoring defaults 40+24) and explains the numbers.
  3. **VyOS 1.4 rewrite flow** — capabilities report `modify_requires_recreate` on 1.4, where FRR rejects any in-place change to an existing segment-routing tree; every mutation of a non-empty tree there runs delete + recreate in two commits, with a persistent page banner, an explicit warning in the edit/delete dialogs, and a "Rewrite & Save" submit label.
- shadcn/ui only, responsive (stat grid collapses, table scrolls horizontally), existing hook patterns (`usePermissions`).

## Testing

- `npx tsc --noEmit` and eslint pass; `next build` fails on beta with or without this change (preexisting `DATABASE_URL`-at-build-time issue in unrelated API routes).
- Manual click-through against the rolling router:
  - Routing → Infrastructure → Segment Routing renders the locators section (not In Progress).
  - Empty router: Add Locator shows the required interface picker with the constraint copy; creating with prefix `2001:db8:aaaa:bbbb::/64` + uSID commits in one batch; table and stats update.
  - Validation: a `/48` prefix with default lengths → inline error naming 40+24=64; block-len 99 → range error. Neither reaches the router.
  - Edit and delete work in place on rolling.
  - VIEWER-grant users see the Read Only badge and no mutation buttons.
- 1.4 paths (banner, Rewrite & Save, two-commit flows) are driven by the `modify_requires_recreate` capability and coded against the #435 live-router probe evidence; click-verify when a 1.4 box is available.