### PR TITLE
fix: stop entrypoint from masking failed database migrations

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -21,29 +21,21 @@ if [ -d "prisma/migrations" ] && [ "$(ls -A prisma/migrations)" ]; then
   # Migrations exist - use migrate deploy (safe for production)
   echo "📋 Applying existing migrations..."
 
-  # Try to apply migrations
+  # A failed migration must stop the container. Never mark migrations as
+  # applied without running them: the schema Prisma believes in would diverge
+  # from the real one, and every later migration builds on that lie. A
+  # container that refuses to boot is recoverable; a database that
+  # misrepresents its own schema is not.
   if ! npx prisma migrate deploy 2>&1; then
-    echo "⚠️  Migration deployment failed - attempting to resolve..."
-
-    # Resolve any failed migrations by marking them as rolled back, then re-applying
-    for MIGRATION_DIR in prisma/migrations/*/; do
-      MIGRATION_NAME=$(basename "$MIGRATION_DIR")
-      # Skip the migration_lock.toml entry
-      [ "$MIGRATION_NAME" = "migration_lock.toml" ] && continue
-      echo "📌 Resolving migration: $MIGRATION_NAME"
-      npx prisma migrate resolve --rolled-back "$MIGRATION_NAME" 2>/dev/null || true
-    done
-
-    # Retry deployment after resolving failed migrations
-    echo "🔄 Retrying migration deployment..."
-    if ! npx prisma migrate deploy 2>&1; then
-      echo "⚠️  Retry failed - marking all migrations as applied..."
-      for MIGRATION_DIR in prisma/migrations/*/; do
-        MIGRATION_NAME=$(basename "$MIGRATION_DIR")
-        [ "$MIGRATION_NAME" = "migration_lock.toml" ] && continue
-        npx prisma migrate resolve --applied "$MIGRATION_NAME" 2>/dev/null || true
-      done
-    fi
+    echo ""
+    echo "❌ Database migration failed - refusing to start."
+    echo ""
+    echo "   The database schema may be mid-migration. Inspect the state with:"
+    echo "       npx prisma migrate status"
+    echo "   and resolve the failed migration manually before restarting."
+    echo "   See https://www.prisma.io/docs/orm/prisma-migrate/workflows/troubleshooting"
+    echo ""
+    exit 1
   fi
 else
   # No migrations yet - this is the first deployment


### PR DESCRIPTION
## Problem

`frontend/docker-entrypoint.sh` handled a failed `prisma migrate deploy` by marking every migration rolled back, retrying, and — if the retry also failed — marking all migrations as applied without running them. The container then started normally.

That leaves `_prisma_migrations` claiming a schema state the database is not actually in. Every later migration builds on the lie, and data-backfill migrations can be skipped silently with no error anywhere. A deployment that refuses to boot is recoverable by an operator; a database that misrepresents its own schema is not — the corruption surfaces later as unrelated failures.

## Change

A failed deploy is now fatal: the entrypoint prints the Prisma error, points at `npx prisma migrate status` and the Prisma troubleshooting guide, and exits nonzero so the container refuses to start. No automatic resolve in either direction. The first-deployment branch (no migrations directory) is unchanged.

This lands ahead of the organization-system groundwork, which introduces the project's first schema-plus-backfill migration — exactly the kind the old fallback could skip silently.

## Verified

- Fresh install: empty database, full entrypoint run, all 23 migrations applied, Next.js start reached, exit 0.
- Unreachable database (P1001): exit 1, refusal message, Next.js never started.
- Recorded failed migration (P3009) — the case the old code papered over: entrypoint exits 1 and refuses to start.
- `sh -n` syntax check clean.

## For the reviewer

Boot the built image once against a healthy database (normal start) and once against a stopped one (container must exit nonzero under compose, not serve traffic).