### PR TITLE
feat: add segment routing UI — interfaces tab and docs

### DIFF
--- a/docs-site/docs/user-guide/routing.md
+++ b/docs-site/docs/user-guide/routing.md
@@ -19,7 +19,16 @@ A protocol selector on the left lists BGP, OSPF, OSPFv3, IS-IS, OpenFabric, RIP,
 
 ## Infrastructure
 
-Same selector layout for BFD, MPLS, NHRP, RPKI and Traffic Engineering. Traffic Engineering only appears when the connected VyOS version reports support for it. BFD is the one section with live state: it reads peer status from the router in addition to configuration. Segment Routing appears in the menu but has no editor yet and shows a work-in-progress placeholder.
+Same selector layout for BFD, MPLS, NHRP, RPKI, Segment Routing and Traffic Engineering. Traffic Engineering only appears when the connected VyOS version reports support for it. BFD is the one section with live state: it reads peer status from the router in addition to configuration.
+
+### Segment Routing (SRv6)
+
+Two tabs: **Locators** (the IPv6 prefixes the router advertises for SRv6 segments — name, prefix, block/node lengths, function bits, uSID behavior) and **Interfaces** (which interfaces accept SR-enabled IPv6 packets, with the ingress HMAC policy). VyOS enforces a few rules the UI handles for you:
+
+- A locator cannot be committed unless at least one interface has SRv6 enabled. When none does, the locator dialog asks for an interface and applies both changes in a single commit. For the same reason, the last SRv6 interface cannot be disabled while locators exist — delete the locators first.
+- The locator prefix length must equal block length + node length (defaults 40 + 24, so a /64 prefix). The dialog validates this before sending anything, because the router itself reports only a generic commit failure.
+- On VyOS 1.4, existing Segment Routing configuration cannot be modified in place (a platform limitation in the FRR integration). Every change on a 1.4 router removes and recreates the whole segment-routing tree in two commits; the page shows a banner and the dialogs say so explicitly. If the second commit fails, the tree is left empty — refresh and re-apply.
+- Removing the entire configuration is always safe: deleting the last interface (with no locators left) clears the whole tree in one commit.
 
 ## Multicast
 

--- a/frontend/src/components/segment-routing/DeleteSrInterfaceModal.tsx
+++ b/frontend/src/components/segment-routing/DeleteSrInterfaceModal.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+
+interface DeleteSrInterfaceModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  interfaceName: string;
+  /**
+   * True when this is the last SRv6 interface and locators still exist:
+   * VyOS rejects that commit, so the dialog explains instead of offering
+   * the action.
+   */
+  blocked: boolean;
+  /** True on VyOS 1.4: deletion rewrites the whole segment-routing tree. */
+  requiresRecreate: boolean;
+  onConfirm: () => Promise<void>;
+}
+
+export function DeleteSrInterfaceModal({
+  open,
+  onOpenChange,
+  interfaceName,
+  blocked,
+  requiresRecreate,
+  onConfirm,
+}: DeleteSrInterfaceModalProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await onConfirm();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {blocked ? "Cannot Disable SRv6" : "Disable SRv6 on Interface"}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {blocked ? (
+              <>
+                <span className="font-mono font-semibold">{interfaceName}</span>{" "}
+                is the last SRv6-enabled interface and locators are still
+                configured. VyOS requires SRv6 on at least one interface while
+                locators exist, so this commit would be rejected. Delete the
+                locators first, or enable SRv6 on another interface.
+              </>
+            ) : (
+              <>
+                Disable SRv6 on{" "}
+                <span className="font-mono font-semibold">{interfaceName}</span>?
+                The interface will stop accepting SR-enabled IPv6 packets.
+                {requiresRecreate && (
+                  <>
+                    {" "}This router runs VyOS 1.4, which cannot modify
+                    existing Segment Routing configuration in place: the whole
+                    segment-routing tree is removed and recreated without this
+                    interface, in two commits.
+                  </>
+                )}
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={loading}>
+            {blocked ? "Close" : "Cancel"}
+          </AlertDialogCancel>
+          {!blocked && (
+            <AlertDialogAction
+              onClick={handleConfirm}
+              disabled={loading}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Disabling...
+                </>
+              ) : (
+                "Disable SRv6"
+              )}
+            </AlertDialogAction>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/segment-routing/SegmentRoutingContent.tsx
+++ b/frontend/src/components/segment-routing/SegmentRoutingContent.tsx
@@ -29,9 +29,12 @@ import {
   SegmentRoutingConfig,
   SegmentRoutingCapabilities,
   Srv6Locator,
+  SrInterface,
 } from "@/lib/api/segment-routing";
 import { LocatorModal } from "./LocatorModal";
 import { DeleteLocatorModal } from "./DeleteLocatorModal";
+import { SrInterfaceModal } from "./SrInterfaceModal";
+import { DeleteSrInterfaceModal } from "./DeleteSrInterfaceModal";
 import { usePermissions } from "@/hooks/usePermissions";
 import { FeatureGroup } from "@/lib/api/user-management";
 
@@ -48,9 +51,15 @@ export function SegmentRoutingContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [activeTab, setActiveTab] = useState<"locators" | "interfaces">("locators");
+
   const [locatorModalOpen, setLocatorModalOpen] = useState(false);
   const [editingLocator, setEditingLocator] = useState<Srv6Locator | null>(null);
   const [deletingLocator, setDeletingLocator] = useState<string | null>(null);
+
+  const [interfaceModalOpen, setInterfaceModalOpen] = useState(false);
+  const [editingInterface, setEditingInterface] = useState<SrInterface | null>(null);
+  const [deletingInterface, setDeletingInterface] = useState<string | null>(null);
 
   const requiresRecreate =
     capabilities?.version_info.modify_requires_recreate === true;
@@ -141,6 +150,61 @@ export function SegmentRoutingContent() {
       await segmentRoutingService.deleteLocator(deletingLocator);
     }
     setDeletingLocator(null);
+    await loadData(true);
+  };
+
+  const handleCreateInterface = async (iface: SrInterface) => {
+    if (requiresRecreate && !treeIsEmpty && config) {
+      const desired: SegmentRoutingConfig = {
+        locators: config.locators,
+        interfaces: [...config.interfaces, iface],
+      };
+      await segmentRoutingService.applyViaRecreate(desired);
+    } else {
+      await segmentRoutingService.createInterface(iface);
+    }
+    await loadData(true);
+  };
+
+  const handleUpdateInterface = async (iface: SrInterface) => {
+    if (!editingInterface || !config) return;
+    if (requiresRecreate) {
+      const desired: SegmentRoutingConfig = {
+        locators: config.locators,
+        interfaces: config.interfaces.map((i) =>
+          i.name === editingInterface.name ? iface : i
+        ),
+      };
+      await segmentRoutingService.applyViaRecreate(desired);
+    } else {
+      await segmentRoutingService.updateInterface(editingInterface, iface);
+    }
+    setEditingInterface(null);
+    await loadData(true);
+  };
+
+  // Deleting the last SRv6 interface while locators exist is rejected by
+  // VyOS; the delete dialog blocks that case instead of attempting it.
+  const deleteInterfaceBlocked =
+    srv6InterfaceCount <= 1 && locatorCount > 0;
+
+  const handleDeleteInterface = async () => {
+    if (!deletingInterface || !config) return;
+    const isLast = config.interfaces.length === 1;
+    if (requiresRecreate) {
+      const desired: SegmentRoutingConfig = {
+        locators: config.locators,
+        interfaces: config.interfaces.filter((i) => i.name !== deletingInterface),
+      };
+      await segmentRoutingService.applyViaRecreate(desired);
+    } else if (isLast && config.locators.length === 0) {
+      // A plain interface delete here can leave (or trip over) an orphan
+      // empty srv6 node; removing the whole tree is the reliable path.
+      await segmentRoutingService.deleteTree();
+    } else {
+      await segmentRoutingService.deleteInterface(deletingInterface);
+    }
+    setDeletingInterface(null);
     await loadData(true);
   };
 
@@ -253,8 +317,33 @@ export function SegmentRoutingContent() {
           </div>
         </div>
 
-        {/* Locators Section */}
+        {/* Tabs */}
+        <div className="flex border-b border-border px-6">
+          <button
+            className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === "locators"
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setActiveTab("locators")}
+          >
+            Locators
+          </button>
+          <button
+            className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === "interfaces"
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setActiveTab("interfaces")}
+          >
+            Interfaces
+          </button>
+        </div>
+
+        {/* Tab Content */}
         <div className="flex-1 overflow-auto p-6">
+          {activeTab === "locators" && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <p className="text-sm text-muted-foreground">
@@ -356,6 +445,106 @@ export function SegmentRoutingContent() {
               </Card>
             )}
           </div>
+          )}
+
+          {activeTab === "interfaces" && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Interfaces that accept SR-enabled IPv6 packets, with the HMAC
+                policy applied to ingress packets. At least one is required
+                while locators exist.
+              </p>
+              {hasWritePermission && (
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    setEditingInterface(null);
+                    setInterfaceModalOpen(true);
+                  }}
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Enable SRv6
+                </Button>
+              )}
+            </div>
+
+            {srv6InterfaceCount === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+                <Network className="h-12 w-12 mb-4 opacity-50" />
+                <p className="text-lg font-medium">No SRv6-enabled interfaces</p>
+                <p className="text-sm mt-1">Enable SRv6 on an interface to accept SR-enabled IPv6 packets</p>
+                {hasWritePermission && (
+                  <Button
+                    className="mt-4"
+                    onClick={() => {
+                      setEditingInterface(null);
+                      setInterfaceModalOpen(true);
+                    }}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Enable SRv6
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <Card>
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Interface</TableHead>
+                        <TableHead>HMAC Policy</TableHead>
+                        {hasWritePermission && <TableHead className="w-20" />}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {config?.interfaces.map((iface) => (
+                        <TableRow key={iface.name}>
+                          <TableCell className="font-mono font-medium">{iface.name}</TableCell>
+                          <TableCell>
+                            {iface.hmac ? (
+                              <Badge variant="secondary" className="font-mono text-xs">
+                                {iface.hmac}
+                              </Badge>
+                            ) : (
+                              <span className="text-muted-foreground">accept (default)</span>
+                            )}
+                          </TableCell>
+                          {hasWritePermission && (
+                            <TableCell>
+                              <div className="flex gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7"
+                                  onClick={() => {
+                                    setEditingInterface(iface);
+                                    setInterfaceModalOpen(true);
+                                  }}
+                                >
+                                  <Pencil className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7 text-destructive hover:text-destructive"
+                                  onClick={() => setDeletingInterface(iface.name)}
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </Button>
+                              </div>
+                            </TableCell>
+                          )}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </Card>
+            )}
+          </div>
+          )}
         </div>
       </div>
 
@@ -381,6 +570,29 @@ export function SegmentRoutingContent() {
         locatorName={deletingLocator ?? ""}
         requiresRecreate={requiresRecreate}
         onConfirm={handleDeleteLocator}
+      />
+
+      <SrInterfaceModal
+        open={interfaceModalOpen}
+        onOpenChange={(open) => {
+          setInterfaceModalOpen(open);
+          if (!open) setEditingInterface(null);
+        }}
+        onSubmit={editingInterface ? handleUpdateInterface : handleCreateInterface}
+        existingInterface={editingInterface}
+        existingNames={config?.interfaces.map((i) => i.name) ?? []}
+        requiresRecreate={requiresRecreate}
+      />
+
+      <DeleteSrInterfaceModal
+        open={deletingInterface !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeletingInterface(null);
+        }}
+        interfaceName={deletingInterface ?? ""}
+        blocked={deleteInterfaceBlocked}
+        requiresRecreate={requiresRecreate}
+        onConfirm={handleDeleteInterface}
       />
     </>
   );

--- a/frontend/src/components/segment-routing/SrInterfaceModal.tsx
+++ b/frontend/src/components/segment-routing/SrInterfaceModal.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { AlertCircle, AlertTriangle, Loader2 } from "lucide-react";
+import { InterfaceSelect } from "@/components/ui/interface-select";
+import type { SrInterface } from "@/lib/api/segment-routing";
+
+interface SrInterfaceModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (iface: SrInterface) => Promise<void>;
+  existingInterface?: SrInterface | null;
+  /** Interfaces that already have SRv6 enabled (excluded from the picker). */
+  existingNames: string[];
+  /** True on VyOS 1.4: saving rewrites the whole segment-routing tree. */
+  requiresRecreate: boolean;
+}
+
+const HMAC_DEFAULT = "default";
+
+export function SrInterfaceModal({
+  open,
+  onOpenChange,
+  onSubmit,
+  existingInterface,
+  existingNames,
+  requiresRecreate,
+}: SrInterfaceModalProps) {
+  const isEditMode = !!existingInterface;
+
+  const [name, setName] = useState("");
+  const [hmac, setHmac] = useState(HMAC_DEFAULT);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      if (existingInterface) {
+        setName(existingInterface.name);
+        setHmac(existingInterface.hmac ?? HMAC_DEFAULT);
+      } else {
+        setName("");
+        setHmac(HMAC_DEFAULT);
+      }
+      setError(null);
+    }
+  }, [open, existingInterface]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!name) {
+      setError("Select an interface");
+      return;
+    }
+    if (!isEditMode && existingNames.includes(name)) {
+      setError(`SRv6 is already enabled on ${name}`);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await onSubmit({
+        name,
+        hmac: hmac === HMAC_DEFAULT ? null : hmac,
+      });
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Operation failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditMode ? "Edit SRv6 Interface" : "Enable SRv6 on Interface"}
+          </DialogTitle>
+          <DialogDescription>
+            Accept SR-enabled IPv6 packets on an interface and set the HMAC
+            policy for ingress packets.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* Interface */}
+          <div className="space-y-1.5">
+            <Label>Interface</Label>
+            {isEditMode ? (
+              <p className="font-mono text-sm rounded-md border border-border bg-muted px-3 py-2">
+                {name}
+              </p>
+            ) : (
+              <InterfaceSelect
+                value={name}
+                onValueChange={setName}
+                placeholder="Select an interface"
+              />
+            )}
+          </div>
+
+          {/* HMAC policy */}
+          <div className="space-y-1.5">
+            <Label>HMAC Policy</Label>
+            <Select value={hmac} onValueChange={setHmac}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={HMAC_DEFAULT}>Default (accept)</SelectItem>
+                <SelectItem value="accept">accept — validate packets with HMAC, accept those without</SelectItem>
+                <SelectItem value="drop">drop — validate packets with HMAC, drop those without</SelectItem>
+                <SelectItem value="ignore">ignore — ignore the HMAC field entirely</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Policy for ingress SR-enabled packets on this interface
+            </p>
+          </div>
+
+          {/* 1.4 recreate warning */}
+          {isEditMode && requiresRecreate && (
+            <div className="flex items-start gap-2 rounded-md bg-amber-500/10 border border-amber-500/20 p-3">
+              <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+              <p className="text-sm text-muted-foreground">
+                This router runs VyOS 1.4, which cannot modify existing
+                Segment Routing configuration in place. Saving removes the
+                whole segment-routing tree and recreates it with your change,
+                in two commits. If the second commit fails, the tree is left
+                empty — refresh and re-apply from this page.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/20 p-3">
+            <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {isEditMode ? "Saving..." : "Enabling..."}
+              </>
+            ) : isEditMode ? (
+              requiresRecreate ? "Rewrite & Save" : "Save Changes"
+            ) : (
+              "Enable SRv6"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api/segment-routing.ts
+++ b/frontend/src/lib/api/segment-routing.ts
@@ -177,6 +177,41 @@ class SegmentRoutingService {
     return this.batch([{ op: "delete_locator", value: name }]);
   }
 
+  /** Enable SRv6 on an interface, optionally with an explicit HMAC policy. */
+  async createInterface(iface: SrInterface): Promise<VyOSResponse> {
+    if (iface.hmac) {
+      return this.batch([{ op: "set_interface_hmac", value: `${iface.name},${iface.hmac}` }]);
+    }
+    return this.batch([{ op: "set_interface_srv6", value: iface.name }]);
+  }
+
+  /** In-place HMAC policy change (works on VyOS 1.5/rolling). */
+  async updateInterface(original: SrInterface, updated: SrInterface): Promise<VyOSResponse> {
+    if (original.hmac === updated.hmac) {
+      return { success: true, data: { message: "No changes" } };
+    }
+    if (updated.hmac) {
+      return this.batch([{ op: "set_interface_hmac", value: `${updated.name},${updated.hmac}` }]);
+    }
+    // Removing the hmac leaf reverts to the VyOS default (accept); the
+    // interface srv6 node itself stays enabled.
+    return this.batch([{ op: "delete_interface_hmac", value: updated.name }]);
+  }
+
+  /** In-place interface removal (works on VyOS 1.5/rolling). */
+  async deleteInterface(name: string): Promise<VyOSResponse> {
+    return this.batch([{ op: "delete_interface", value: name }]);
+  }
+
+  /**
+   * Remove the whole segment-routing tree. Used when deleting the last SRv6
+   * interface with no locators left: a plain interface delete would leave an
+   * orphan empty srv6 node that VyOS still counts as "SRv6 configured".
+   */
+  async deleteTree(): Promise<VyOSResponse> {
+    return this.batch([{ op: "delete_segment_routing" }]);
+  }
+
   /**
    * VyOS 1.4 mutation path: FRR rejects in-place changes to an existing
    * segment-routing tree, so apply the desired end state by deleting the


### PR DESCRIPTION
Frontend part 2 of #434, stacked on #436. Completes the Segment Routing page: SRv6 interfaces tab (enable/disable per interface, ingress HMAC policy) and the user-guide documentation.

- Interface add/edit/delete following the same patterns as the locators tab; explicit HMAC values shown as badges, unset shown as the VyOS default (accept).
- Constraint handling from the live-router evidence behind #435: disabling the last SRv6 interface while locators exist is blocked in the dialog with an explanation (VyOS rejects that commit); deleting the last interface with no locators removes the whole tree in one commit, avoiding the orphan empty `srv6` node that otherwise blocks it; on VyOS 1.4 all interface mutations use the same delete + recreate two-commit flow as locators.
- Docs: `user-guide/routing.md` gains a Segment Routing section covering both tabs and the VyOS rules the UI enforces (interface-before-locator, prefix = block-len + node-len, the 1.4 in-place-edit limitation, teardown behavior).

## Testing

- `npx tsc --noEmit` and eslint pass; docs-site `npm run build` passes (validates internal links).
- Manual click-through: interfaces tab CRUD against the rolling router; blocked-delete dialog with a locator present; delete-last-interface-clears-tree path (the orphan-srv6-node regression case); 1.4 flows are capability-driven and coded against the #435 probe evidence.