### PR TITLE
feat: move admin surface onto org-scoped connections

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -28,7 +28,14 @@ from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
 
 import asyncpg
-from fastapi import Request
+from fastapi import HTTPException, Query, Request
+
+
+def _require_pool(request: Request) -> asyncpg.Pool:
+    pool = getattr(request.app.state, "db_pool", None)
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+    return pool
 
 
 @asynccontextmanager
@@ -81,21 +88,85 @@ async def _resolve_system_admin(conn: asyncpg.Connection, request: Request) -> b
     return role == "ADMIN"
 
 
-async def org_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
-    """FastAPI dependency: the handler's whole body is one unit of work.
+async def _resolve_admin_org(
+    conn: asyncpg.Connection,
+    request: Request,
+    requested_org_id: Optional[str],
+    is_system_admin: bool,
+) -> str:
+    """Validate an explicitly requested org for a no-instance endpoint.
 
-    Yields a connection inside an org-scoped transaction and exposes it as
-    request.state.org_conn so nested permission checks join the same
+    The org must exist and (unless the caller is a System Administrator)
+    be one of the caller's organizations.
+    """
+    user = getattr(request.state, "user", None)
+    exists = await conn.fetchval(
+        "SELECT 1 FROM organizations WHERE id = $1", requested_org_id)
+    if not exists:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    if not is_system_admin:
+        member = user and await conn.fetchval(
+            'SELECT 1 FROM org_memberships'
+            ' WHERE "userId" = $1 AND "orgId" = $2',
+            user["id"], requested_org_id)
+        if not member:
+            raise HTTPException(
+                status_code=403,
+                detail="You are not a member of this organization")
+    return requested_org_id
+
+
+@asynccontextmanager
+async def _handler_conn(
+    request: Request,
+    requested_org_id: Optional[str],
+) -> AsyncIterator[asyncpg.Connection]:
+    """Shared core of the handler dependencies.
+
+    The handler's whole body is one unit of work; the connection is exposed
+    as request.state.org_conn so nested permission checks join the same
     transaction instead of opening their own.
     """
-    pool: asyncpg.Pool = request.app.state.db_pool
+    pool = _require_pool(request)
+    user = getattr(request.state, "user", None)
     async with pool.acquire() as conn:
         async with conn.transaction():
-            is_admin = await _resolve_system_admin(conn, request)
+            org_id = org_id_from_state(request)
+            is_admin = is_system_admin_from_state(request)
+
+            if requested_org_id and org_id is None:
+                if is_admin is None:
+                    is_admin = await _resolve_system_admin(conn, request)
+                org_id = await _resolve_admin_org(
+                    conn, request, requested_org_id, is_admin)
+            elif user and (is_admin is None or org_id is None):
+                # One round trip resolves both the deployment role and the
+                # sole-org default — this dependency runs on every admin
+                # request, so per-query trips matter.
+                row = await conn.fetchrow(
+                    "SELECT (SELECT role FROM users WHERE id = $1) AS role,"
+                    ' ARRAY(SELECT "orgId" FROM org_memberships'
+                    '       WHERE "userId" = $1 ORDER BY "orgId" LIMIT 2)'
+                    " AS orgs",
+                    user["id"])
+                if is_admin is None:
+                    is_admin = row["role"] == "ADMIN"
+                if org_id is None:
+                    orgs = row["orgs"]
+                    if len(orgs) == 1:
+                        org_id = orgs[0]
+                    elif len(orgs) > 1:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="You belong to multiple organizations;"
+                                   " pass org_id")
+
+            if is_admin is None:
+                is_admin = False
             await conn.execute(
                 "SELECT set_config('app.org_id', $1, true),"
                 "       set_config('app.is_system_admin', $2, true)",
-                org_id_from_state(request) or "",
+                org_id or "",
                 "true" if is_admin else "false",
             )
             request.state.org_conn = conn
@@ -103,6 +174,27 @@ async def org_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
                 yield conn
             finally:
                 request.state.org_conn = None
+
+
+async def org_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
+    """FastAPI dependency for handlers whose org context comes from the
+    active instance (SessionMiddleware) or is deliberately absent."""
+    async with _handler_conn(request, None) as conn:
+        yield conn
+
+
+async def org_conn_admin(
+    request: Request,
+    org_id: Optional[str] = Query(
+        None,
+        description="Organization to act in; defaults to your sole organization.",
+    ),
+) -> AsyncIterator[asyncpg.Connection]:
+    """FastAPI dependency for the admin surface (sites, instances, users,
+    tokens, backup): no active instance required; org context comes from
+    the optional org_id parameter or the caller's sole membership."""
+    async with _handler_conn(request, org_id) as conn:
+        yield conn
 
 
 @asynccontextmanager

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -5,7 +5,8 @@ API endpoints for managing user sessions with VyOS instances.
 Handles connect/disconnect operations and instance selection.
 """
 
-from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Form
+from fastapi import Depends, APIRouter, HTTPException, Request, UploadFile, File, Form
+from org_scope import org_conn_admin
 from starlette.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -160,26 +161,21 @@ class ApiResponse(BaseModel):
 
 
 @router.get("/onboarding-status", response_model=OnboardingStatusResponse)
-async def get_onboarding_status(request: Request):
+async def get_onboarding_status(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Check if the system needs initial onboarding setup.
 
     Returns True if no users exist in the system.
     """
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Count users
-            result = await conn.fetchrow('SELECT COUNT(*) as count FROM users')
-            user_count = result['count']
+        # Count users
+        result = await conn.fetchrow('SELECT COUNT(*) as count FROM users')
+        user_count = result['count']
 
-            return OnboardingStatusResponse(
-                needs_onboarding=user_count == 0,
-                user_count=user_count
-            )
+        return OnboardingStatusResponse(
+            needs_onboarding=user_count == 0,
+            user_count=user_count
+        )
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -191,7 +187,7 @@ async def get_onboarding_status(request: Request):
 
 
 @router.get("/current", response_model=Optional[ActiveSessionResponse])
-async def get_current_session(request: Request):
+async def get_current_session(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Get the user's current active session (which instance they're connected to).
 
@@ -205,44 +201,39 @@ async def get_current_session(request: Request):
     user_id = user["id"]
 
     # Get database pool from app state
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Get active session with instance and site details
-            session = await conn.fetchrow(
-                """
-                SELECT
-                    a.id as session_id,
-                    a."instanceId" as instance_id,
-                    a."connectedAt" as connected_at,
-                    i.name as instance_name,
-                    i.host,
-                    i.port,
-                    i."siteId" as site_id,
-                    s.name as site_name
-                FROM active_sessions a
-                JOIN instances i ON a."instanceId" = i.id
-                JOIN sites s ON i."siteId" = s.id
-                WHERE a."userId" = $1
-                """,
-                user_id,
-            )
+        # Get active session with instance and site details
+        session = await conn.fetchrow(
+            """
+            SELECT
+                a.id as session_id,
+                a."instanceId" as instance_id,
+                a."connectedAt" as connected_at,
+                i.name as instance_name,
+                i.host,
+                i.port,
+                i."siteId" as site_id,
+                s.name as site_name
+            FROM active_sessions a
+            JOIN instances i ON a."instanceId" = i.id
+            JOIN sites s ON i."siteId" = s.id
+            WHERE a."userId" = $1
+            """,
+            user_id,
+        )
 
-            if not session:
-                return None
+        if not session:
+            return None
 
-            return ActiveSessionResponse(
-                instance_id=session["instance_id"],
-                instance_name=session["instance_name"],
-                site_id=session["site_id"],
-                site_name=session["site_name"],
-                host=session["host"],
-                port=session["port"],
-                connected_at=session["connected_at"],
-            )
+        return ActiveSessionResponse(
+            instance_id=session["instance_id"],
+            instance_name=session["instance_name"],
+            site_id=session["site_id"],
+            site_name=session["site_name"],
+            host=session["host"],
+            port=session["port"],
+            connected_at=session["connected_at"],
+        )
 
     except Exception as e:
         logger.exception("Unhandled error")
@@ -255,7 +246,7 @@ async def get_current_session(request: Request):
 
 
 @router.post("/connect", response_model=ApiResponse)
-async def connect_to_instance(request: Request, body: ConnectRequest):
+async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Connect to a specific VyOS instance.
 
@@ -270,132 +261,126 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
     user_id = user["id"]
     instance_id = body.instance_id
 
-    # Get database pool
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check if user is site-level ADMIN
-            user_site_role = await conn.fetchval(
+        # Check if user is site-level ADMIN
+        user_site_role = await conn.fetchval(
+            """
+            SELECT role FROM users WHERE id = $1
+            """,
+            user_id
+        )
+
+        # Site ADMIN users can access any instance
+        # Other users need explicit instance-level permissions
+        if user_site_role == "ADMIN":
+            # ADMIN can access any instance - no instance role check needed
+            instance = await conn.fetchrow(
                 """
-                SELECT role FROM users WHERE id = $1
+                SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
+                       i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
+                       s.name as site_name,
+                       'ADMIN' as role
+                FROM instances i
+                JOIN sites s ON i."siteId" = s.id
+                WHERE i.id = $1
                 """,
-                user_id
+                instance_id,
             )
-
-            # Site ADMIN users can access any instance
-            # Other users need explicit instance-level permissions
-            if user_site_role == "ADMIN":
-                # ADMIN can access any instance - no instance role check needed
-                instance = await conn.fetchrow(
-                    """
-                    SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
-                           s.name as site_name,
-                           'ADMIN' as role
-                    FROM instances i
-                    JOIN sites s ON i."siteId" = s.id
-                    WHERE i.id = $1
-                    """,
-                    instance_id,
-                )
-            else:
-                # VIEWER users need explicit instance-level role assignment
-                instance = await conn.fetchrow(
-                    """
-                    SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
-                           s.name as site_name,
-                           uir.role as role
-                    FROM instances i
-                    JOIN sites s ON i."siteId" = s.id
-                    JOIN user_instance_roles uir
-                        ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
-                        AND uir."userId" = $1
-                    WHERE i.id = $2
-                    ORDER BY CASE uir.role
-                        WHEN 'ADMIN' THEN 3 WHEN 'OPERATOR' THEN 2 WHEN 'VIEWER' THEN 1 ELSE 0
-                    END DESC
-                    LIMIT 1
-                    """,
-                    user_id,
-                    instance_id,
-                )
-
-            if not instance:
-                raise HTTPException(
-                    status_code=404,
-                    detail="Instance not found or you don't have permission to access it",
-                )
-
-            if not instance["isActive"]:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Instance '{instance['name']}' is not active",
-                )
-
-            # Test the connection to VyOS before creating session
-            try:
-                device_config = VyOSDeviceConfig(
-                    hostname=instance["host"],
-                    apikey=instance["apiKey"],
-                    version=instance["vyosVersion"],
-                    protocol=instance["protocol"],
-                    port=instance["port"],
-                    verify=instance["verifySsl"],
-                    timeout=instance.get("timeout") or 10,
-                )
-                vyos_service = VyOSService(device_config)
-
-                # Test connection by fetching config (this will raise exception if connection fails)
-                await run_in_threadpool(vyos_service.get_full_config)
-
-            except Exception as e:
-                error_msg = str(e)
-                raise HTTPException(
-                    status_code=503,
-                    detail=f"Failed to connect to VyOS instance: {error_msg}. Please verify the host, port, API key, and network connectivity.",
-                )
-
-            # Get current auth session token from cookie and verify its signature
-            # This allows us to track which auth session created this VyOS connection
-            cookie_token = request.cookies.get("better-auth.session_token")
-            current_session_token = verify_session_cookie(cookie_token) if cookie_token else None
-
-            # Create or update active session (upsert)
-            # Generate a 32-character ID similar to CUIDs used elsewhere in the database
-            import secrets
-            import string
-            alphabet = string.ascii_letters + string.digits
-            session_id = ''.join(secrets.choice(alphabet) for _ in range(32))
-
-            result = await conn.execute(
+        else:
+            # VIEWER users need explicit instance-level role assignment
+            instance = await conn.fetchrow(
                 """
-                INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
-                VALUES ($1, $2, $3, $4, NOW())
-                ON CONFLICT ("userId")
-                DO UPDATE SET "instanceId" = $3, "sessionToken" = $4, "connectedAt" = NOW()
+                SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
+                       i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
+                       s.name as site_name,
+                       uir.role as role
+                FROM instances i
+                JOIN sites s ON i."siteId" = s.id
+                JOIN user_instance_roles uir
+                    ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
+                    AND uir."userId" = $1
+                WHERE i.id = $2
+                ORDER BY CASE uir.role
+                    WHEN 'ADMIN' THEN 3 WHEN 'OPERATOR' THEN 2 WHEN 'VIEWER' THEN 1 ELSE 0
+                END DESC
+                LIMIT 1
                 """,
-                session_id,
                 user_id,
                 instance_id,
-                current_session_token,
             )
 
-            return ApiResponse(
-                success=True,
-                message=f"Connected to instance '{instance['name']}'",
-                data={
-                    "instance_id": instance_id,
-                    "instance_name": instance["name"],
-                    "site_id": instance["siteId"],
-                    "site_name": instance["site_name"],
-                    "host": instance["host"],
-                    "port": instance["port"],
-                },
+        if not instance:
+            raise HTTPException(
+                status_code=404,
+                detail="Instance not found or you don't have permission to access it",
             )
+
+        if not instance["isActive"]:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Instance '{instance['name']}' is not active",
+            )
+
+        # Test the connection to VyOS before creating session
+        try:
+            device_config = VyOSDeviceConfig(
+                hostname=instance["host"],
+                apikey=instance["apiKey"],
+                version=instance["vyosVersion"],
+                protocol=instance["protocol"],
+                port=instance["port"],
+                verify=instance["verifySsl"],
+                timeout=instance.get("timeout") or 10,
+            )
+            vyos_service = VyOSService(device_config)
+
+            # Test connection by fetching config (this will raise exception if connection fails)
+            await run_in_threadpool(vyos_service.get_full_config)
+
+        except Exception as e:
+            error_msg = str(e)
+            raise HTTPException(
+                status_code=503,
+                detail=f"Failed to connect to VyOS instance: {error_msg}. Please verify the host, port, API key, and network connectivity.",
+            )
+
+        # Get current auth session token from cookie and verify its signature
+        # This allows us to track which auth session created this VyOS connection
+        cookie_token = request.cookies.get("better-auth.session_token")
+        current_session_token = verify_session_cookie(cookie_token) if cookie_token else None
+
+        # Create or update active session (upsert)
+        # Generate a 32-character ID similar to CUIDs used elsewhere in the database
+        import secrets
+        import string
+        alphabet = string.ascii_letters + string.digits
+        session_id = ''.join(secrets.choice(alphabet) for _ in range(32))
+
+        result = await conn.execute(
+            """
+            INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT ("userId")
+            DO UPDATE SET "instanceId" = $3, "sessionToken" = $4, "connectedAt" = NOW()
+            """,
+            session_id,
+            user_id,
+            instance_id,
+            current_session_token,
+        )
+
+        return ApiResponse(
+            success=True,
+            message=f"Connected to instance '{instance['name']}'",
+            data={
+                "instance_id": instance_id,
+                "instance_name": instance["name"],
+                "site_id": instance["siteId"],
+                "site_name": instance["site_name"],
+                "host": instance["host"],
+                "port": instance["port"],
+            },
+        )
 
     except HTTPException:
         raise
@@ -410,7 +395,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
 
 
 @router.post("/disconnect", response_model=ApiResponse)
-async def disconnect_from_instance(request: Request):
+async def disconnect_from_instance(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Disconnect from the current VyOS instance.
 
@@ -423,32 +408,26 @@ async def disconnect_from_instance(request: Request):
     user = request.state.user
     user_id = user["id"]
 
-    # Get database pool
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Delete active session
-            result = await conn.execute(
-                """
-                DELETE FROM active_sessions
-                WHERE "userId" = $1
-                """,
-                user_id,
+        # Delete active session
+        result = await conn.execute(
+            """
+            DELETE FROM active_sessions
+            WHERE "userId" = $1
+            """,
+            user_id,
+        )
+
+        # Check if a session was deleted
+        if result == "DELETE 0":
+            raise HTTPException(
+                status_code=404, detail="No active session to disconnect"
             )
 
-            # Check if a session was deleted
-            if result == "DELETE 0":
-                raise HTTPException(
-                    status_code=404, detail="No active session to disconnect"
-                )
-
-            return ApiResponse(
-                success=True,
-                message="Disconnected from instance",
-            )
+        return ApiResponse(
+            success=True,
+            message="Disconnected from instance",
+        )
 
     except HTTPException:
         raise
@@ -463,7 +442,7 @@ async def disconnect_from_instance(request: Request):
 
 
 @router.get("/sites", response_model=List[SiteResponse])
-async def list_user_sites(request: Request):
+async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Get all sites the user has access to.
 
@@ -478,85 +457,79 @@ async def list_user_sites(request: Request):
     user = request.state.user
     user_id = user["id"]
 
-    # Get database pool
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # First, check if user is a site ADMIN
-            user_role = await conn.fetchval(
+        # First, check if user is a site ADMIN
+        user_role = await conn.fetchval(
+            """
+            SELECT role FROM users WHERE id = $1
+            """,
+            user_id,
+        )
+
+        if user_role == "ADMIN":
+            # Site ADMINs see ALL sites with ADMIN role
+            sites = await conn.fetch(
                 """
-                SELECT role FROM users WHERE id = $1
+                SELECT id, name, description, "createdAt", "updatedAt"
+                FROM sites
+                ORDER BY name
+                """,
+            )
+
+            return [
+                SiteResponse(
+                    id=site["id"],
+                    name=site["name"],
+                    description=site["description"],
+                    role="ADMIN",  # Site ADMINs have ADMIN role on all sites
+                    created_at=site["createdAt"],
+                    updated_at=site["updatedAt"],
+                )
+                for site in sites
+            ]
+        else:
+            # Regular users see only sites where they have instance access
+            # Role shown is the highest role the user has across all instances in that site
+            sites = await conn.fetch(
+                """
+                SELECT DISTINCT s.id, s.name, s.description, s."createdAt", s."updatedAt",
+                       MAX(
+                           CASE uir.role
+                               WHEN 'ADMIN' THEN 3
+                               WHEN 'OPERATOR' THEN 2
+                               WHEN 'VIEWER' THEN 1
+                               ELSE 0
+                           END
+                       ) as role_rank,
+                       (ARRAY_AGG(uir.role ORDER BY
+                           CASE uir.role
+                               WHEN 'ADMIN' THEN 3
+                               WHEN 'OPERATOR' THEN 2
+                               WHEN 'VIEWER' THEN 1
+                               ELSE 0
+                           END DESC))[1] as role
+                FROM sites s
+                JOIN instances i ON s.id = i."siteId"
+                JOIN user_instance_roles uir
+                    ON (uir."instanceId" = i.id OR uir."siteId" = s.id)
+                    AND uir."userId" = $1
+                GROUP BY s.id, s.name, s.description, s."createdAt", s."updatedAt"
+                ORDER BY s.name
                 """,
                 user_id,
             )
 
-            if user_role == "ADMIN":
-                # Site ADMINs see ALL sites with ADMIN role
-                sites = await conn.fetch(
-                    """
-                    SELECT id, name, description, "createdAt", "updatedAt"
-                    FROM sites
-                    ORDER BY name
-                    """,
+            return [
+                SiteResponse(
+                    id=site["id"],
+                    name=site["name"],
+                    description=site["description"],
+                    role=site["role"],
+                    created_at=site["createdAt"],
+                    updated_at=site["updatedAt"],
                 )
-
-                return [
-                    SiteResponse(
-                        id=site["id"],
-                        name=site["name"],
-                        description=site["description"],
-                        role="ADMIN",  # Site ADMINs have ADMIN role on all sites
-                        created_at=site["createdAt"],
-                        updated_at=site["updatedAt"],
-                    )
-                    for site in sites
-                ]
-            else:
-                # Regular users see only sites where they have instance access
-                # Role shown is the highest role the user has across all instances in that site
-                sites = await conn.fetch(
-                    """
-                    SELECT DISTINCT s.id, s.name, s.description, s."createdAt", s."updatedAt",
-                           MAX(
-                               CASE uir.role
-                                   WHEN 'ADMIN' THEN 3
-                                   WHEN 'OPERATOR' THEN 2
-                                   WHEN 'VIEWER' THEN 1
-                                   ELSE 0
-                               END
-                           ) as role_rank,
-                           (ARRAY_AGG(uir.role ORDER BY
-                               CASE uir.role
-                                   WHEN 'ADMIN' THEN 3
-                                   WHEN 'OPERATOR' THEN 2
-                                   WHEN 'VIEWER' THEN 1
-                                   ELSE 0
-                               END DESC))[1] as role
-                    FROM sites s
-                    JOIN instances i ON s.id = i."siteId"
-                    JOIN user_instance_roles uir
-                        ON (uir."instanceId" = i.id OR uir."siteId" = s.id)
-                        AND uir."userId" = $1
-                    GROUP BY s.id, s.name, s.description, s."createdAt", s."updatedAt"
-                    ORDER BY s.name
-                    """,
-                    user_id,
-                )
-
-                return [
-                    SiteResponse(
-                        id=site["id"],
-                        name=site["name"],
-                        description=site["description"],
-                        role=site["role"],
-                        created_at=site["createdAt"],
-                        updated_at=site["updatedAt"],
-                    )
-                    for site in sites
-                ]
+                for site in sites
+            ]
 
     except Exception as e:
         logger.exception("Unhandled error")
@@ -569,7 +542,7 @@ async def list_user_sites(request: Request):
 
 
 @router.get("/sites/{site_id}/instances", response_model=List[InstanceResponse])
-async def list_site_instances(request: Request, site_id: str):
+async def list_site_instances(request: Request, site_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Get all instances for a specific site that the user has access to.
 
@@ -584,80 +557,74 @@ async def list_site_instances(request: Request, site_id: str):
     user = request.state.user
     user_id = user["id"]
 
-    # Get database pool
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # First, check if user is a site ADMIN
-            user_role = await conn.fetchval(
+        # First, check if user is a site ADMIN
+        user_role = await conn.fetchval(
+            """
+            SELECT role FROM users WHERE id = $1
+            """,
+            user_id,
+        )
+
+        if user_role == "ADMIN":
+            # Site ADMINs see ALL instances in the site
+            instances = await conn.fetch(
                 """
-                SELECT role FROM users WHERE id = $1
+                SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "isActive",
+                       "vyosVersion", "sshPort", "sshUsername", "sshKeyConfigured",
+                       "commitConfirmEnabled", "commitConfirmMinutes", timeout,
+                       "createdAt", "updatedAt"
+                FROM instances
+                WHERE "siteId" = $1
+                ORDER BY name
                 """,
+                site_id,
+            )
+        else:
+            # Regular users see only instances they have explicit access to
+            instances = await conn.fetch(
+                """
+                SELECT DISTINCT i.id, i."siteId", i.name, i.description, i.host, i.port, i.protocol, i."verifySsl", i."isActive",
+                       i."vyosVersion", i."sshPort", i."sshUsername", i."sshKeyConfigured",
+                       i."commitConfirmEnabled", i."commitConfirmMinutes", i.timeout,
+                       i."createdAt", i."updatedAt"
+                FROM instances i
+                JOIN user_instance_roles uir
+                    ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
+                    AND uir."userId" = $2
+                WHERE i."siteId" = $1
+                ORDER BY i.name
+                """,
+                site_id,
                 user_id,
             )
 
-            if user_role == "ADMIN":
-                # Site ADMINs see ALL instances in the site
-                instances = await conn.fetch(
-                    """
-                    SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "isActive",
-                           "vyosVersion", "sshPort", "sshUsername", "sshKeyConfigured",
-                           "commitConfirmEnabled", "commitConfirmMinutes", timeout,
-                           "createdAt", "updatedAt"
-                    FROM instances
-                    WHERE "siteId" = $1
-                    ORDER BY name
-                    """,
-                    site_id,
-                )
-            else:
-                # Regular users see only instances they have explicit access to
-                instances = await conn.fetch(
-                    """
-                    SELECT DISTINCT i.id, i."siteId", i.name, i.description, i.host, i.port, i.protocol, i."verifySsl", i."isActive",
-                           i."vyosVersion", i."sshPort", i."sshUsername", i."sshKeyConfigured",
-                           i."commitConfirmEnabled", i."commitConfirmMinutes", i.timeout,
-                           i."createdAt", i."updatedAt"
-                    FROM instances i
-                    JOIN user_instance_roles uir
-                        ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
-                        AND uir."userId" = $2
-                    WHERE i."siteId" = $1
-                    ORDER BY i.name
-                    """,
-                    site_id,
-                    user_id,
-                )
+        # If no instances found, return empty list (don't throw 404)
+        # This allows the frontend to show "No instances available"
 
-            # If no instances found, return empty list (don't throw 404)
-            # This allows the frontend to show "No instances available"
-
-            return [
-                InstanceResponse(
-                    id=inst["id"],
-                    site_id=inst["siteId"],
-                    name=inst["name"],
-                    description=inst["description"],
-                    host=inst["host"],
-                    port=inst["port"],
-                    protocol=inst.get("protocol") or "https",
-                    verify_ssl=inst.get("verifySsl") or False,
-                    vyos_version=inst.get("vyosVersion"),
-                    is_active=inst["isActive"],
-                    ssh_port=inst["sshPort"],
-                    ssh_username=inst["sshUsername"],
-                    ssh_key_configured=inst["sshKeyConfigured"],
-                    commit_confirm_enabled=inst.get("commitConfirmEnabled") or False,
-                    commit_confirm_minutes=inst.get("commitConfirmMinutes") or 5,
-                    timeout=inst.get("timeout") or 10,
-                    created_at=inst["createdAt"],
-                    updated_at=inst["updatedAt"],
-                )
-                for inst in instances
-            ]
+        return [
+            InstanceResponse(
+                id=inst["id"],
+                site_id=inst["siteId"],
+                name=inst["name"],
+                description=inst["description"],
+                host=inst["host"],
+                port=inst["port"],
+                protocol=inst.get("protocol") or "https",
+                verify_ssl=inst.get("verifySsl") or False,
+                vyos_version=inst.get("vyosVersion"),
+                is_active=inst["isActive"],
+                ssh_port=inst["sshPort"],
+                ssh_username=inst["sshUsername"],
+                ssh_key_configured=inst["sshKeyConfigured"],
+                commit_confirm_enabled=inst.get("commitConfirmEnabled") or False,
+                commit_confirm_minutes=inst.get("commitConfirmMinutes") or 5,
+                timeout=inst.get("timeout") or 10,
+                created_at=inst["createdAt"],
+                updated_at=inst["updatedAt"],
+            )
+            for inst in instances
+        ]
 
     except HTTPException:
         raise
@@ -672,7 +639,7 @@ async def list_site_instances(request: Request, site_id: str):
 
 
 @router.post("/sites", response_model=SiteResponse, status_code=201)
-async def create_site(request: Request, body: SiteCreateRequest):
+async def create_site(request: Request, body: SiteCreateRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Create a new site.
 
@@ -685,54 +652,49 @@ async def create_site(request: Request, body: SiteCreateRequest):
     user = request.state.user
     user_id = user["id"]
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check if this is the first site (onboarding)
-            site_count = await conn.fetchval("SELECT COUNT(*) FROM sites")
-            is_first_site = site_count == 0
+        # Check if this is the first site (onboarding)
+        site_count = await conn.fetchval("SELECT COUNT(*) FROM sites")
+        is_first_site = site_count == 0
 
-            # If not first site, verify user is site ADMIN
-            if not is_first_site:
-                user_role = await conn.fetchval(
-                    "SELECT role FROM users WHERE id = $1",
-                    user_id
+        # If not first site, verify user is site ADMIN
+        if not is_first_site:
+            user_role = await conn.fetchval(
+                "SELECT role FROM users WHERE id = $1",
+                user_id
+            )
+            if user_role != "ADMIN":
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only site ADMIN users can create sites"
                 )
-                if user_role != "ADMIN":
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Only site ADMIN users can create sites"
-                    )
 
-            # Generate site ID
-            import secrets
-            import string
-            alphabet = string.ascii_letters + string.digits
-            site_id = ''.join(secrets.choice(alphabet) for _ in range(32))
+        # Generate site ID
+        import secrets
+        import string
+        alphabet = string.ascii_letters + string.digits
+        site_id = ''.join(secrets.choice(alphabet) for _ in range(32))
 
-            # Create site
-            site = await conn.fetchrow(
-                """
-                INSERT INTO sites (id, name, description, "createdAt", "updatedAt")
-                VALUES ($1, $2, $3, NOW(), NOW())
-                RETURNING id, name, description, "createdAt", "updatedAt"
-                """,
-                site_id,
-                body.name,
-                body.description,
-            )
+        # Create site
+        site = await conn.fetchrow(
+            """
+            INSERT INTO sites (id, name, description, "createdAt", "updatedAt")
+            VALUES ($1, $2, $3, NOW(), NOW())
+            RETURNING id, name, description, "createdAt", "updatedAt"
+            """,
+            site_id,
+            body.name,
+            body.description,
+        )
 
-            return SiteResponse(
-                id=site["id"],
-                name=site["name"],
-                description=site["description"],
-                role="ADMIN",  # Site ADMINs have ADMIN role on all sites
-                created_at=site["createdAt"],
-                updated_at=site["updatedAt"],
-            )
+        return SiteResponse(
+            id=site["id"],
+            name=site["name"],
+            description=site["description"],
+            role="ADMIN",  # Site ADMINs have ADMIN role on all sites
+            created_at=site["createdAt"],
+            updated_at=site["updatedAt"],
+        )
 
     except HTTPException:
         raise
@@ -742,7 +704,7 @@ async def create_site(request: Request, body: SiteCreateRequest):
 
 
 @router.put("/sites/{site_id}", response_model=SiteResponse)
-async def update_site(request: Request, site_id: str, body: SiteUpdateRequest):
+async def update_site(request: Request, site_id: str, body: SiteUpdateRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Update a site.
 
@@ -754,72 +716,67 @@ async def update_site(request: Request, site_id: str, body: SiteUpdateRequest):
     user = request.state.user
     user_id = user["id"]
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check user is site ADMIN
-            user_role = await conn.fetchval(
-                "SELECT role FROM users WHERE id = $1",
-                user_id
+        # Check user is site ADMIN
+        user_role = await conn.fetchval(
+            "SELECT role FROM users WHERE id = $1",
+            user_id
+        )
+
+        if user_role != "ADMIN":
+            raise HTTPException(
+                status_code=403,
+                detail="Only site ADMIN users can update sites"
             )
 
-            if user_role != "ADMIN":
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only site ADMIN users can update sites"
-                )
+        # Verify site exists
+        site_exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+            site_id
+        )
 
-            # Verify site exists
-            site_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+        if not site_exists:
+            raise HTTPException(status_code=404, detail="Site not found")
+
+        # Build update query dynamically
+        updates = []
+        params = [site_id]
+        param_num = 2
+
+        if body.name is not None:
+            updates.append(f'name = ${param_num}')
+            params.append(body.name)
+            param_num += 1
+
+        if body.description is not None:
+            updates.append(f'description = ${param_num}')
+            params.append(body.description)
+            param_num += 1
+
+        if not updates:
+            # No fields to update, return current site
+            site = await conn.fetchrow(
+                'SELECT id, name, description, "createdAt", "updatedAt" FROM sites WHERE id = $1',
                 site_id
             )
+        else:
+            updates.append(f'"updatedAt" = NOW()')
+            query = f"""
+                UPDATE sites
+                SET {', '.join(updates)}
+                WHERE id = $1
+                RETURNING id, name, description, "createdAt", "updatedAt"
+            """
+            site = await conn.fetchrow(query, *params)
 
-            if not site_exists:
-                raise HTTPException(status_code=404, detail="Site not found")
-
-            # Build update query dynamically
-            updates = []
-            params = [site_id]
-            param_num = 2
-
-            if body.name is not None:
-                updates.append(f'name = ${param_num}')
-                params.append(body.name)
-                param_num += 1
-
-            if body.description is not None:
-                updates.append(f'description = ${param_num}')
-                params.append(body.description)
-                param_num += 1
-
-            if not updates:
-                # No fields to update, return current site
-                site = await conn.fetchrow(
-                    'SELECT id, name, description, "createdAt", "updatedAt" FROM sites WHERE id = $1',
-                    site_id
-                )
-            else:
-                updates.append(f'"updatedAt" = NOW()')
-                query = f"""
-                    UPDATE sites
-                    SET {', '.join(updates)}
-                    WHERE id = $1
-                    RETURNING id, name, description, "createdAt", "updatedAt"
-                """
-                site = await conn.fetchrow(query, *params)
-
-            return SiteResponse(
-                id=site["id"],
-                name=site["name"],
-                description=site["description"],
-                role="ADMIN",  # Site ADMINs have ADMIN role on all sites
-                created_at=site["createdAt"],
-                updated_at=site["updatedAt"],
-            )
+        return SiteResponse(
+            id=site["id"],
+            name=site["name"],
+            description=site["description"],
+            role="ADMIN",  # Site ADMINs have ADMIN role on all sites
+            created_at=site["createdAt"],
+            updated_at=site["updatedAt"],
+        )
 
     except HTTPException:
         raise
@@ -829,7 +786,7 @@ async def update_site(request: Request, site_id: str, body: SiteUpdateRequest):
 
 
 @router.delete("/sites/{site_id}", response_model=ApiResponse)
-async def delete_site(request: Request, site_id: str):
+async def delete_site(request: Request, site_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Delete a site.
 
@@ -842,49 +799,44 @@ async def delete_site(request: Request, site_id: str):
     user = request.state.user
     user_id = user["id"]
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check user is site ADMIN
-            user_role = await conn.fetchval(
-                "SELECT role FROM users WHERE id = $1",
-                user_id
+        # Check user is site ADMIN
+        user_role = await conn.fetchval(
+            "SELECT role FROM users WHERE id = $1",
+            user_id
+        )
+
+        if user_role != "ADMIN":
+            raise HTTPException(
+                status_code=403,
+                detail="Only site ADMIN users can delete sites"
             )
 
-            if user_role != "ADMIN":
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only site ADMIN users can delete sites"
-                )
+        # Verify site exists
+        site_exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+            site_id
+        )
 
-            # Verify site exists
-            site_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
-                site_id
+        if not site_exists:
+            raise HTTPException(status_code=404, detail="Site not found")
+
+        async with conn.transaction():
+            # Delete will cascade to instances and user_instance_roles
+            result = await conn.execute(
+                """
+                DELETE FROM sites WHERE id = $1
+                """,
+                site_id,
             )
 
-            if not site_exists:
+            if result == "DELETE 0":
                 raise HTTPException(status_code=404, detail="Site not found")
 
-            async with conn.transaction():
-                # Delete will cascade to instances and user_instance_roles
-                result = await conn.execute(
-                    """
-                    DELETE FROM sites WHERE id = $1
-                    """,
-                    site_id,
-                )
-
-                if result == "DELETE 0":
-                    raise HTTPException(status_code=404, detail="Site not found")
-
-                return ApiResponse(
-                    success=True,
-                    message="Site deleted successfully",
-                )
+            return ApiResponse(
+                success=True,
+                message="Site deleted successfully",
+            )
 
     except HTTPException:
         raise
@@ -899,7 +851,7 @@ async def delete_site(request: Request, site_id: str):
 
 
 @router.post("/instances", response_model=InstanceResponse, status_code=201)
-async def create_instance(request: Request, body: InstanceCreateRequest):
+async def create_instance(request: Request, body: InstanceCreateRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Create a new instance.
 
@@ -911,98 +863,93 @@ async def create_instance(request: Request, body: InstanceCreateRequest):
     user = request.state.user
     user_id = user["id"]
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check user is site ADMIN
-            user_role = await conn.fetchval(
-                "SELECT role FROM users WHERE id = $1",
-                user_id
+        # Check user is site ADMIN
+        user_role = await conn.fetchval(
+            "SELECT role FROM users WHERE id = $1",
+            user_id
+        )
+
+        if user_role != "ADMIN":
+            raise HTTPException(
+                status_code=403,
+                detail="Only site ADMIN users can create instances"
             )
 
-            if user_role != "ADMIN":
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only site ADMIN users can create instances"
-                )
+        # Verify site exists
+        site_exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+            body.site_id
+        )
 
-            # Verify site exists
-            site_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
-                body.site_id
+        if not site_exists:
+            raise HTTPException(status_code=404, detail="Site not found")
+
+        # Generate instance ID
+        import secrets
+        import string
+        alphabet = string.ascii_letters + string.digits
+        instance_id = ''.join(secrets.choice(alphabet) for _ in range(32))
+
+        # Create instance
+        # Note: username/password are legacy fields, VyOS uses apiKey
+        instance = await conn.fetchrow(
+            """
+            INSERT INTO instances (
+                id, "siteId", name, description, host, port, username, password,
+                "apiKey", "vyosVersion", protocol, "verifySsl", "isActive",
+                "sshPort", "sshUsername",
+                "commitConfirmEnabled", "commitConfirmMinutes", timeout,
+                "createdAt", "updatedAt"
             )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, NOW(), NOW())
+            RETURNING id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
+                      "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
+                      "commitConfirmEnabled", "commitConfirmMinutes", timeout,
+                      "createdAt", "updatedAt"
+            """,
+            instance_id,
+            body.site_id,
+            body.name,
+            body.description,
+            body.host,
+            body.port,
+            "api",  # username (legacy field, not used with API key auth)
+            "",  # password (legacy field, not used with API key auth)
+            body.api_key,
+            body.vyos_version,
+            body.protocol,
+            body.verify_ssl,
+            body.is_active,
+            body.ssh_port,
+            body.ssh_username,
+            body.commit_confirm_enabled,
+            body.commit_confirm_minutes,
+            body.timeout,
+        )
 
-            if not site_exists:
-                raise HTTPException(status_code=404, detail="Site not found")
+        clear_session_cache(instance_id)
 
-            # Generate instance ID
-            import secrets
-            import string
-            alphabet = string.ascii_letters + string.digits
-            instance_id = ''.join(secrets.choice(alphabet) for _ in range(32))
-
-            # Create instance
-            # Note: username/password are legacy fields, VyOS uses apiKey
-            instance = await conn.fetchrow(
-                """
-                INSERT INTO instances (
-                    id, "siteId", name, description, host, port, username, password,
-                    "apiKey", "vyosVersion", protocol, "verifySsl", "isActive",
-                    "sshPort", "sshUsername",
-                    "commitConfirmEnabled", "commitConfirmMinutes", timeout,
-                    "createdAt", "updatedAt"
-                )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, NOW(), NOW())
-                RETURNING id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
-                          "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
-                          "commitConfirmEnabled", "commitConfirmMinutes", timeout,
-                          "createdAt", "updatedAt"
-                """,
-                instance_id,
-                body.site_id,
-                body.name,
-                body.description,
-                body.host,
-                body.port,
-                "api",  # username (legacy field, not used with API key auth)
-                "",  # password (legacy field, not used with API key auth)
-                body.api_key,
-                body.vyos_version,
-                body.protocol,
-                body.verify_ssl,
-                body.is_active,
-                body.ssh_port,
-                body.ssh_username,
-                body.commit_confirm_enabled,
-                body.commit_confirm_minutes,
-                body.timeout,
-            )
-
-            clear_session_cache(instance_id)
-
-            return InstanceResponse(
-                id=instance["id"],
-                site_id=instance["siteId"],
-                name=instance["name"],
-                description=instance["description"],
-                host=instance["host"],
-                port=instance["port"],
-                protocol=instance["protocol"] or "https",
-                verify_ssl=instance["verifySsl"] or False,
-                vyos_version=instance["vyosVersion"],
-                is_active=instance["isActive"],
-                ssh_port=instance["sshPort"],
-                ssh_username=instance["sshUsername"],
-                ssh_key_configured=instance["sshKeyConfigured"],
-                commit_confirm_enabled=instance.get("commitConfirmEnabled") or False,
-                commit_confirm_minutes=instance.get("commitConfirmMinutes") or 5,
-                timeout=instance.get("timeout") or 10,
-                created_at=instance["createdAt"],
-                updated_at=instance["updatedAt"],
-            )
+        return InstanceResponse(
+            id=instance["id"],
+            site_id=instance["siteId"],
+            name=instance["name"],
+            description=instance["description"],
+            host=instance["host"],
+            port=instance["port"],
+            protocol=instance["protocol"] or "https",
+            verify_ssl=instance["verifySsl"] or False,
+            vyos_version=instance["vyosVersion"],
+            is_active=instance["isActive"],
+            ssh_port=instance["sshPort"],
+            ssh_username=instance["sshUsername"],
+            ssh_key_configured=instance["sshKeyConfigured"],
+            commit_confirm_enabled=instance.get("commitConfirmEnabled") or False,
+            commit_confirm_minutes=instance.get("commitConfirmMinutes") or 5,
+            timeout=instance.get("timeout") or 10,
+            created_at=instance["createdAt"],
+            updated_at=instance["updatedAt"],
+        )
 
     except HTTPException:
         raise
@@ -1012,7 +959,7 @@ async def create_instance(request: Request, body: InstanceCreateRequest):
 
 
 @router.put("/instances/{instance_id}", response_model=InstanceResponse)
-async def update_instance(request: Request, instance_id: str, body: InstanceUpdateRequest):
+async def update_instance(request: Request, instance_id: str, body: InstanceUpdateRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Update an instance.
 
@@ -1025,180 +972,175 @@ async def update_instance(request: Request, instance_id: str, body: InstanceUpda
     user = request.state.user
     user_id = user["id"]
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check user is site ADMIN
-            user_role = await conn.fetchval(
-                "SELECT role FROM users WHERE id = $1",
-                user_id
+        # Check user is site ADMIN
+        user_role = await conn.fetchval(
+            "SELECT role FROM users WHERE id = $1",
+            user_id
+        )
+
+        if user_role != "ADMIN":
+            raise HTTPException(
+                status_code=403,
+                detail="Only site ADMIN users can update instances"
             )
 
-            if user_role != "ADMIN":
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only site ADMIN users can update instances"
-                )
+        # Verify instance exists
+        instance_exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM instances WHERE id = $1)",
+            instance_id
+        )
 
-            # Verify instance exists
-            instance_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM instances WHERE id = $1)",
+        if not instance_exists:
+            raise HTTPException(status_code=404, detail="Instance not found")
+
+        # If moving to a different site, verify target site exists
+        if body.site_id:
+            target_site_exists = await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+                body.site_id
+            )
+            if not target_site_exists:
+                raise HTTPException(status_code=404, detail="Target site not found")
+
+        # Build update query dynamically
+        updates = []
+        params = [instance_id]
+        param_num = 2
+
+        if body.site_id is not None:
+            updates.append(f'"siteId" = ${param_num}')
+            params.append(body.site_id)
+            param_num += 1
+
+        if body.name is not None:
+            updates.append(f'name = ${param_num}')
+            params.append(body.name)
+            param_num += 1
+
+        if body.description is not None:
+            updates.append(f'description = ${param_num}')
+            params.append(body.description)
+            param_num += 1
+
+        if body.host is not None:
+            updates.append(f'host = ${param_num}')
+            params.append(body.host)
+            param_num += 1
+
+        if body.port is not None:
+            updates.append(f'port = ${param_num}')
+            params.append(body.port)
+            param_num += 1
+
+        if body.api_key is not None:
+            updates.append(f'"apiKey" = ${param_num}')
+            params.append(body.api_key)
+            param_num += 1
+            # Also update username/password legacy fields
+            updates.append(f'username = ${param_num}')
+            params.append("api")
+            param_num += 1
+            updates.append(f'password = ${param_num}')
+            params.append("")
+            param_num += 1
+
+        if body.vyos_version is not None:
+            updates.append(f'"vyosVersion" = ${param_num}')
+            params.append(body.vyos_version)
+            param_num += 1
+
+        if body.protocol is not None:
+            updates.append(f'protocol = ${param_num}')
+            params.append(body.protocol)
+            param_num += 1
+
+        if body.verify_ssl is not None:
+            updates.append(f'"verifySsl" = ${param_num}')
+            params.append(body.verify_ssl)
+            param_num += 1
+
+        if body.is_active is not None:
+            updates.append(f'"isActive" = ${param_num}')
+            params.append(body.is_active)
+            param_num += 1
+
+        if body.ssh_port is not None:
+            updates.append(f'"sshPort" = ${param_num}')
+            params.append(body.ssh_port)
+            param_num += 1
+
+        if body.ssh_username is not None:
+            updates.append(f'"sshUsername" = ${param_num}')
+            params.append(body.ssh_username)
+            param_num += 1
+
+        if body.commit_confirm_enabled is not None:
+            updates.append(f'"commitConfirmEnabled" = ${param_num}')
+            params.append(body.commit_confirm_enabled)
+            param_num += 1
+
+        if body.commit_confirm_minutes is not None:
+            updates.append(f'"commitConfirmMinutes" = ${param_num}')
+            params.append(body.commit_confirm_minutes)
+            param_num += 1
+
+        if body.timeout is not None:
+            updates.append(f'timeout = ${param_num}')
+            params.append(body.timeout)
+            param_num += 1
+
+        if not updates:
+            # No fields to update, return current instance
+            instance = await conn.fetchrow(
+                """
+                SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
+                       "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
+                       "commitConfirmEnabled", "commitConfirmMinutes", timeout,
+                       "createdAt", "updatedAt"
+                FROM instances WHERE id = $1
+                """,
                 instance_id
             )
+        else:
+            updates.append(f'"updatedAt" = NOW()')
+            query = f"""
+                UPDATE instances
+                SET {', '.join(updates)}
+                WHERE id = $1
+                RETURNING id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
+                          "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
+                          "commitConfirmEnabled", "commitConfirmMinutes", timeout,
+                          "createdAt", "updatedAt"
+            """
+            instance = await conn.fetchrow(query, *params)
 
-            if not instance_exists:
-                raise HTTPException(status_code=404, detail="Instance not found")
+        if not instance:
+            raise HTTPException(status_code=404, detail="Instance not found")
 
-            # If moving to a different site, verify target site exists
-            if body.site_id:
-                target_site_exists = await conn.fetchval(
-                    "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
-                    body.site_id
-                )
-                if not target_site_exists:
-                    raise HTTPException(status_code=404, detail="Target site not found")
+        # Invalidate cached VyOS service so changes take effect immediately
+        clear_session_cache(instance_id)
 
-            # Build update query dynamically
-            updates = []
-            params = [instance_id]
-            param_num = 2
-
-            if body.site_id is not None:
-                updates.append(f'"siteId" = ${param_num}')
-                params.append(body.site_id)
-                param_num += 1
-
-            if body.name is not None:
-                updates.append(f'name = ${param_num}')
-                params.append(body.name)
-                param_num += 1
-
-            if body.description is not None:
-                updates.append(f'description = ${param_num}')
-                params.append(body.description)
-                param_num += 1
-
-            if body.host is not None:
-                updates.append(f'host = ${param_num}')
-                params.append(body.host)
-                param_num += 1
-
-            if body.port is not None:
-                updates.append(f'port = ${param_num}')
-                params.append(body.port)
-                param_num += 1
-
-            if body.api_key is not None:
-                updates.append(f'"apiKey" = ${param_num}')
-                params.append(body.api_key)
-                param_num += 1
-                # Also update username/password legacy fields
-                updates.append(f'username = ${param_num}')
-                params.append("api")
-                param_num += 1
-                updates.append(f'password = ${param_num}')
-                params.append("")
-                param_num += 1
-
-            if body.vyos_version is not None:
-                updates.append(f'"vyosVersion" = ${param_num}')
-                params.append(body.vyos_version)
-                param_num += 1
-
-            if body.protocol is not None:
-                updates.append(f'protocol = ${param_num}')
-                params.append(body.protocol)
-                param_num += 1
-
-            if body.verify_ssl is not None:
-                updates.append(f'"verifySsl" = ${param_num}')
-                params.append(body.verify_ssl)
-                param_num += 1
-
-            if body.is_active is not None:
-                updates.append(f'"isActive" = ${param_num}')
-                params.append(body.is_active)
-                param_num += 1
-
-            if body.ssh_port is not None:
-                updates.append(f'"sshPort" = ${param_num}')
-                params.append(body.ssh_port)
-                param_num += 1
-
-            if body.ssh_username is not None:
-                updates.append(f'"sshUsername" = ${param_num}')
-                params.append(body.ssh_username)
-                param_num += 1
-
-            if body.commit_confirm_enabled is not None:
-                updates.append(f'"commitConfirmEnabled" = ${param_num}')
-                params.append(body.commit_confirm_enabled)
-                param_num += 1
-
-            if body.commit_confirm_minutes is not None:
-                updates.append(f'"commitConfirmMinutes" = ${param_num}')
-                params.append(body.commit_confirm_minutes)
-                param_num += 1
-
-            if body.timeout is not None:
-                updates.append(f'timeout = ${param_num}')
-                params.append(body.timeout)
-                param_num += 1
-
-            if not updates:
-                # No fields to update, return current instance
-                instance = await conn.fetchrow(
-                    """
-                    SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
-                           "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
-                           "commitConfirmEnabled", "commitConfirmMinutes", timeout,
-                           "createdAt", "updatedAt"
-                    FROM instances WHERE id = $1
-                    """,
-                    instance_id
-                )
-            else:
-                updates.append(f'"updatedAt" = NOW()')
-                query = f"""
-                    UPDATE instances
-                    SET {', '.join(updates)}
-                    WHERE id = $1
-                    RETURNING id, "siteId", name, description, host, port, protocol, "verifySsl", "vyosVersion",
-                              "isActive", "sshPort", "sshUsername", "sshKeyConfigured",
-                              "commitConfirmEnabled", "commitConfirmMinutes", timeout,
-                              "createdAt", "updatedAt"
-                """
-                instance = await conn.fetchrow(query, *params)
-
-            if not instance:
-                raise HTTPException(status_code=404, detail="Instance not found")
-
-            # Invalidate cached VyOS service so changes take effect immediately
-            clear_session_cache(instance_id)
-
-            return InstanceResponse(
-                id=instance["id"],
-                site_id=instance["siteId"],
-                name=instance["name"],
-                description=instance["description"],
-                host=instance["host"],
-                port=instance["port"],
-                protocol=instance["protocol"] or "https",
-                verify_ssl=instance["verifySsl"] or False,
-                vyos_version=instance["vyosVersion"],
-                is_active=instance["isActive"],
-                ssh_port=instance["sshPort"],
-                ssh_username=instance["sshUsername"],
-                ssh_key_configured=instance["sshKeyConfigured"],
-                commit_confirm_enabled=instance.get("commitConfirmEnabled") or False,
-                commit_confirm_minutes=instance.get("commitConfirmMinutes") or 5,
-                timeout=instance.get("timeout") or 10,
-                created_at=instance["createdAt"],
-                updated_at=instance["updatedAt"],
-            )
+        return InstanceResponse(
+            id=instance["id"],
+            site_id=instance["siteId"],
+            name=instance["name"],
+            description=instance["description"],
+            host=instance["host"],
+            port=instance["port"],
+            protocol=instance["protocol"] or "https",
+            verify_ssl=instance["verifySsl"] or False,
+            vyos_version=instance["vyosVersion"],
+            is_active=instance["isActive"],
+            ssh_port=instance["sshPort"],
+            ssh_username=instance["sshUsername"],
+            ssh_key_configured=instance["sshKeyConfigured"],
+            commit_confirm_enabled=instance.get("commitConfirmEnabled") or False,
+            commit_confirm_minutes=instance.get("commitConfirmMinutes") or 5,
+            timeout=instance.get("timeout") or 10,
+            created_at=instance["createdAt"],
+            updated_at=instance["updatedAt"],
+        )
 
     except HTTPException:
         raise
@@ -1208,7 +1150,7 @@ async def update_instance(request: Request, instance_id: str, body: InstanceUpda
 
 
 @router.delete("/instances/{instance_id}", response_model=ApiResponse)
-async def delete_instance(request: Request, instance_id: str):
+async def delete_instance(request: Request, instance_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Delete an instance.
 
@@ -1221,50 +1163,45 @@ async def delete_instance(request: Request, instance_id: str):
     user = request.state.user
     user_id = user["id"]
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Check user is site ADMIN
-            user_role = await conn.fetchval(
-                "SELECT role FROM users WHERE id = $1",
-                user_id
+        # Check user is site ADMIN
+        user_role = await conn.fetchval(
+            "SELECT role FROM users WHERE id = $1",
+            user_id
+        )
+
+        if user_role != "ADMIN":
+            raise HTTPException(
+                status_code=403,
+                detail="Only site ADMIN users can delete instances"
             )
 
-            if user_role != "ADMIN":
-                raise HTTPException(
-                    status_code=403,
-                    detail="Only site ADMIN users can delete instances"
-                )
+        # Verify instance exists
+        instance_exists = await conn.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM instances WHERE id = $1)",
+            instance_id
+        )
 
-            # Verify instance exists
-            instance_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM instances WHERE id = $1)",
-                instance_id
-            )
+        if not instance_exists:
+            raise HTTPException(status_code=404, detail="Instance not found")
 
-            if not instance_exists:
-                raise HTTPException(status_code=404, detail="Instance not found")
+        # Delete instance
+        result = await conn.execute(
+            """
+            DELETE FROM instances WHERE id = $1
+            """,
+            instance_id,
+        )
 
-            # Delete instance
-            result = await conn.execute(
-                """
-                DELETE FROM instances WHERE id = $1
-                """,
-                instance_id,
-            )
+        if result == "DELETE 0":
+            raise HTTPException(status_code=404, detail="Instance not found")
 
-            if result == "DELETE 0":
-                raise HTTPException(status_code=404, detail="Instance not found")
+        clear_session_cache(instance_id)
 
-            clear_session_cache(instance_id)
-
-            return ApiResponse(
-                success=True,
-                message="Instance deleted successfully",
-            )
+        return ApiResponse(
+            success=True,
+            message="Instance deleted successfully",
+        )
 
     except HTTPException:
         raise
@@ -1398,22 +1335,17 @@ def _build_insert(table: str, columns: List[str], col_types: Dict[str, str], mer
 
 
 @router.post("/backup")
-async def create_backup(request: Request, body: BackupRequest):
+async def create_backup(request: Request, body: BackupRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Create an encrypted full backup of all VyManager configuration."""
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            await _require_backup_admin(conn, request)
+        await _require_backup_admin(conn, request)
 
-            tables: Dict[str, List[Dict[str, Any]]] = {}
-            for table in BACKUP_TABLES:
-                rows = await conn.fetch(f'SELECT * FROM "{table}"')
-                tables[table] = [
-                    {k: _json_safe(v) for k, v in row.items()} for row in rows
-                ]
+        tables: Dict[str, List[Dict[str, Any]]] = {}
+        for table in BACKUP_TABLES:
+            rows = await conn.fetch(f'SELECT * FROM "{table}"')
+            tables[table] = [
+                {k: _json_safe(v) for k, v in row.items()} for row in rows
+            ]
 
         payload = {
             "format_version": BACKUP_FORMAT_VERSION,
@@ -1454,17 +1386,13 @@ async def preview_restore(
     request: Request,
     file: UploadFile = File(...),
     passphrase: str = Form(...),
+    conn: asyncpg.Connection = Depends(org_conn_admin),
 ):
     """Decrypt a backup and report its contents without applying anything.
 
     Lets the restore UI validate the passphrase and show record counts first.
     """
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
-    async with db_pool.acquire() as conn:
-        await _require_backup_admin(conn, request)
+    await _require_backup_admin(conn, request)
 
     contents = await file.read()
     try:
@@ -1496,17 +1424,13 @@ async def restore_backup(
     file: UploadFile = File(...),
     passphrase: str = Form(...),
     mode: str = Form("merge"),
+    conn: asyncpg.Connection = Depends(org_conn_admin),
 ):
     """Restore a backup in "replace" (wipe + restore) or "merge" (upsert) mode."""
     if mode not in ("replace", "merge"):
         raise HTTPException(status_code=400, detail="mode must be 'replace' or 'merge'")
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
-    async with db_pool.acquire() as conn:
-        await _require_backup_admin(conn, request)
+    await _require_backup_admin(conn, request)
 
     contents = await file.read()
     try:
@@ -1543,51 +1467,50 @@ async def restore_backup(
     skipped_counts: Dict[str, int] = {}
     affected_instance_ids: List[str] = []
 
-    async with db_pool.acquire() as conn:
-        # Cache each table's real columns so we can cast text -> column type and
-        # ignore any backed-up columns that no longer exist in the schema.
-        col_types = {t: await _table_columns(conn, t) for t in BACKUP_TABLES}
+    # Cache each table's real columns so we can cast text -> column type and
+    # ignore any backed-up columns that no longer exist in the schema.
+    col_types = {t: await _table_columns(conn, t) for t in BACKUP_TABLES}
 
-        async with conn.transaction():
-            if mode == "replace":
-                for table in reversed(BACKUP_TABLES):
-                    await conn.execute(f'DELETE FROM "{table}"')
+    async with conn.transaction():
+        if mode == "replace":
+            for table in reversed(BACKUP_TABLES):
+                await conn.execute(f'DELETE FROM "{table}"')
 
-            for table in BACKUP_TABLES:
-                rows = tables.get(table, [])
-                types = col_types.get(table, {})
-                inserted = updated = skipped = 0
+        for table in BACKUP_TABLES:
+            rows = tables.get(table, [])
+            types = col_types.get(table, {})
+            inserted = updated = skipped = 0
 
-                for row in rows:
-                    columns = [c for c in row.keys() if c in types]
-                    if not columns:
-                        continue
-                    values = [_bind_value(row[c], types[c]) for c in columns]
-                    sql = _build_insert(table, columns, types, merge=(mode == "merge"))
+            for row in rows:
+                columns = [c for c in row.keys() if c in types]
+                if not columns:
+                    continue
+                values = [_bind_value(row[c], types[c]) for c in columns]
+                sql = _build_insert(table, columns, types, merge=(mode == "merge"))
 
-                    try:
-                        if mode == "merge":
-                            # Row-level savepoint so a natural-key collision skips
-                            # just this row instead of aborting the whole restore.
-                            async with conn.transaction():
-                                was_inserted = await conn.fetchval(sql, *values)
-                        else:
+                try:
+                    if mode == "merge":
+                        # Row-level savepoint so a natural-key collision skips
+                        # just this row instead of aborting the whole restore.
+                        async with conn.transaction():
                             was_inserted = await conn.fetchval(sql, *values)
-                    except asyncpg.UniqueViolationError:
-                        skipped += 1
-                        continue
-
-                    if was_inserted:
-                        inserted += 1
                     else:
-                        updated += 1
-                    if table == "instances":
-                        affected_instance_ids.append(row.get("id"))
+                        was_inserted = await conn.fetchval(sql, *values)
+                except asyncpg.UniqueViolationError:
+                    skipped += 1
+                    continue
 
-                inserted_counts[table] = inserted
-                updated_counts[table] = updated
-                if skipped:
-                    skipped_counts[table] = skipped
+                if was_inserted:
+                    inserted += 1
+                else:
+                    updated += 1
+                if table == "instances":
+                    affected_instance_ids.append(row.get("id"))
+
+            inserted_counts[table] = inserted
+            updated_counts[table] = updated
+            if skipped:
+                skipped_counts[table] = skipped
 
     for instance_id in affected_instance_ids:
         if instance_id:
@@ -1647,7 +1570,7 @@ class RevokeSessionRequest(BaseModel):
 
 
 @router.get("/auth-sessions", response_model=ActiveSessionsResponse)
-async def get_active_auth_sessions(request: Request):
+async def get_active_auth_sessions(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Get all active authentication sessions for the current user.
 
@@ -1666,44 +1589,39 @@ async def get_active_auth_sessions(request: Request):
     # Verify the signature and extract the session ID
     current_token = verify_session_cookie(cookie_token) if cookie_token else None
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Get all active sessions for this user from better-auth's session table
-            sessions = await conn.fetch(
-                """
-                SELECT token, "createdAt", "expiresAt", "ipAddress", "userAgent"
-                FROM sessions
-                WHERE "userId" = $1 AND "expiresAt" > NOW()
-                ORDER BY "createdAt" DESC
-                """,
-                user_id,
-            )
+        # Get all active sessions for this user from better-auth's session table
+        sessions = await conn.fetch(
+            """
+            SELECT token, "createdAt", "expiresAt", "ipAddress", "userAgent"
+            FROM sessions
+            WHERE "userId" = $1 AND "expiresAt" > NOW()
+            ORDER BY "createdAt" DESC
+            """,
+            user_id,
+        )
 
-            other_sessions = []
-            for session in sessions:
-                session_token = session["token"]
-                is_current = session_token == current_token
-                if not is_current:
-                    other_sessions.append(
-                        AuthSessionInfo(
-                            token=session["token"],
-                            created_at=session["createdAt"],
-                            expires_at=session["expiresAt"],
-                            ip_address=session["ipAddress"],
-                            user_agent=session["userAgent"],
-                            is_current=False,
-                        )
+        other_sessions = []
+        for session in sessions:
+            session_token = session["token"]
+            is_current = session_token == current_token
+            if not is_current:
+                other_sessions.append(
+                    AuthSessionInfo(
+                        token=session["token"],
+                        created_at=session["createdAt"],
+                        expires_at=session["expiresAt"],
+                        ip_address=session["ipAddress"],
+                        user_agent=session["userAgent"],
+                        is_current=False,
                     )
+                )
 
-            return ActiveSessionsResponse(
-                has_other_sessions=len(other_sessions) > 0,
-                current_session_token=current_token or "",
-                other_sessions=other_sessions,
-            )
+        return ActiveSessionsResponse(
+            has_other_sessions=len(other_sessions) > 0,
+            current_session_token=current_token or "",
+            other_sessions=other_sessions,
+        )
 
     except Exception as e:
         logger.exception("Unhandled error")
@@ -1711,7 +1629,7 @@ async def get_active_auth_sessions(request: Request):
 
 
 @router.post("/revoke-session", response_model=ApiResponse)
-async def revoke_auth_session(request: Request, body: RevokeSessionRequest):
+async def revoke_auth_session(request: Request, body: RevokeSessionRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Revoke a specific authentication session.
 
@@ -1733,46 +1651,41 @@ async def revoke_auth_session(request: Request, body: RevokeSessionRequest):
             detail="Cannot revoke your current session. Use logout instead.",
         )
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
     try:
-        async with db_pool.acquire() as conn:
-            # Verify the session belongs to this user before deleting
-            session_check = await conn.fetchrow(
-                """
-                SELECT "userId" FROM sessions
-                WHERE token = $1
-                """,
-                body.session_token,
+        # Verify the session belongs to this user before deleting
+        session_check = await conn.fetchrow(
+            """
+            SELECT "userId" FROM sessions
+            WHERE token = $1
+            """,
+            body.session_token,
+        )
+
+        if not session_check:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        if session_check["userId"] != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail="You can only revoke your own sessions",
             )
 
-            if not session_check:
-                raise HTTPException(status_code=404, detail="Session not found")
+        # Delete the session
+        result = await conn.execute(
+            """
+            DELETE FROM sessions
+            WHERE token = $1
+            """,
+            body.session_token,
+        )
 
-            if session_check["userId"] != user_id:
-                raise HTTPException(
-                    status_code=403,
-                    detail="You can only revoke your own sessions",
-                )
+        if result == "DELETE 0":
+            raise HTTPException(status_code=404, detail="Session not found")
 
-            # Delete the session
-            result = await conn.execute(
-                """
-                DELETE FROM sessions
-                WHERE token = $1
-                """,
-                body.session_token,
-            )
-
-            if result == "DELETE 0":
-                raise HTTPException(status_code=404, detail="Session not found")
-
-            return ApiResponse(
-                success=True,
-                message="Session revoked successfully",
-            )
+        return ApiResponse(
+            success=True,
+            message="Session revoked successfully",
+        )
 
     except HTTPException:
         raise

--- a/backend/routers/tokens/tokens.py
+++ b/backend/routers/tokens/tokens.py
@@ -7,7 +7,8 @@ automatically capped to that user's RBAC. The plaintext token is returned once
 at creation and never again; only its sha256 hash is stored.
 """
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import Depends, APIRouter, HTTPException, Request
+from org_scope import org_conn_admin
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime, timedelta
@@ -63,13 +64,6 @@ class TokenCreateResponse(BaseModel):
     metadata: TokenMetadata
 
 
-def _get_db_pool(request: Request) -> asyncpg.Pool:
-    pool = getattr(request.app.state, "db_pool", None)
-    if pool is None:
-        raise HTTPException(status_code=503, detail="Database connection not available")
-    return pool
-
-
 def _row_to_metadata(row: asyncpg.Record) -> TokenMetadata:
     return TokenMetadata(
         id=row["id"],
@@ -95,7 +89,7 @@ def _reject_read_only(request: Request) -> None:
 
 
 @router.post("", response_model=TokenCreateResponse)
-async def create_token(request: Request, body: TokenCreateRequest):
+async def create_token(request: Request, body: TokenCreateRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     user = get_current_user(request)
     _reject_read_only(request)
 
@@ -116,58 +110,52 @@ async def create_token(request: Request, body: TokenCreateRequest):
 
     plaintext, token_hash, prefix = generate_api_token()
 
-    db_pool = _get_db_pool(request)
-    async with db_pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            INSERT INTO api_tokens
-                (id, "userId", name, "tokenHash", prefix, scopes,
-                 "allowedInstanceIds", "allowedSiteIds", "expiresAt", "createdAt")
-            VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, NOW())
-            RETURNING id, name, prefix, scopes, "allowedInstanceIds", "allowedSiteIds",
-                      "lastUsedAt", "expiresAt", "revokedAt", "createdAt"
-            """,
-            user["id"], body.name, token_hash, prefix, scopes,
-            allowed_instance_ids, allowed_site_ids, expires_at,
-        )
+    row = await conn.fetchrow(
+        """
+        INSERT INTO api_tokens
+            (id, "userId", name, "tokenHash", prefix, scopes,
+             "allowedInstanceIds", "allowedSiteIds", "expiresAt", "createdAt")
+        VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, $7, $8, NOW())
+        RETURNING id, name, prefix, scopes, "allowedInstanceIds", "allowedSiteIds",
+                  "lastUsedAt", "expiresAt", "revokedAt", "createdAt"
+        """,
+        user["id"], body.name, token_hash, prefix, scopes,
+        allowed_instance_ids, allowed_site_ids, expires_at,
+    )
 
     logger.info("API token created for user %s (id=%s)", user["id"], row["id"])
     return TokenCreateResponse(token=plaintext, metadata=_row_to_metadata(row))
 
 
 @router.get("", response_model=List[TokenMetadata])
-async def list_tokens(request: Request):
+async def list_tokens(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     user = get_current_user(request)
-    db_pool = _get_db_pool(request)
-    async with db_pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, name, prefix, scopes, "allowedInstanceIds", "allowedSiteIds",
-                   "lastUsedAt", "expiresAt", "revokedAt", "createdAt"
-            FROM api_tokens
-            WHERE "userId" = $1
-            ORDER BY "createdAt" DESC
-            """,
-            user["id"],
-        )
+    rows = await conn.fetch(
+        """
+        SELECT id, name, prefix, scopes, "allowedInstanceIds", "allowedSiteIds",
+               "lastUsedAt", "expiresAt", "revokedAt", "createdAt"
+        FROM api_tokens
+        WHERE "userId" = $1
+        ORDER BY "createdAt" DESC
+        """,
+        user["id"],
+    )
     return [_row_to_metadata(r) for r in rows]
 
 
 @router.delete("/{token_id}")
-async def revoke_token(request: Request, token_id: str):
+async def revoke_token(request: Request, token_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     user = get_current_user(request)
     _reject_read_only(request)
-    db_pool = _get_db_pool(request)
-    async with db_pool.acquire() as conn:
-        # Scope the revoke to the caller's own tokens; null revokedAt = not yet revoked.
-        result = await conn.execute(
-            """
-            UPDATE api_tokens
-            SET "revokedAt" = NOW()
-            WHERE id = $1 AND "userId" = $2 AND "revokedAt" IS NULL
-            """,
-            token_id, user["id"],
-        )
+    # Scope the revoke to the caller's own tokens; null revokedAt = not yet revoked.
+    result = await conn.execute(
+        """
+        UPDATE api_tokens
+        SET "revokedAt" = NOW()
+        WHERE id = $1 AND "userId" = $2 AND "revokedAt" IS NULL
+        """,
+        token_id, user["id"],
+    )
 
     # asyncpg returns e.g. "UPDATE 1" / "UPDATE 0"; 0 rows = nothing to revoke.
     if int(result.split()[-1]) == 0:

--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -6,7 +6,8 @@ ADMIN only.
 """
 import os
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import Depends, APIRouter, HTTPException, Request
+from org_scope import org_conn_admin
 from pydantic import BaseModel, Field, EmailStr
 from typing import List, Dict, Optional, Any
 from datetime import datetime
@@ -137,7 +138,7 @@ class AssignmentResponse(BaseModel):
 # ============================================================================
 
 @router.get("/my-permissions", response_model=MyPermissionsResponse)
-async def get_my_permissions(request: Request):
+async def get_my_permissions(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Get the current user's permissions for their active instance.
 
@@ -149,187 +150,173 @@ async def get_my_permissions(request: Request):
     if not user:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    # Get user's active session to find which instance they're connected to
+    active_session = await conn.fetchrow(
+        """
+        SELECT "instanceId"
+        FROM active_sessions
+        WHERE "userId" = $1
+        LIMIT 1
+        """,
+        user["id"]
+    )
 
-    async with db_pool.acquire() as conn:
-        # Get user's active session to find which instance they're connected to
-        active_session = await conn.fetchrow(
-            """
-            SELECT "instanceId"
-            FROM active_sessions
-            WHERE "userId" = $1
-            LIMIT 1
-            """,
-            user["id"]
-        )
+    if not active_session:
+        # User has no active session - return empty permissions
+        return MyPermissionsResponse(has_active_session=False, permissions={})
 
-        if not active_session:
-            # User has no active session - return empty permissions
-            return MyPermissionsResponse(has_active_session=False, permissions={})
+    instance_id = active_session["instanceId"]
 
-        instance_id = active_session["instanceId"]
+    # Get user's permissions for this instance
+    permissions = await get_user_permissions(conn, user["id"], instance_id)
 
-        # Get user's permissions for this instance
-        permissions = await get_user_permissions(db_pool, user["id"], instance_id)
+    # Convert enum values to strings for JSON serialization
+    permissions_dict = {
+        feature.value: level.value
+        for feature, level in permissions.items()
+    }
 
-        # Convert enum values to strings for JSON serialization
-        permissions_dict = {
-            feature.value: level.value
-            for feature, level in permissions.items()
-        }
-
-        return MyPermissionsResponse(
-            has_active_session=True,
-            instance_id=instance_id,
-            permissions=permissions_dict,
-        )
+    return MyPermissionsResponse(
+        has_active_session=True,
+        instance_id=instance_id,
+        permissions=permissions_dict,
+    )
 
 
 @router.get("/users", response_model=List[UserListItem])
-async def list_users(request: Request):
+async def list_users(request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Get list of all users with their instance counts and site roles."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    users = await conn.fetch(
+        """
+        SELECT
+            u.id,
+            u.name,
+            u.email,
+            u."emailVerified" as email_verified,
+            u."createdAt" as created_at,
+            u.role as site_role,
+            COUNT(DISTINCT uir."instanceId") as instance_count,
+            EXISTS (
+                SELECT 1 FROM accounts acc
+                JOIN oauth_providers op ON op."providerId" = acc."providerId"
+                WHERE acc."userId" = u.id AND op."roleMappingEnabled" = true
+            ) as sso_role_managed
+        FROM users u
+        LEFT JOIN user_instance_roles uir ON u.id = uir."userId"
+        GROUP BY u.id, u.name, u.email, u."emailVerified", u."createdAt", u.role
+        ORDER BY u."createdAt" DESC
+        """
+    )
 
-    async with db_pool.acquire() as conn:
-        users = await conn.fetch(
-            """
-            SELECT
-                u.id,
-                u.name,
-                u.email,
-                u."emailVerified" as email_verified,
-                u."createdAt" as created_at,
-                u.role as site_role,
-                COUNT(DISTINCT uir."instanceId") as instance_count,
-                EXISTS (
-                    SELECT 1 FROM accounts acc
-                    JOIN oauth_providers op ON op."providerId" = acc."providerId"
-                    WHERE acc."userId" = u.id AND op."roleMappingEnabled" = true
-                ) as sso_role_managed
-            FROM users u
-            LEFT JOIN user_instance_roles uir ON u.id = uir."userId"
-            GROUP BY u.id, u.name, u.email, u."emailVerified", u."createdAt", u.role
-            ORDER BY u."createdAt" DESC
-            """
-        )
-
-        return [UserListItem(
-            id=user["id"],
-            name=user["name"],
-            email=user["email"],
-            email_verified=user["email_verified"],
-            created_at=user["created_at"],
-            instance_count=user["instance_count"],
-            site_role=user["site_role"],
-            sso_role_managed=user["sso_role_managed"]
-        ) for user in users]
+    return [UserListItem(
+        id=user["id"],
+        name=user["name"],
+        email=user["email"],
+        email_verified=user["email_verified"],
+        created_at=user["created_at"],
+        instance_count=user["instance_count"],
+        site_role=user["site_role"],
+        sso_role_managed=user["sso_role_managed"]
+    ) for user in users]
 
 
 @router.get("/users/{user_id}", response_model=UserDetail)
-async def get_user(request: Request, user_id: str):
+async def get_user(request: Request, user_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Get detailed information about a specific user."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    user = await conn.fetchrow(
+        """
+        SELECT id, name, email, "emailVerified" as email_verified,
+               "createdAt" as created_at, "updatedAt" as updated_at
+        FROM users
+        WHERE id = $1
+        """,
+        user_id
+    )
 
-    async with db_pool.acquire() as conn:
-        user = await conn.fetchrow(
-            """
-            SELECT id, name, email, "emailVerified" as email_verified,
-                   "createdAt" as created_at, "updatedAt" as updated_at
-            FROM users
-            WHERE id = $1
-            """,
-            user_id
-        )
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
 
-        if not user:
-            raise HTTPException(status_code=404, detail="User not found")
-
-        return UserDetail(**dict(user))
+    return UserDetail(**dict(user))
 
 
 @router.get("/users/{user_id}/assignments", response_model=List[UserInstanceAssignment])
-async def get_user_assignments(request: Request, user_id: str):
+async def get_user_assignments(request: Request, user_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Get all instance assignments for a specific user."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    assignments = await conn.fetch(
+        """
+        SELECT
+            uir.id,
+            uir."userId" as user_id,
+            uir."instanceId" as instance_id,
+            i.name as instance_name,
+            COALESCE(uir."siteId", i."siteId") as site_id,
+            COALESCE(sg.name, s.name) as site_name,
+            (uir."siteId" IS NOT NULL) as is_site_grant,
+            uir.role,
+            uir."createdAt" as assigned_at,
+            uir."assignedBy" as assigned_by
+        FROM user_instance_roles uir
+        LEFT JOIN instances i ON uir."instanceId" = i.id
+        LEFT JOIN sites s ON i."siteId" = s.id
+        LEFT JOIN sites sg ON uir."siteId" = sg.id
+        WHERE uir."userId" = $1
+        ORDER BY COALESCE(sg.name, s.name), i.name NULLS FIRST
+        """,
+        user_id
+    )
 
-    async with db_pool.acquire() as conn:
-        assignments = await conn.fetch(
+    result = []
+    for assignment in assignments:
+        # Get feature permissions for this assignment
+        feature_perms = await conn.fetch(
             """
-            SELECT
-                uir.id,
-                uir."userId" as user_id,
-                uir."instanceId" as instance_id,
-                i.name as instance_name,
-                COALESCE(uir."siteId", i."siteId") as site_id,
-                COALESCE(sg.name, s.name) as site_name,
-                (uir."siteId" IS NOT NULL) as is_site_grant,
-                uir.role,
-                uir."createdAt" as assigned_at,
-                uir."assignedBy" as assigned_by
-            FROM user_instance_roles uir
-            LEFT JOIN instances i ON uir."instanceId" = i.id
-            LEFT JOIN sites s ON i."siteId" = s.id
-            LEFT JOIN sites sg ON uir."siteId" = sg.id
-            WHERE uir."userId" = $1
-            ORDER BY COALESCE(sg.name, s.name), i.name NULLS FIRST
+            SELECT feature, "canEdit" as can_edit, "canView" as can_view
+            FROM user_feature_permissions
+            WHERE "userInstanceRoleId" = $1
             """,
-            user_id
+            assignment["id"]
         )
 
-        result = []
-        for assignment in assignments:
-            # Get feature permissions for this assignment
-            feature_perms = await conn.fetch(
-                """
-                SELECT feature, "canEdit" as can_edit, "canView" as can_view
-                FROM user_feature_permissions
-                WHERE "userInstanceRoleId" = $1
-                """,
-                assignment["id"]
+        permissions = [
+            FeaturePermissionItem(
+                feature=fp["feature"],
+                can_edit=fp["can_edit"],
+                can_view=fp["can_view"]
             )
+            for fp in feature_perms
+        ]
 
-            permissions = [
-                FeaturePermissionItem(
-                    feature=fp["feature"],
-                    can_edit=fp["can_edit"],
-                    can_view=fp["can_view"]
-                )
-                for fp in feature_perms
-            ]
+        result.append(UserInstanceAssignment(
+            id=assignment["id"],
+            user_id=assignment["user_id"],
+            instance_id=assignment["instance_id"],
+            instance_name=assignment["instance_name"],
+            site_id=assignment["site_id"],
+            site_name=assignment["site_name"],
+            is_site_grant=assignment["is_site_grant"],
+            role=assignment["role"],
+            feature_permissions=permissions,
+            assigned_at=assignment["assigned_at"],
+            assigned_by=assignment["assigned_by"]
+        ))
 
-            result.append(UserInstanceAssignment(
-                id=assignment["id"],
-                user_id=assignment["user_id"],
-                instance_id=assignment["instance_id"],
-                instance_name=assignment["instance_name"],
-                site_id=assignment["site_id"],
-                site_name=assignment["site_name"],
-                is_site_grant=assignment["is_site_grant"],
-                role=assignment["role"],
-                feature_permissions=permissions,
-                assigned_at=assignment["assigned_at"],
-                assigned_by=assignment["assigned_by"]
-            ))
-
-        return result
+    return result
 
 
 @router.post("/users", response_model=UserDetail)
-async def create_user(request: Request, body: CreateUserRequest):
+async def create_user(request: Request, body: CreateUserRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Create a new user by calling Better Auth's internal API.
     This ensures password hashing is handled correctly by Better Auth.
     Then sets the site role in the database.
     """
     await require_super_admin(request)
-
-    db_pool: asyncpg.Pool = request.app.state.db_pool
 
     # Validate site_role
     if body.site_role not in ["ADMIN", "VIEWER"]:
@@ -373,39 +360,38 @@ async def create_user(request: Request, body: CreateUserRequest):
             )
 
     # Set the site role in the database
-    async with db_pool.acquire() as conn:
-        await conn.execute(
-            """
-            UPDATE users
-            SET role = $1, "updatedAt" = NOW()
-            WHERE id = $2
-            """,
-            body.site_role,
-            user_id
+    await conn.execute(
+        """
+        UPDATE users
+        SET role = $1, "updatedAt" = NOW()
+        WHERE id = $2
+        """,
+        body.site_role,
+        user_id
+    )
+
+    # Fetch the created user from database
+    user = await conn.fetchrow(
+        """
+        SELECT id, name, email, "emailVerified" as email_verified,
+               "createdAt" as created_at, "updatedAt" as updated_at
+        FROM users
+        WHERE id = $1
+        """,
+        user_id
+    )
+
+    if not user:
+        raise HTTPException(
+            status_code=500,
+            detail="User was created but not found in database"
         )
 
-        # Fetch the created user from database
-        user = await conn.fetchrow(
-            """
-            SELECT id, name, email, "emailVerified" as email_verified,
-                   "createdAt" as created_at, "updatedAt" as updated_at
-            FROM users
-            WHERE id = $1
-            """,
-            user_id
-        )
-
-        if not user:
-            raise HTTPException(
-                status_code=500,
-                detail="User was created but not found in database"
-            )
-
-        return UserDetail(**dict(user))
+    return UserDetail(**dict(user))
 
 
 @router.put("/users/{user_id}", response_model=UserDetail)
-async def update_user(request: Request, user_id: str, body: UpdateUserRequest):
+async def update_user(request: Request, user_id: str, body: UpdateUserRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """
     Update a user.
 
@@ -414,96 +400,91 @@ async def update_user(request: Request, user_id: str, body: UpdateUserRequest):
     """
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    # Check if user exists
+    existing = await conn.fetchval("SELECT id FROM users WHERE id = $1", user_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="User not found")
 
-    async with db_pool.acquire() as conn:
-        # Check if user exists
-        existing = await conn.fetchval("SELECT id FROM users WHERE id = $1", user_id)
-        if not existing:
-            raise HTTPException(status_code=404, detail="User not found")
+    # Validate site_role if provided
+    if body.site_role is not None and body.site_role not in ["ADMIN", "VIEWER"]:
+        raise HTTPException(status_code=400, detail="site_role must be ADMIN or VIEWER")
 
-        # Validate site_role if provided
-        if body.site_role is not None and body.site_role not in ["ADMIN", "VIEWER"]:
-            raise HTTPException(status_code=400, detail="site_role must be ADMIN or VIEWER")
+    # Update user
+    updates = []
+    params = []
+    param_count = 1
 
-        # Update user
-        updates = []
-        params = []
-        param_count = 1
+    if body.name is not None:
+        updates.append(f'name = ${param_count}')
+        params.append(body.name)
+        param_count += 1
 
-        if body.name is not None:
-            updates.append(f'name = ${param_count}')
-            params.append(body.name)
-            param_count += 1
-
-        if body.email is not None:
-            # Check if new email already exists
-            email_exists = await conn.fetchval(
-                "SELECT id FROM users WHERE email = $1 AND id != $2",
-                body.email,
-                user_id
-            )
-            if email_exists:
-                raise HTTPException(status_code=400, detail="Email already exists")
-
-            updates.append(f'email = ${param_count}')
-            params.append(body.email)
-            param_count += 1
-
-        if body.site_role is not None:
-            updates.append(f'role = ${param_count}')
-            params.append(body.site_role)
-            param_count += 1
-
-        if body.password is not None:
-            # Password updates not supported - require password reset flow
-            raise HTTPException(
-                status_code=400,
-                detail="Password updates not supported. Please use the password reset flow."
-            )
-
-        if updates:
-            updates.append(f'"updatedAt" = NOW()')
-            params.append(user_id)
-            query = f"UPDATE users SET {', '.join(updates)} WHERE id = ${param_count}"
-            await conn.execute(query, *params)
-
-        # Fetch updated user
-        user = await conn.fetchrow(
-            """
-            SELECT id, name, email, "emailVerified" as email_verified,
-                   "createdAt" as created_at, "updatedAt" as updated_at
-            FROM users
-            WHERE id = $1
-            """,
+    if body.email is not None:
+        # Check if new email already exists
+        email_exists = await conn.fetchval(
+            "SELECT id FROM users WHERE email = $1 AND id != $2",
+            body.email,
             user_id
         )
+        if email_exists:
+            raise HTTPException(status_code=400, detail="Email already exists")
 
-        return UserDetail(**dict(user))
+        updates.append(f'email = ${param_count}')
+        params.append(body.email)
+        param_count += 1
+
+    if body.site_role is not None:
+        updates.append(f'role = ${param_count}')
+        params.append(body.site_role)
+        param_count += 1
+
+    if body.password is not None:
+        # Password updates not supported - require password reset flow
+        raise HTTPException(
+            status_code=400,
+            detail="Password updates not supported. Please use the password reset flow."
+        )
+
+    if updates:
+        updates.append(f'"updatedAt" = NOW()')
+        params.append(user_id)
+        query = f"UPDATE users SET {', '.join(updates)} WHERE id = ${param_count}"
+        await conn.execute(query, *params)
+
+    # Fetch updated user
+    user = await conn.fetchrow(
+        """
+        SELECT id, name, email, "emailVerified" as email_verified,
+               "createdAt" as created_at, "updatedAt" as updated_at
+        FROM users
+        WHERE id = $1
+        """,
+        user_id
+    )
+
+    return UserDetail(**dict(user))
 
 
 @router.delete("/users/{user_id}", response_model=SuccessResponse)
-async def delete_user(request: Request, user_id: str):
+async def delete_user(request: Request, user_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Delete a user."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
     current_user = request.state.user
 
     # Prevent self-deletion
     if user_id == current_user["id"]:
         raise HTTPException(status_code=400, detail="Cannot delete your own account")
 
-    async with db_pool.acquire() as conn:
-        # Check if user exists
-        existing = await conn.fetchval("SELECT id FROM users WHERE id = $1", user_id)
-        if not existing:
-            raise HTTPException(status_code=404, detail="User not found")
+    # Check if user exists
+    existing = await conn.fetchval("SELECT id FROM users WHERE id = $1", user_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="User not found")
 
-        # Delete user (cascades to sessions, accounts, user_instance_roles, etc.)
-        await conn.execute("DELETE FROM users WHERE id = $1", user_id)
+    # Delete user (cascades to sessions, accounts, user_instance_roles, etc.)
+    await conn.execute("DELETE FROM users WHERE id = $1", user_id)
 
-        return SuccessResponse(success=True, message="User deleted successfully")
+    return SuccessResponse(success=True, message="User deleted successfully")
 
 
 # ============================================================================
@@ -511,178 +492,170 @@ async def delete_user(request: Request, user_id: str):
 # ============================================================================
 
 @router.post("/assignments", response_model=AssignmentResponse)
-async def assign_user_to_instances(request: Request, body: AssignUserRequest):
+async def assign_user_to_instances(request: Request, body: AssignUserRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Assign a user to instance(s) with a role and optional feature permissions."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
     current_user = request.state.user
 
     # Validate role
     if body.role not in ["ADMIN", "OPERATOR", "VIEWER"]:
         raise HTTPException(status_code=400, detail="role must be ADMIN, OPERATOR, or VIEWER")
 
-    async with db_pool.acquire() as conn:
-        # Verify user exists
-        user_exists = await conn.fetchval("SELECT id FROM users WHERE id = $1", body.user_id)
-        if not user_exists:
-            raise HTTPException(status_code=404, detail="User not found")
+    # Verify user exists
+    user_exists = await conn.fetchval("SELECT id FROM users WHERE id = $1", body.user_id)
+    if not user_exists:
+        raise HTTPException(status_code=404, detail="User not found")
 
-        # Verify instances exist
-        for instance_id in body.instance_ids:
-            if not await conn.fetchval("SELECT id FROM instances WHERE id = $1", instance_id):
-                raise HTTPException(status_code=404, detail=f"Instance {instance_id} not found")
+    # Verify instances exist
+    for instance_id in body.instance_ids:
+        if not await conn.fetchval("SELECT id FROM instances WHERE id = $1", instance_id):
+            raise HTTPException(status_code=404, detail=f"Instance {instance_id} not found")
 
-        # Verify sites exist
-        for site_id in body.site_ids:
-            if not await conn.fetchval("SELECT id FROM sites WHERE id = $1", site_id):
-                raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
+    # Verify sites exist
+    for site_id in body.site_ids:
+        if not await conn.fetchval("SELECT id FROM sites WHERE id = $1", site_id):
+            raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
 
-        async def insert_feature_perms(assignment_id: str):
-            # Feature permissions only apply to OPERATOR/VIEWER.
-            if not body.feature_permissions:
-                return
-            for perm in body.feature_permissions:
-                await conn.execute(
-                    """
-                    INSERT INTO user_feature_permissions
-                    (id, "userInstanceRoleId", feature, "canEdit", "canView", "createdAt")
-                    VALUES (gen_random_uuid()::text, $1, $2, $3, $4, NOW())
-                    """,
-                    assignment_id, perm.feature, perm.can_edit, perm.can_view,
-                )
-
-        assignments_created = 0
-
-        # Per-instance grants
-        for instance_id in body.instance_ids:
-            existing = await conn.fetchval(
-                'SELECT id FROM user_instance_roles WHERE "userId" = $1 AND "instanceId" = $2',
-                body.user_id, instance_id,
-            )
-            if existing:
-                continue
-            assignment_id = await conn.fetchval(
+    async def insert_feature_perms(assignment_id: str):
+        # Feature permissions only apply to OPERATOR/VIEWER.
+        if not body.feature_permissions:
+            return
+        for perm in body.feature_permissions:
+            await conn.execute(
                 """
-                INSERT INTO user_instance_roles
-                (id, "userId", "instanceId", role, "createdAt", "updatedAt", "assignedBy")
-                VALUES (gen_random_uuid()::text, $1, $2, $3, NOW(), NOW(), $4)
-                RETURNING id
+                INSERT INTO user_feature_permissions
+                (id, "userInstanceRoleId", feature, "canEdit", "canView", "createdAt")
+                VALUES (gen_random_uuid()::text, $1, $2, $3, $4, NOW())
                 """,
-                body.user_id, instance_id, body.role, current_user["id"],
+                assignment_id, perm.feature, perm.can_edit, perm.can_view,
             )
-            await insert_feature_perms(assignment_id)
-            assignments_created += 1
 
-        # Whole-site grants (cover every instance in the site, incl. future ones)
-        for site_id in body.site_ids:
-            existing = await conn.fetchval(
-                'SELECT id FROM user_instance_roles WHERE "userId" = $1 AND "siteId" = $2',
-                body.user_id, site_id,
-            )
-            if existing:
-                continue
-            assignment_id = await conn.fetchval(
-                """
-                INSERT INTO user_instance_roles
-                (id, "userId", "siteId", role, "createdAt", "updatedAt", "assignedBy")
-                VALUES (gen_random_uuid()::text, $1, $2, $3, NOW(), NOW(), $4)
-                RETURNING id
-                """,
-                body.user_id, site_id, body.role, current_user["id"],
-            )
-            await insert_feature_perms(assignment_id)
-            assignments_created += 1
+    assignments_created = 0
 
-        return AssignmentResponse(
-            success=True,
-            assignments_created=assignments_created,
-            message=f"Created {assignments_created} grant(s) successfully",
+    # Per-instance grants
+    for instance_id in body.instance_ids:
+        existing = await conn.fetchval(
+            'SELECT id FROM user_instance_roles WHERE "userId" = $1 AND "instanceId" = $2',
+            body.user_id, instance_id,
         )
+        if existing:
+            continue
+        assignment_id = await conn.fetchval(
+            """
+            INSERT INTO user_instance_roles
+            (id, "userId", "instanceId", role, "createdAt", "updatedAt", "assignedBy")
+            VALUES (gen_random_uuid()::text, $1, $2, $3, NOW(), NOW(), $4)
+            RETURNING id
+            """,
+            body.user_id, instance_id, body.role, current_user["id"],
+        )
+        await insert_feature_perms(assignment_id)
+        assignments_created += 1
+
+    # Whole-site grants (cover every instance in the site, incl. future ones)
+    for site_id in body.site_ids:
+        existing = await conn.fetchval(
+            'SELECT id FROM user_instance_roles WHERE "userId" = $1 AND "siteId" = $2',
+            body.user_id, site_id,
+        )
+        if existing:
+            continue
+        assignment_id = await conn.fetchval(
+            """
+            INSERT INTO user_instance_roles
+            (id, "userId", "siteId", role, "createdAt", "updatedAt", "assignedBy")
+            VALUES (gen_random_uuid()::text, $1, $2, $3, NOW(), NOW(), $4)
+            RETURNING id
+            """,
+            body.user_id, site_id, body.role, current_user["id"],
+        )
+        await insert_feature_perms(assignment_id)
+        assignments_created += 1
+
+    return AssignmentResponse(
+        success=True,
+        assignments_created=assignments_created,
+        message=f"Created {assignments_created} grant(s) successfully",
+    )
 
 
 @router.delete("/assignments/{assignment_id}", response_model=SuccessResponse)
-async def remove_assignment(request: Request, assignment_id: str):
+async def remove_assignment(request: Request, assignment_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Remove a user's access to an instance."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    # Check if assignment exists
+    existing = await conn.fetchval("SELECT id FROM user_instance_roles WHERE id = $1", assignment_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Assignment not found")
 
-    async with db_pool.acquire() as conn:
-        # Check if assignment exists
-        existing = await conn.fetchval("SELECT id FROM user_instance_roles WHERE id = $1", assignment_id)
-        if not existing:
-            raise HTTPException(status_code=404, detail="Assignment not found")
+    # Delete assignment
+    await conn.execute("DELETE FROM user_instance_roles WHERE id = $1", assignment_id)
 
-        # Delete assignment
-        await conn.execute("DELETE FROM user_instance_roles WHERE id = $1", assignment_id)
-
-        return SuccessResponse(success=True, message="Assignment removed successfully")
+    return SuccessResponse(success=True, message="Assignment removed successfully")
 
 
 @router.get("/instances/{instance_id}/users", response_model=List[InstanceUserListItem])
-async def get_instance_users(request: Request, instance_id: str):
+async def get_instance_users(request: Request, instance_id: str, conn: asyncpg.Connection = Depends(org_conn_admin)):
     """Get all users with access to a specific instance."""
     await require_super_admin(request)
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
+    # Verify instance exists
+    instance_exists = await conn.fetchval("SELECT id FROM instances WHERE id = $1", instance_id)
+    if not instance_exists:
+        raise HTTPException(status_code=404, detail="Instance not found")
 
-    async with db_pool.acquire() as conn:
-        # Verify instance exists
-        instance_exists = await conn.fetchval("SELECT id FROM instances WHERE id = $1", instance_id)
-        if not instance_exists:
-            raise HTTPException(status_code=404, detail="Instance not found")
+    # Get users with access and their instance roles
+    users_data = await conn.fetch(
+        """
+        SELECT DISTINCT
+            u.id as user_id,
+            u.name as user_name,
+            u.email as user_email,
+            uir.role as instance_role,
+            uir.id as assignment_id
+        FROM users u
+        JOIN user_instance_roles uir ON u.id = uir."userId"
+        WHERE uir."instanceId" = $1
+        ORDER BY u.name, u.email
+        """,
+        instance_id
+    )
 
-        # Get users with access and their instance roles
-        users_data = await conn.fetch(
-            """
-            SELECT DISTINCT
-                u.id as user_id,
-                u.name as user_name,
-                u.email as user_email,
-                uir.role as instance_role,
-                uir.id as assignment_id
-            FROM users u
-            JOIN user_instance_roles uir ON u.id = uir."userId"
-            WHERE uir."instanceId" = $1
-            ORDER BY u.name, u.email
-            """,
-            instance_id
-        )
+    result = []
+    for user in users_data:
+        role = user["instance_role"]
+        feature_permissions = None
 
-        result = []
-        for user in users_data:
-            role = user["instance_role"]
-            feature_permissions = None
+        # For OPERATOR/VIEWER roles, fetch feature permissions
+        if role in ["OPERATOR", "VIEWER"]:
+            perms_data = await conn.fetch(
+                """
+                SELECT feature, "canEdit" as can_edit, "canView" as can_view
+                FROM user_feature_permissions
+                WHERE "userInstanceRoleId" = $1
+                ORDER BY feature
+                """,
+                user["assignment_id"]
+            )
 
-            # For OPERATOR/VIEWER roles, fetch feature permissions
-            if role in ["OPERATOR", "VIEWER"]:
-                perms_data = await conn.fetch(
-                    """
-                    SELECT feature, "canEdit" as can_edit, "canView" as can_view
-                    FROM user_feature_permissions
-                    WHERE "userInstanceRoleId" = $1
-                    ORDER BY feature
-                    """,
-                    user["assignment_id"]
-                )
+            if perms_data:
+                feature_permissions = [
+                    FeaturePermissionItem(
+                        feature=perm["feature"],
+                        can_edit=perm["can_edit"],
+                        can_view=perm["can_view"]
+                    )
+                    for perm in perms_data
+                ]
 
-                if perms_data:
-                    feature_permissions = [
-                        FeaturePermissionItem(
-                            feature=perm["feature"],
-                            can_edit=perm["can_edit"],
-                            can_view=perm["can_view"]
-                        )
-                        for perm in perms_data
-                    ]
+        result.append(InstanceUserListItem(
+            user_id=user["user_id"],
+            user_name=user["user_name"],
+            user_email=user["user_email"],
+            role=role,
+            feature_permissions=feature_permissions
+        ))
 
-            result.append(InstanceUserListItem(
-                user_id=user["user_id"],
-                user_name=user["user_name"],
-                user_email=user["user_email"],
-                role=role,
-                feature_permissions=feature_permissions
-            ))
-
-        return result
+    return result


### PR DESCRIPTION
Second PR of the org-scoped connection plumbing stack (follows #443; organization-system groundwork, design docs to follow on docs.vyprojects.org). **Base is `feat/org-conn-core` because #443 is not yet merged** — after #443 merges I retarget this to `beta`.

## What

All 31 handler-level pool acquisitions in `session`, `user-management` and `tokens` routers move to `Depends(org_conn_admin)`: the whole handler body is one unit of work inside a transaction carrying the request's org context. **The raw diff is dominated by mechanical dedent — review with whitespace ignored** (`git diff -w`: ~300 lines).

`org_conn_admin` extends the core dependency for endpoints that have no active instance:
- optional `org_id` query parameter names the organization to act in — must exist (404), and non-operators must be members (403); System Administrators may act in any org;
- absent the parameter, the caller's sole membership is the default; no membership → the `''` no-context sentinel (nothing filters on it until enforcement);
- deployment role + sole-org default resolve in a single round trip — the dependency runs on every admin request;
- the per-handler "database not available" 503 guard moved into the dependency.

Notable semantics, both deliberate:
- **Restore** now runs inside one transaction (row-level savepoints unchanged): a mid-restore failure rolls back instead of leaving partial data. Strict improvement, invisible on success.
- **Connect** keeps its pre-existing shape of holding a connection across the VyOS reachability test — user-driven, low-frequency; converting it to multiple units would change behavior for no gain.

## Evidence

- **Golden invisibility**: captured running the base branch code, compared running this branch — permission output byte-identical.
- **Endpoint probes** (real app + database, signed session cookies), 14/14: sites list as operator and as granted member; `org_id=default` 200; unknown org 404; non-member org 403; operator acting in a foreign org 200; users list (admin 200 / non-admin 403); my-permissions with an active instance (levels correct incl. parent propagation); token create/list/revoke; backup create; onboarding-status.
- **Suite**: 71 passed, 0 skipped with a database; 66/5 without.

## Perf — over budget, decision needed before merge

p50/p95 over 300 warm in-process requests, local Postgres, baseline = before this stack:

| Endpoint | baseline p50 | stack p50 | delta |
|---|---|---|---|
| GET /session/sites | 1.10 ms | 1.27 ms | **+0.17 ms (+15.5%)** |
| GET /user-management/my-permissions | 1.78 ms | 1.98 ms | +0.20 ms (+11%, within run-to-run noise of the earlier 1.90 ms measurement) |

The agreed ~10% p50 budget is exceeded on `/session/sites` even after folding role+org resolution into one round trip. The remaining overhead is the structural floor of the design: BEGIN + `set_config` + COMMIT round trips that the row-level-security model requires. Escalated in review rather than tuned away silently — see the review thread for options.

## For the reviewer

Read `org_scope.py` first; then `git diff -w` for the routers. The invariant: no handler in these three files touches the pool directly anymore.