### PR TITLE
feat: add org-scoped connection plumbing and middleware org context

### DIFF
--- a/backend/fastapi_permissions.py
+++ b/backend/fastapi_permissions.py
@@ -8,8 +8,8 @@ on their active VyOS instance.
 
 from fastapi import Request, HTTPException
 from typing import Optional
-import asyncpg
 
+from org_scope import org_id_from_state, request_scoped_conn
 from rbac_permissions import (
     FeatureGroup,
     PermissionLevel,
@@ -47,7 +47,7 @@ async def require_permission(
     Site ADMIN users bypass all permission checks.
 
     Args:
-        request: FastAPI request object (contains user and db_pool)
+        request: FastAPI request object (carries user and org context)
         feature: Feature group to check (e.g., FIREWALL, NAT)
         level: Required permission level (READ or WRITE)
 
@@ -70,33 +70,35 @@ async def require_permission(
             detail="This API token is read-only and cannot perform write operations."
         )
 
-    # Get database pool
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-
-    # Site ADMIN bypasses all permission checks
-    if await is_super_admin(db_pool, user["id"]):
-        return
-
     # The active instance is resolved by SessionMiddleware for both auth paths:
     # the browser cookie session, or (for token clients) the X-VyOS-Instance-Id
-    # header validated against the user's grants.
+    # header validated against the user's grants. Checked before touching the
+    # database so a missing instance stays a 404 and never costs a connection.
     instance = getattr(request.state, "instance", None)
-    if not instance:
-        raise HTTPException(
-            status_code=404,
-            detail="No active VyOS instance. Please connect to an instance first."
+
+    # One unit of work: the whole permission check runs on one org-scoped
+    # connection (the handler's org_conn transaction when one is open,
+    # otherwise a short-lived one of its own — /vyos handlers hold no
+    # connection across their VyOS HTTP call).
+    async with request_scoped_conn(request) as conn:
+        # Site ADMIN bypasses all permission checks
+        if await is_super_admin(conn, user["id"]):
+            return
+
+        if not instance:
+            raise HTTPException(
+                status_code=404,
+                detail="No active VyOS instance. Please connect to an instance first."
+            )
+
+        has_permission = await check_permission(
+            db_pool=conn,
+            user_id=user["id"],
+            instance_id=instance["id"],
+            feature=feature,
+            required_level=level,
+            org_id=org_id_from_state(request),
         )
-
-    instance_id = instance["id"]
-
-    # Check permission
-    has_permission = await check_permission(
-        db_pool=db_pool,
-        user_id=user["id"],
-        instance_id=instance_id,
-        feature=feature,
-        required_level=level
-    )
 
     if not has_permission:
         # Get feature name for error message
@@ -152,13 +154,12 @@ async def require_super_admin(request: Request) -> None:
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-
-    if not await is_super_admin(db_pool, user["id"]):
-        raise HTTPException(
-            status_code=403,
-            detail="Insufficient permissions. Site ADMIN role required."
-        )
+    async with request_scoped_conn(request) as conn:
+        if not await is_super_admin(conn, user["id"]):
+            raise HTTPException(
+                status_code=403,
+                detail="Insufficient permissions. Site ADMIN role required."
+            )
 
 
 async def get_user_feature_permissions(request: Request) -> dict:
@@ -177,8 +178,6 @@ async def get_user_feature_permissions(request: Request) -> dict:
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-
     # Active instance resolved by SessionMiddleware (cookie session or token header).
     instance = getattr(request.state, "instance", None)
     if not instance:
@@ -187,10 +186,12 @@ async def get_user_feature_permissions(request: Request) -> dict:
             detail="No active VyOS instance"
         )
 
-    instance_id = instance["id"]
-
-    # Get all permissions
-    permissions = await get_user_permissions(db_pool, user["id"], instance_id)
+    # Get all permissions (one unit of work, org-scoped)
+    async with request_scoped_conn(request) as conn:
+        permissions = await get_user_permissions(
+            conn, user["id"], instance["id"],
+            org_id=org_id_from_state(request),
+        )
 
     # Convert to JSON-serializable format
     return {

--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -77,7 +77,9 @@ class SessionMiddleware(BaseHTTPMiddleware):
         i."commitConfirmEnabled" as commit_confirm_enabled,
         i."commitConfirmMinutes" as commit_confirm_minutes,
         i.timeout,
-        s.name as site_name
+        s.name as site_name,
+        s."orgId" as org_id,
+        o.name as org_name
     """
 
     async def _resolve_cookie_instance(self, conn, request: Request, path: str, user_id: str, user_site_role):
@@ -95,6 +97,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                 FROM active_sessions a
                 JOIN instances i ON a."instanceId" = i.id
                 JOIN sites s ON i."siteId" = s.id
+                LEFT JOIN organizations o ON o.id = s."orgId"
                 WHERE a."userId" = $1
                 """,
                 user_id,
@@ -109,6 +112,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                 FROM active_sessions a
                 JOIN instances i ON a."instanceId" = i.id
                 JOIN sites s ON i."siteId" = s.id
+                LEFT JOIN organizations o ON o.id = s."orgId"
                 JOIN user_instance_roles uir
                     ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
                     AND uir."userId" = $1
@@ -166,6 +170,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
                 SELECT {self._INSTANCE_COLUMNS}, 'ADMIN' as user_role
                 FROM instances i
                 JOIN sites s ON i."siteId" = s.id
+                LEFT JOIN organizations o ON o.id = s."orgId"
                 WHERE i.id = $1
                 """,
                 instance_id,
@@ -175,6 +180,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
             SELECT {self._INSTANCE_COLUMNS}, uir.role as user_role
             FROM instances i
             JOIN sites s ON i."siteId" = s.id
+            LEFT JOIN organizations o ON o.id = s."orgId"
             JOIN user_instance_roles uir
                 ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
                 AND uir."userId" = $2
@@ -221,6 +227,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
             # Database not available - continue without instance resolution
             request.state.instance = None
             request.state.site = None
+            request.state.org = None
             return await call_next(request)
 
         # Token clients (e.g. the MCP server) authenticate without a cookie and
@@ -234,6 +241,9 @@ class SessionMiddleware(BaseHTTPMiddleware):
                     "SELECT role FROM users WHERE id = $1",
                     user_id,
                 )
+                # Deployment-operator flag for org-scoped connections
+                # (org_scope.py) — resolved here anyway, so keep it.
+                request.state.user_role = user_site_role
 
                 if is_token_auth:
                     instance_id = request.headers.get("X-VyOS-Instance-Id")
@@ -279,15 +289,24 @@ class SessionMiddleware(BaseHTTPMiddleware):
                         "name": session["site_name"],
                         "user_role": session["user_role"],
                     }
+                    # Org derived from the active instance
+                    # (instance -> site -> org); the LEFT JOIN keeps a
+                    # pre-migration row resolvable, hence the None guard.
+                    request.state.org = (
+                        {"id": session["org_id"], "name": session["org_name"]}
+                        if session.get("org_id") else None
+                    )
                 else:
                     # No active session
                     request.state.instance = None
                     request.state.site = None
+                    request.state.org = None
 
         except Exception as e:
             # Error resolving active session - set to None and continue
             request.state.instance = None
             request.state.site = None
+            request.state.org = None
 
         # Continue with the request
         response = await call_next(request)

--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -1,0 +1,139 @@
+"""Org-scoped database access.
+
+Every database touch runs inside a transaction that carries the request's
+organization context as PostgreSQL settings:
+
+    app.org_id           the acting organization id, or '' when the request
+                         has no org context (deployment-operator surface).
+                         Organizations can never have an empty-string id
+                         (DB CHECK constraint), so the sentinel cannot
+                         collide with a real org.
+    app.is_system_admin  'true' only for deployment operators
+                         (users.role = 'ADMIN'). This is the single,
+                         greppable bypass flag for row-level security.
+
+Both are SET LOCAL (set_config(..., true)), so they die with the
+transaction and can never leak across requests on a pooled connection.
+
+THE RULE — one unit of work = one org_scoped_conn acquisition. A logically
+atomic read-modify-write must never split across two acquisitions: the
+second acquisition is a new transaction on (possibly) another connection,
+and the data read under the first is stale by then. Handlers that own
+queries take the whole handler as their unit of work via the org_conn
+dependency; the permission check path is read-only and uses one short
+acquisition of its own.
+"""
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Optional
+
+import asyncpg
+from fastapi import Request
+
+
+@asynccontextmanager
+async def org_scoped_conn(
+    pool: asyncpg.Pool,
+    org_id: Optional[str],
+    is_system_admin: bool,
+) -> AsyncIterator[asyncpg.Connection]:
+    """One connection, one transaction, org context applied.
+
+    The building block for every DB unit of work. SET LOCAL cannot bind
+    parameters, so set_config(..., is_local => true) — its exact
+    equivalent — is used instead.
+    """
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.org_id', $1, true),"
+                "       set_config('app.is_system_admin', $2, true)",
+                org_id or "",
+                "true" if is_system_admin else "false",
+            )
+            yield conn
+
+
+def org_id_from_state(request: Request) -> Optional[str]:
+    """The org derived by SessionMiddleware (instance -> site -> org)."""
+    org = getattr(request.state, "org", None)
+    return org["id"] if org else None
+
+
+def is_system_admin_from_state(request: Request) -> Optional[bool]:
+    """Deployment-operator flag when middleware already resolved the role.
+
+    None means the role was not resolved on this request path (e.g.
+    /session/*, which SessionMiddleware skips) and must be fetched.
+    """
+    role = getattr(request.state, "user_role", None)
+    return None if role is None else role == "ADMIN"
+
+
+async def _resolve_system_admin(conn: asyncpg.Connection, request: Request) -> bool:
+    known = is_system_admin_from_state(request)
+    if known is not None:
+        return known
+    user = getattr(request.state, "user", None)
+    if not user:
+        return False
+    role = await conn.fetchval("SELECT role FROM users WHERE id = $1", user["id"])
+    return role == "ADMIN"
+
+
+async def org_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
+    """FastAPI dependency: the handler's whole body is one unit of work.
+
+    Yields a connection inside an org-scoped transaction and exposes it as
+    request.state.org_conn so nested permission checks join the same
+    transaction instead of opening their own.
+    """
+    pool: asyncpg.Pool = request.app.state.db_pool
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            is_admin = await _resolve_system_admin(conn, request)
+            await conn.execute(
+                "SELECT set_config('app.org_id', $1, true),"
+                "       set_config('app.is_system_admin', $2, true)",
+                org_id_from_state(request) or "",
+                "true" if is_admin else "false",
+            )
+            request.state.org_conn = conn
+            try:
+                yield conn
+            finally:
+                request.state.org_conn = None
+
+
+@asynccontextmanager
+async def request_scoped_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
+    """Org-scoped connection for code called from request context.
+
+    Joins the handler's org_conn transaction when one is open; otherwise
+    opens a short-lived org_scoped_conn of its own (the /vyos/* permission
+    path, where the handler holds no DB connection across its VyOS call).
+    """
+    existing = getattr(request.state, "org_conn", None)
+    if existing is not None:
+        yield existing
+        return
+
+    pool: asyncpg.Pool = request.app.state.db_pool
+    known_admin = is_system_admin_from_state(request)
+    if known_admin is None:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                is_admin = await _resolve_system_admin(conn, request)
+                await conn.execute(
+                    "SELECT set_config('app.org_id', $1, true),"
+                    "       set_config('app.is_system_admin', $2, true)",
+                    org_id_from_state(request) or "",
+                    "true" if is_admin else "false",
+                )
+                yield conn
+        return
+
+    async with org_scoped_conn(
+        pool, org_id_from_state(request), known_admin
+    ) as conn:
+        yield conn

--- a/backend/rbac_permissions.py
+++ b/backend/rbac_permissions.py
@@ -12,9 +12,25 @@ Permission Resolution:
 4. Apply special rules (e.g., WRITE on CONFIGURATION requires READ on all features)
 """
 
-from typing import Dict, List, Optional
+from contextlib import asynccontextmanager
+from typing import Dict, List, Optional, Union
 from enum import Enum
 import asyncpg
+
+
+# Resolver entry points accept either a pool (acquire per call, the historic
+# shape) or an already org-scoped connection (org_scope.py), so permission
+# checks can run inside the caller's transaction.
+DbSource = Union[asyncpg.Pool, asyncpg.Connection]
+
+
+@asynccontextmanager
+async def _acquire(db: DbSource):
+    if isinstance(db, asyncpg.Pool):
+        async with db.acquire() as conn:
+            yield conn
+    else:
+        yield db
 
 
 # ============================================================================
@@ -653,9 +669,10 @@ async def _apply_instance_grant(conn, role, assignment_id, permissions):
 
 
 async def get_user_permissions(
-    db_pool: asyncpg.Pool,
+    db_pool: DbSource,
     user_id: str,
-    instance_id: str
+    instance_id: str,
+    org_id: Optional[str] = None,
 ) -> Dict[FeatureGroup, PermissionLevel]:
     """
     Get all permissions for a user on a specific instance.
@@ -666,9 +683,12 @@ async def get_user_permissions(
     - Instance OPERATOR/VIEWER: Check user_feature_permissions for granular access
 
     Args:
-        db_pool: Database connection pool
+        db_pool: Database connection pool, or an org-scoped connection
         user_id: User ID
         instance_id: Instance ID
+        org_id: Acting organization. Accepted and threaded through so
+            callers can pass it today; resolution stays org-agnostic until
+            org enforcement turns on (single-org semantics).
 
     Returns:
         Dictionary mapping feature groups to permission levels
@@ -678,7 +698,7 @@ async def get_user_permissions(
         feature: PermissionLevel.NONE for feature in FeatureGroup
     }
 
-    async with db_pool.acquire() as conn:
+    async with _acquire(db_pool) as conn:
         # First check if user is site-level ADMIN
         site_role = await conn.fetchval(
             """
@@ -836,26 +856,29 @@ async def get_user_permissions(
 
 
 async def check_permission(
-    db_pool: asyncpg.Pool,
+    db_pool: DbSource,
     user_id: str,
     instance_id: str,
     feature: FeatureGroup,
-    required_level: PermissionLevel
+    required_level: PermissionLevel,
+    org_id: Optional[str] = None,
 ) -> bool:
     """
     Check if a user has a specific permission level for a feature on an instance.
 
     Args:
-        db_pool: Database connection pool
+        db_pool: Database connection pool, or an org-scoped connection
         user_id: User ID
         instance_id: Instance ID
         feature: Feature group to check
         required_level: Required permission level (READ or WRITE)
+        org_id: Acting organization, threaded to the resolver (single-org
+            semantics until org enforcement turns on)
 
     Returns:
         True if user has required permission, False otherwise
     """
-    permissions = await get_user_permissions(db_pool, user_id, instance_id)
+    permissions = await get_user_permissions(db_pool, user_id, instance_id, org_id=org_id)
     user_level = permissions.get(feature, PermissionLevel.NONE)
 
     # WRITE includes READ
@@ -867,7 +890,7 @@ async def check_permission(
     return False
 
 
-async def is_admin(db_pool: asyncpg.Pool, user_id: str) -> bool:
+async def is_admin(db_pool: DbSource, user_id: str) -> bool:
     """
     Check if a user is an ADMIN (has role='ADMIN' in users table).
 
@@ -880,7 +903,7 @@ async def is_admin(db_pool: asyncpg.Pool, user_id: str) -> bool:
     Returns:
         True if user has ADMIN role, False otherwise
     """
-    async with db_pool.acquire() as conn:
+    async with _acquire(db_pool) as conn:
         result = await conn.fetchval(
             """
             SELECT role FROM users WHERE id = $1
@@ -891,7 +914,7 @@ async def is_admin(db_pool: asyncpg.Pool, user_id: str) -> bool:
 
 
 # Deprecated: Kept for backwards compatibility
-async def is_super_admin(db_pool: asyncpg.Pool, user_id: str) -> bool:
+async def is_super_admin(db_pool: DbSource, user_id: str) -> bool:
     """Deprecated: Use is_admin() instead."""
     return await is_admin(db_pool, user_id)
 
@@ -910,7 +933,7 @@ async def get_user_accessible_instances(
     Returns:
         List of instance IDs
     """
-    async with db_pool.acquire() as conn:
+    async with _acquire(db_pool) as conn:
         # Check if user is ADMIN
         user_is_admin = await is_admin(db_pool, user_id)
 

--- a/backend/tests/test_org_scope.py
+++ b/backend/tests/test_org_scope.py
@@ -1,0 +1,203 @@
+"""Tests for org-scoped database connections and middleware org derivation.
+
+Pure helper tests run everywhere; connection and middleware tests need a
+migrated database and skip without DATABASE_URL.
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from org_scope import is_system_admin_from_state, org_id_from_state
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="org-scope connection tests need DATABASE_URL",
+)
+
+
+def request_with_state(**attrs):
+    return SimpleNamespace(state=SimpleNamespace(**attrs))
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def test_org_id_from_state_reads_middleware_org():
+    request = request_with_state(org={"id": "default", "name": "Default"})
+    assert org_id_from_state(request) == "default"
+
+
+def test_org_id_from_state_none_without_org():
+    assert org_id_from_state(request_with_state(org=None)) is None
+    assert org_id_from_state(request_with_state()) is None
+
+
+def test_system_admin_flag_tristate():
+    assert is_system_admin_from_state(request_with_state(user_role="ADMIN")) is True
+    assert is_system_admin_from_state(request_with_state(user_role="VIEWER")) is False
+    # Role not resolved on this path (e.g. /session/*): caller must fetch.
+    assert is_system_admin_from_state(request_with_state()) is None
+
+
+# ---------------------------------------------------------------------------
+# Connection scoping (real database)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_org_scoped_conn_sets_context_and_it_dies_with_transaction():
+    import asyncpg
+    from org_scope import org_scoped_conn
+
+    async def main():
+        pool = await asyncpg.create_pool(
+            os.environ["DATABASE_URL"], min_size=1, max_size=1)
+        try:
+            async with org_scoped_conn(pool, "org_a", False) as conn:
+                assert await conn.fetchval(
+                    "SELECT current_setting('app.org_id', true)") == "org_a"
+                assert await conn.fetchval(
+                    "SELECT current_setting('app.is_system_admin', true)"
+                ) == "false"
+            # max_size=1 guarantees this is the same physical connection:
+            # the settings must not have leaked past the transaction.
+            async with pool.acquire() as conn:
+                leaked = await conn.fetchval(
+                    "SELECT current_setting('app.org_id', true)")
+                assert leaked in (None, "")
+        finally:
+            await pool.close()
+
+    asyncio.run(main())
+
+
+@requires_db
+def test_org_scoped_conn_operator_path_uses_empty_sentinel():
+    import asyncpg
+    from org_scope import org_scoped_conn
+
+    async def main():
+        pool = await asyncpg.create_pool(
+            os.environ["DATABASE_URL"], min_size=1, max_size=1)
+        try:
+            async with org_scoped_conn(pool, None, True) as conn:
+                assert await conn.fetchval(
+                    "SELECT current_setting('app.org_id', true)") == ""
+                assert await conn.fetchval(
+                    "SELECT current_setting('app.is_system_admin', true)"
+                ) == "true"
+        finally:
+            await pool.close()
+
+    asyncio.run(main())
+
+
+@requires_db
+def test_empty_string_org_id_is_rejected_by_constraint():
+    import asyncpg
+
+    async def main():
+        conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+        try:
+            with pytest.raises(asyncpg.CheckViolationError):
+                await conn.execute(
+                    """
+                    INSERT INTO organizations
+                        (id, name, "createdAt", "updatedAt")
+                    VALUES ('', 'Sentinel Collision', NOW(), NOW())
+                    """)
+        finally:
+            await conn.close()
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
+# Middleware org derivation (real app, real database)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_middleware_derives_org_from_active_instance():
+    import base64
+    import hashlib
+    import hmac
+
+    import asyncpg
+    from fastapi.testclient import TestClient
+
+    import session_cookie
+    from app import app
+
+    secret = "org-scope-test-secret"
+
+    async def seed():
+        conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+        await conn.execute("""
+            INSERT INTO users (id, email, name, role, "emailVerified",
+                               "createdAt", "updatedAt")
+            VALUES ('u_orgscope', 'orgscope@test.local', 'Org Scope',
+                    'ADMIN', true, NOW(), NOW())
+        """)
+        await conn.execute("""
+            INSERT INTO sessions (id, token, "userId", "expiresAt",
+                                  "createdAt", "updatedAt")
+            VALUES ('sess_orgscope', 'tok_orgscope', 'u_orgscope',
+                    NOW() + interval '1 hour', NOW(), NOW())
+        """)
+        await conn.execute("""
+            INSERT INTO sites (id, name, "createdAt", "updatedAt")
+            VALUES ('s_orgscope', 'Org Scope Site', NOW(), NOW())
+        """)
+        await conn.execute("""
+            INSERT INTO instances (id, "siteId", name, host, username,
+                                   password, "createdAt", "updatedAt")
+            VALUES ('i_orgscope', 's_orgscope', 'org-scope-router',
+                    '192.0.2.99', 'vyos', 'enc-placeholder', NOW(), NOW())
+        """)
+        await conn.execute("""
+            INSERT INTO active_sessions (id, "userId", "instanceId",
+                                         "sessionToken", "connectedAt")
+            VALUES ('as_orgscope', 'u_orgscope', 'i_orgscope',
+                    'tok_orgscope', NOW())
+        """)
+        await conn.close()
+
+    async def cleanup():
+        conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+        # users cascades sessions/active_sessions; sites cascades instances
+        await conn.execute("DELETE FROM users WHERE id = 'u_orgscope'")
+        await conn.execute("DELETE FROM sites WHERE id = 's_orgscope'")
+        await conn.close()
+
+    from fastapi import Request
+
+    if not any(getattr(r, "path", None) == "/_test/org-state"
+               for r in app.router.routes):
+        @app.get("/_test/org-state")
+        async def _org_state(request: Request):
+            return {
+                "org": getattr(request.state, "org", "unset"),
+                "user_role": getattr(request.state, "user_role", "unset"),
+            }
+
+    original_secret = session_cookie._secret
+    session_cookie._secret = secret.encode()
+    try:
+        asyncio.run(seed())
+        signature = base64.b64encode(
+            hmac.new(secret.encode(), b"tok_orgscope",
+                     hashlib.sha256).digest()).decode()
+        with TestClient(app) as client:
+            client.cookies.set("better-auth.session_token",
+                               f"tok_orgscope.{signature}")
+            response = client.get("/_test/org-state")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["org"] == {"id": "default", "name": "Default"}
+        assert body["user_role"] == "ADMIN"
+    finally:
+        session_cookie._secret = original_secret
+        asyncio.run(cleanup())

--- a/frontend/prisma/migrations/20260708_org_id_guard/migration.sql
+++ b/frontend/prisma/migrations/20260708_org_id_guard/migration.sql
@@ -1,0 +1,5 @@
+-- The empty string is the "no org context" sentinel carried in the
+-- app.org_id connection setting; an organization must never be able to
+-- take it as a real id.
+ALTER TABLE "organizations"
+    ADD CONSTRAINT "organizations_id_not_empty" CHECK ("id" <> '');


### PR DESCRIPTION
First of a three-PR stack (core plumbing → admin-surface migration → adversarial test skeleton) for the organization-system groundwork (design docs to follow on docs.vyprojects.org). Behavior-invisible: no endpoint changes its responses; the umbrella issue tracks the stack.

## What

**`org_scope.py`** — org-scoped database access:
- `org_scoped_conn(pool, org_id, is_system_admin)`: one connection, one transaction, with the request's org context applied as `SET LOCAL` settings (`app.org_id`, `app.is_system_admin` — via `set_config(..., true)`, since `SET LOCAL` cannot bind parameters). Settings die with the transaction, so they can never leak across requests on a pooled connection. These are the settings the later row-level-security work keys on; `app.is_system_admin` is the single greppable bypass flag.
- `org_conn`: FastAPI dependency for handlers that own queries — the whole handler body is one unit of work; the connection is exposed as `request.state.org_conn` so nested permission checks join the same transaction.
- `request_scoped_conn`: joins the handler's open transaction, or opens a short-lived scoped one — the permission path for VyOS feature handlers, which must not hold a DB connection across a potentially slow router HTTP call (pool exhaustion).
- The rule, stated in the module docstring: **one unit of work = one acquisition.** A logically atomic read-modify-write must never split across two acquisitions.

**`SessionMiddleware`** — derives the org from the active instance (instance → site → org) through the shared column projection, so the browser-cookie path and the `X-VyOS-Instance-Id` token path both get it from the same join. Injects `request.state.org` beside `state.site`, and keeps the already-fetched deployment role as `state.user_role` (previously fetched and discarded).

**Permission path** (`fastapi_permissions.py`) — `require_permission`, `require_super_admin` and `get_user_feature_permissions` now run their DB work on one org-scoped connection instead of ad-hoc pool acquisitions. Resolver entry points (`get_user_permissions`, `check_permission`, `is_admin`) accept a pool **or** an existing connection, and take an `org_id` parameter — threaded through today, org-agnostic until enforcement turns on.

**Migration** — a CHECK constraint forbidding the empty-string organization id: `''` is the no-org-context sentinel carried in `app.org_id` and must never collide with a real org. (Prisma does not model CHECK constraints, so `schema.prisma` is untouched and drift-free.)

## Evidence

- **Behavioral invisibility**: golden permission file captured against a seeded database (3 users, 2 instances, OPERATOR/VIEWER grants with feature permissions) running the **previous** resolver code, then compared running **this branch**: output identical for all pairs.
- **Context scoping**: with a pool of `max_size=1` (same physical connection guaranteed), `app.org_id` is visible inside `org_scoped_conn` and gone on the next acquisition — no leak past the transaction.
- **Operator path**: `org_id=None` yields the `''` sentinel with `app.is_system_admin='true'`.
- **Sentinel guard**: inserting an organization with id `''` fails with a check violation.
- **Middleware derivation**: full app + real database, authenticated browser-cookie request with an active instance — `request.state.org` resolves to the default org and `state.user_role` to the deployment role.
- **Suite**: 71 passed, 0 skipped with a database; 66 passed / 5 skipped without (DB-gated tests skip cleanly).

Perf numbers (hot-endpoint p50/p95 before vs after the transaction change) land with the next PR in the stack, measured across both, as agreed.

## For the reviewer

The invariant to check: every code path in this diff that touches the database does so inside exactly one `org_scoped_conn`/`org_conn` acquisition, and nothing outside a transaction ever calls `set_config` on these keys.