### PR TITLE
feat: add organization schema with backfill and verifier

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -1306,7 +1306,6 @@ BACKUP_EXCLUDED_TABLES: List[str] = [
     "verifications",
     "audit_logs",
     "scheduled_power_actions",
-    "role_permissions",
 ]
 
 # Natural unique key per table for merge mode. When a row collides on this key

--- a/backend/scripts/verify_org_migration.py
+++ b/backend/scripts/verify_org_migration.py
@@ -1,0 +1,178 @@
+"""Post-migration verifier for the organization schema backfill.
+
+Run once against a database that has just applied the organizations
+migration (fresh install or upgrade). Asserts the backfill invariants and
+exits nonzero on any violation, so it slots into upgrade runbooks and CI:
+
+    DATABASE_URL=postgresql://... python -m scripts.verify_org_migration
+
+Rules:
+
+    R1  the default organization (id 'default') exists
+    R2  every site references an existing organization
+    R3  membership count equals user count (every user was backfilled)
+    R4  every membership references an existing user and organization
+    R5  every organization that has members has at least one OWNER
+
+R3 holds at migration time by construction. Users created later are only
+enrolled once the membership write path lands, so run this right after the
+migration, not as a recurring check.
+
+The rule logic is pure (plain values in, violation strings out) and unit
+tested in tests/test_org_migration_verifier.py; this script only gathers
+the inputs with SQL and reports.
+"""
+
+import asyncio
+import os
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Pure rules: inputs are plain values, output is a list of violations
+# ---------------------------------------------------------------------------
+
+DEFAULT_ORG_ID = "default"
+
+
+def rule_default_org_exists(default_org_count: int) -> list:
+    if default_org_count == 1:
+        return []
+    return [f"R1: expected exactly one organization with id "
+            f"'{DEFAULT_ORG_ID}', found {default_org_count}"]
+
+
+def rule_sites_reference_valid_org(orphan_sites: list) -> list:
+    return [f"R2: site {site_id!r} references missing organization {org_id!r}"
+            for site_id, org_id in orphan_sites]
+
+
+def rule_membership_count_matches_users(user_count: int,
+                                        membership_count: int) -> list:
+    if membership_count == user_count:
+        return []
+    return [f"R3: membership count ({membership_count}) does not equal "
+            f"user count ({user_count})"]
+
+
+def rule_memberships_reference_valid_rows(orphan_memberships: list) -> list:
+    return [f"R4: membership {membership_id!r} references a missing "
+            f"{kind}" for membership_id, kind in orphan_memberships]
+
+
+def rule_orgs_with_members_have_owner(org_owner_stats: list) -> list:
+    problems = []
+    for org_id, member_count, owner_count in org_owner_stats:
+        if member_count > 0 and owner_count == 0:
+            problems.append(f"R5: organization {org_id!r} has "
+                            f"{member_count} member(s) but no OWNER")
+    return problems
+
+
+def evaluate(default_org_count: int, orphan_sites: list, user_count: int,
+             membership_count: int, orphan_memberships: list,
+             org_owner_stats: list) -> list:
+    """All rules over gathered inputs; empty list means the backfill holds."""
+    return (
+        rule_default_org_exists(default_org_count)
+        + rule_sites_reference_valid_org(orphan_sites)
+        + rule_membership_count_matches_users(user_count, membership_count)
+        + rule_memberships_reference_valid_rows(orphan_memberships)
+        + rule_orgs_with_members_have_owner(org_owner_stats)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input gathering
+# ---------------------------------------------------------------------------
+
+async def gather(conn) -> dict:
+    default_org_count = await conn.fetchval(
+        "SELECT COUNT(*) FROM organizations WHERE id = $1", DEFAULT_ORG_ID)
+
+    orphan_sites = [
+        (r["id"], r["orgId"]) for r in await conn.fetch(
+            """
+            SELECT s.id, s."orgId" FROM sites s
+            LEFT JOIN organizations o ON o.id = s."orgId"
+            WHERE o.id IS NULL
+            ORDER BY s.id
+            """)
+    ]
+
+    user_count = await conn.fetchval("SELECT COUNT(*) FROM users")
+    membership_count = await conn.fetchval(
+        "SELECT COUNT(*) FROM org_memberships")
+
+    orphan_memberships = [
+        (r["id"], r["kind"]) for r in await conn.fetch(
+            """
+            SELECT m.id, 'user' AS kind FROM org_memberships m
+            LEFT JOIN users u ON u.id = m."userId" WHERE u.id IS NULL
+            UNION ALL
+            SELECT m.id, 'organization' AS kind FROM org_memberships m
+            LEFT JOIN organizations o ON o.id = m."orgId" WHERE o.id IS NULL
+            ORDER BY 1, 2
+            """)
+    ]
+
+    org_owner_stats = [
+        (r["id"], r["member_count"], r["owner_count"]) for r in await conn.fetch(
+            """
+            SELECT o.id,
+                   COUNT(m.id) AS member_count,
+                   COUNT(m.id) FILTER (WHERE m."orgRole" = 'OWNER') AS owner_count
+            FROM organizations o
+            LEFT JOIN org_memberships m ON m."orgId" = o.id
+            GROUP BY o.id
+            ORDER BY o.id
+            """)
+    ]
+
+    return {
+        "default_org_count": default_org_count,
+        "orphan_sites": orphan_sites,
+        "user_count": user_count,
+        "membership_count": membership_count,
+        "orphan_memberships": orphan_memberships,
+        "org_owner_stats": org_owner_stats,
+    }
+
+
+async def run(database_url: str) -> int:
+    import asyncpg
+
+    conn = await asyncpg.connect(database_url)
+    try:
+        inputs = await gather(conn)
+    finally:
+        await conn.close()
+
+    problems = evaluate(**inputs)
+
+    print(f"Organization migration verifier")
+    print(f"  users: {inputs['user_count']}, "
+          f"memberships: {inputs['membership_count']}, "
+          f"organizations checked: {len(inputs['org_owner_stats'])}")
+
+    if problems:
+        for problem in problems:
+            print(f"  FAIL {problem}")
+        print(f"{len(problems)} violation(s). The backfill did not hold — "
+              f"do not proceed with the upgrade.")
+        return 1
+
+    print("  All rules hold (R1-R5).")
+    return 0
+
+
+def main() -> int:
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL is required", file=sys.stderr)
+        return 2
+    return asyncio.run(run(database_url))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_org_migration_verifier.py
+++ b/backend/tests/test_org_migration_verifier.py
@@ -1,0 +1,92 @@
+"""Unit tests for the organization-migration verifier rules.
+
+The rules are pure functions over gathered inputs — no database or FastAPI
+app needed, matching the house unit-test style.
+"""
+
+from scripts.verify_org_migration import (
+    evaluate,
+    rule_default_org_exists,
+    rule_membership_count_matches_users,
+    rule_memberships_reference_valid_rows,
+    rule_orgs_with_members_have_owner,
+    rule_sites_reference_valid_org,
+)
+
+
+def clean_inputs(**overrides):
+    """Inputs for a healthy freshly-migrated database with three users."""
+    inputs = {
+        "default_org_count": 1,
+        "orphan_sites": [],
+        "user_count": 3,
+        "membership_count": 3,
+        "orphan_memberships": [],
+        "org_owner_stats": [("default", 3, 1)],
+    }
+    inputs.update(overrides)
+    return inputs
+
+
+def test_healthy_upgrade_passes():
+    assert evaluate(**clean_inputs()) == []
+
+
+def test_fresh_install_passes():
+    # Empty database: no users, no memberships, no OWNER — all valid.
+    assert evaluate(**clean_inputs(
+        user_count=0, membership_count=0,
+        org_owner_stats=[("default", 0, 0)])) == []
+
+
+def test_missing_default_org_fails():
+    problems = rule_default_org_exists(0)
+    assert len(problems) == 1
+    assert problems[0].startswith("R1")
+
+
+def test_orphan_site_fails():
+    problems = rule_sites_reference_valid_org([("s_one", "gone")])
+    assert problems == ["R2: site 's_one' references missing "
+                        "organization 'gone'"]
+
+
+def test_membership_count_mismatch_fails():
+    problems = rule_membership_count_matches_users(3, 2)
+    assert len(problems) == 1
+    assert "membership count (2)" in problems[0]
+    assert "user count (3)" in problems[0]
+
+
+def test_orphan_membership_fails():
+    problems = rule_memberships_reference_valid_rows(
+        [("om_x", "user"), ("om_y", "organization")])
+    assert problems == [
+        "R4: membership 'om_x' references a missing user",
+        "R4: membership 'om_y' references a missing organization",
+    ]
+
+
+def test_org_with_members_but_no_owner_fails():
+    problems = rule_orgs_with_members_have_owner([("default", 3, 0)])
+    assert problems == ["R5: organization 'default' has 3 member(s) "
+                        "but no OWNER"]
+
+
+def test_org_without_members_needs_no_owner():
+    assert rule_orgs_with_members_have_owner([("default", 0, 0)]) == []
+
+
+def test_multiple_owners_are_fine():
+    assert rule_orgs_with_members_have_owner([("default", 5, 2)]) == []
+
+
+def test_evaluate_collects_across_rules():
+    problems = evaluate(**clean_inputs(
+        default_org_count=0,
+        membership_count=2,
+        org_owner_stats=[("default", 2, 0)],
+    ))
+    assert len(problems) == 3
+    prefixes = sorted(p.split(":")[0] for p in problems)
+    assert prefixes == ["R1", "R3", "R5"]

--- a/frontend/prisma/migrations/20260707_add_organizations/migration.sql
+++ b/frontend/prisma/migrations/20260707_add_organizations/migration.sql
@@ -1,0 +1,87 @@
+-- Organization layer, additive and inert: nothing reads these tables yet.
+-- Create + backfill + constrain happen in this one migration so it is valid
+-- on both an empty database (fresh install) and a populated one (upgrade).
+
+CREATE TYPE "OrgRole" AS ENUM ('OWNER', 'ADMIN', 'MEMBER');
+
+CREATE TABLE "organizations" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organizations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "organizations_name_key" ON "organizations"("name");
+
+CREATE TABLE "org_memberships" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "orgRole" "OrgRole" NOT NULL DEFAULT 'MEMBER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "org_memberships_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "org_memberships_userId_fkey" FOREIGN KEY ("userId")
+        REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "org_memberships_orgId_fkey" FOREIGN KEY ("orgId")
+        REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "org_memberships_userId_orgId_key"
+    ON "org_memberships"("userId", "orgId");
+CREATE INDEX "org_memberships_orgId_idx" ON "org_memberships"("orgId");
+
+-- Default organization with a fixed id: sites carry a column DEFAULT that
+-- points at it, so fresh installs create their first site before any org
+-- management exists. The DEFAULT is scaffolding for the inert phase and is
+-- removed when org enforcement turns on.
+INSERT INTO "organizations" ("id", "name", "createdAt", "updatedAt")
+VALUES ('default', 'Default', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- sites.orgId: add nullable, backfill every existing site to the default
+-- org, then constrain.
+ALTER TABLE "sites" ADD COLUMN "orgId" TEXT;
+
+UPDATE "sites" SET "orgId" = 'default';
+
+ALTER TABLE "sites"
+    ALTER COLUMN "orgId" SET NOT NULL,
+    ALTER COLUMN "orgId" SET DEFAULT 'default',
+    ADD CONSTRAINT "sites_orgId_fkey" FOREIGN KEY ("orgId")
+        REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE INDEX "sites_orgId_idx" ON "sites"("orgId");
+
+-- Membership backfill. Deterministic ids derived from user ids: re-runnable
+-- by inspection and no dependency on any uuid extension. Deployment ADMINs
+-- become org ADMINs of the default org; everyone else a MEMBER. users.role
+-- itself is untouched.
+INSERT INTO "org_memberships" ("id", "userId", "orgId", "orgRole", "createdAt", "updatedAt")
+SELECT 'om_' || u."id",
+       u."id",
+       'default',
+       CASE WHEN u."role" = 'ADMIN' THEN 'ADMIN' ELSE 'MEMBER' END::"OrgRole",
+       CURRENT_TIMESTAMP,
+       CURRENT_TIMESTAMP
+FROM "users" u;
+
+-- Every org with members needs an OWNER. The earliest-created deployment
+-- ADMIN takes it; if users exist but no ADMIN does (interrupted first-user
+-- promotion), the earliest user takes it. An empty database (fresh install)
+-- backfills no memberships and designates no OWNER, which is valid.
+UPDATE "org_memberships" SET "orgRole" = 'OWNER'
+WHERE "userId" = (SELECT "id" FROM "users" WHERE "role" = 'ADMIN'
+                  ORDER BY "createdAt", "id" LIMIT 1);
+
+UPDATE "org_memberships" SET "orgRole" = 'OWNER'
+WHERE NOT EXISTS (SELECT 1 FROM "org_memberships" WHERE "orgRole" = 'OWNER')
+  AND "userId" = (SELECT "id" FROM "users" ORDER BY "createdAt", "id" LIMIT 1);
+
+-- Vestigial since the custom-roles removal: declared in the schema, never
+-- read or written by frontend or backend, excluded from backups.
+DROP TABLE IF EXISTS "role_permissions";
+DROP TYPE IF EXISTS "Action";

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   activeSession     ActiveSession?
   userInstanceRoles UserInstanceRole[]
   apiTokens         ApiToken[]
+  orgMemberships    OrgMembership[]
 
   @@map("users")
 }
@@ -132,26 +133,47 @@ enum InstanceRole {
   VIEWER   // Can view specific features (defined in FeaturePermission)
 }
 
-// Role Permissions Matrix
-// Define what each role can access
+// ============================================================================
+// Organizations - tenant grouping above sites (inert until enforcement)
+// ============================================================================
 
-model RolePermission {
-  id        String   @id @default(cuid())
-  role      Role
-  resource  String // e.g., "firewall", "dhcp", "nat", "interfaces", "users"
-  action    Action // e.g., READ, CREATE, UPDATE, DELETE
-  createdAt DateTime @default(now())
-
-  @@unique([role, resource, action])
-  @@map("role_permissions")
+// Org-level roles. Deployment-wide User.role is unchanged and orthogonal:
+// users.role=ADMIN is the deployment operator ("System Administrator").
+enum OrgRole {
+  OWNER // Org lifecycle, membership, settings; superset of ADMIN; >=1 per org with members
+  ADMIN // Manage sites/instances and per-instance RBAC within the org
+  MEMBER // Access limited to explicit per-instance grants
 }
 
-enum Action {
-  READ
-  CREATE
-  UPDATE
-  DELETE
-  MANAGE // Full control (all actions)
+model Organization {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Relations
+  sites       Site[]
+  memberships OrgMembership[]
+
+  @@map("organizations")
+}
+
+model OrgMembership {
+  id        String   @id @default(cuid())
+  userId    String
+  orgId     String
+  orgRole   OrgRole  @default(MEMBER)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relations
+  user User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  org  Organization @relation(fields: [orgId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, orgId])
+  @@index([orgId])
+  @@map("org_memberships")
 }
 
 // Audit Log for tracking all user actions
@@ -175,18 +197,25 @@ model AuditLog {
 // Multi-Instance Management
 // ============================================================================
 
-// Site - Represents a customer/organization
+// Site - a group of instances within an organization
 model Site {
   id          String   @id @default(cuid())
   name        String   @unique
   description String?
+  // DEFAULT "default" is inert-phase scaffolding: it keeps site creation,
+  // seeding and pre-org backup restores working while nothing reads orgs.
+  // Removed when org enforcement turns on — site creation then requires an
+  // explicit organization.
+  orgId       String   @default("default")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   // Relations
+  org               Organization       @relation(fields: [orgId], references: [id], onDelete: Restrict)
   instances         Instance[]
   userInstanceRoles UserInstanceRole[] // whole-site grants
 
+  @@index([orgId])
   @@map("sites")
 }
 


### PR DESCRIPTION
Organization-system groundwork (design docs to follow on docs.vyprojects.org). Additive and inert: nothing reads the new tables after this lands. Merge order: #440 (entrypoint fix) and #441 (golden harness) should land first — the upgrade rehearsal below ran through both.

## Schema

One migration, valid on both an empty database (fresh install) and a populated one (upgrade), everything inside the migration's transaction:

- `organizations` and `org_memberships` (`orgRole` OWNER/ADMIN/MEMBER; `userId` FK ON DELETE CASCADE), plus `sites.orgId` (NOT NULL, FK, indexed).
- A fixed-id default organization is created before any site can exist. `sites.orgId` carries `DEFAULT 'default'` so fresh-install onboarding, seeding and pre-org backup restores work unchanged — this default is inert-phase scaffolding and is removed when org enforcement turns on; site creation will then require an explicit organization.
- Membership backfill: deployment ADMINs become org ADMINs of the default org, everyone else MEMBER; deterministic ids, `users.role` untouched. The earliest-created ADMIN is designated OWNER; if users exist but no ADMIN does (interrupted first-user promotion), the earliest user takes it; an empty database backfills nothing, which is valid.
- Drops the vestigial `role_permissions` table and `Action` enum — declared since the custom-roles removal, never read or written anywhere, already excluded from backups (the stale exclusion-list entry is removed too).

## Verifier

`DATABASE_URL=... python -m scripts.verify_org_migration` — asserts the backfill invariants (default org exists; every site references a valid org; memberships match users one-to-one; no orphaned memberships; every org with members has an OWNER) and exits nonzero on violation. Run right after the migration; membership-count parity is a migration-time invariant until the membership write path lands. Rule logic is pure and unit tested (10 tests).

## Evidence (all against real Postgres 17, migrations applied through the fixed docker entrypoint with the app start stubbed)

**Upgrade rehearsal** — pre-org database seeded with 3 users (exactly one ADMIN, created first), 2 sites, 3 instances, OPERATOR/VIEWER grants with feature permissions:
1. Golden capture (#441 harness): 9 pairs at app 1.0.0-beta.3.
2. Entrypoint migration: `20260707_add_organizations` applied, exit 0.
3. Verifier: users 3, memberships 3 — all rules hold, exit 0.
4. Golden compare (simulated new version + explicit mismatch override): output identical for all 9 pairs — zero permission changes.
5. Backfill: earliest ADMIN → OWNER, others MEMBER, both sites on the default org, `role_permissions` gone.

**Fresh install** — empty database → entrypoint applies all 24 migrations → verifier passes (0 users, 0 memberships, default org present) → first user creates the first site through the real `POST /session/sites` endpoint: 201, site row lands with `orgId='default'` via the column default. No app-code change needed.

**Zero-ADMIN edge** — database with two VIEWER-only users: earliest user became OWNER, verifier passes.

**Consistency** — `prisma migrate diff` between a fully-migrated database and `schema.prisma`: the only differences are drift that already exists on `beta` (Role enum surgery, two `updatedAt` defaults, a stray `PermissionLevel` type) — verified identical against a pre-org database; this PR adds no new drift and removes the `role_permissions` line of it.

**Suite** — 63 passed, 1 skipped (the golden test without `DATABASE_URL`).

## For the reviewer

- Review the migration SQL as the source of truth; the Prisma models mirror it (`prisma validate` clean).
- On a staging copy: capture a golden file, upgrade, run the verifier, compare — the runbook this PR exists to serve.