### PR TITLE
test: add adversarial suite skeleton with unscoped-connection canary

### DIFF
--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -1,0 +1,43 @@
+"""Reviewed allowlist for the unscoped-connection canary.
+
+Every file that resolves a database connection outside the org_scope
+primitives must be listed here with a justification. Any ADDITION to
+either list must carry its justification in the PR that makes it —
+widening the boundary is a visible, reviewed decision, never a silent
+one. The canary also fails on STALE entries (file listed but clean), so
+the burn-down list cannot rot.
+"""
+
+# Files that legitimately access the pool outside org scoping, forever.
+PERMANENT_GLOBAL = {
+    "middleware/auth.py":
+        "Identity resolution (sessions/users/api_tokens) necessarily "
+        "precedes org context; the org is derived FROM the "
+        "authenticated user.",
+    "middleware/session.py":
+        "The resolver that CREATES org context must query "
+        "instances/sites to derive it.",
+    "app.py":
+        "Pool lifecycle and the session-cleanup background task: no "
+        "request, no org; deployment-wide janitor by nature.",
+    "org_scope.py":
+        "The sanctioned primitive itself - every org-scoped "
+        "acquisition goes through it.",
+}
+
+# Files not yet migrated to org-scoped connections. Each conversion wave
+# removes its entries; the target end state is an empty dict.
+MIGRATION_PENDING = {
+    # Wave B - streaming/scheduling surfaces (per-tick scoped connections)
+    "routers/events.py": "SSE poll tick",
+    "routers/monitoring/monitoring.py": "SSH monitoring streams",
+    "routers/console/console.py": "console websocket sessions",
+    "routers/power.py": "scheduled power actions",
+    # Wave C - remaining DB-backed handlers
+    "middleware/audit.py": "audit log writes",
+    "routers/firewall/separators.py": "separator CRUD",
+    "routers/dashboard.py": "dashboard layouts",
+    "routers/container/container.py": "container feature state",
+    "routers/site_updates/site_updates.py": "site update polling",
+    "routers/show.py": "SSE stream session revalidation tick",
+}

--- a/backend/tests/adversarial/conftest.py
+++ b/backend/tests/adversarial/conftest.py
@@ -1,0 +1,165 @@
+"""Two-organization world for the adversarial suite.
+
+Seeds two organizations with sites, instances, users and grants directly
+in SQL (the org tables exist since the schema migration; org management
+endpoints do not exist yet and are not needed for seeding). Everything is
+torn down afterwards. All fixtures skip without DATABASE_URL.
+
+The golden-file harness (tests/test_permission_golden.py) is the
+equivalence stage of this suite: capture before a migration, compare
+after. It shares the pytest invocation; nothing to wire here.
+"""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import os
+
+import pytest
+
+SECRET = b"adversarial-local-secret"
+
+USERS = {
+    # deployment operator (System Administrator)
+    "sys": ("adv_sys", "tok_adv_sys", "ADMIN"),
+    # org-A ADMIN by membership only - deployment role stays VIEWER
+    "a_admin": ("adv_a_admin", "tok_adv_a_admin", "VIEWER"),
+    # org-A MEMBER with an OPERATOR grant on one org-A instance
+    "a_member": ("adv_a_member", "tok_adv_a_member", "VIEWER"),
+    # org-B MEMBER with a grant on the org-B instance
+    "b_member": ("adv_b_member", "tok_adv_b_member", "VIEWER"),
+}
+
+IDS = {
+    "org_a": "adv_org_a",
+    "org_b": "adv_org_b",
+    "site_a": "s_adv_a",
+    "site_b": "s_adv_b",
+    "instance_a": "i_adv_a1",
+    "instance_b": "i_adv_b1",
+    "grant_a": "g_adv_a1",
+    "grant_b": "g_adv_b1",
+}
+
+
+def signed_cookie(token: str) -> str:
+    signature = base64.b64encode(
+        hmac.new(SECRET, token.encode(), hashlib.sha256).digest()).decode()
+    return f"{token}.{signature}"
+
+
+def as_user(client, key: str):
+    """Point the shared client's session cookie at one of the seeded users."""
+    token = USERS[key][1]
+    client.cookies.set("better-auth.session_token", signed_cookie(token))
+    return client
+
+
+async def _seed(db_url: str) -> None:
+    import asyncpg
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(
+            """
+            INSERT INTO organizations (id, name, "createdAt", "updatedAt")
+            VALUES ($1, 'Adversarial Org A', NOW(), NOW()),
+                   ($2, 'Adversarial Org B', NOW(), NOW())
+            """, IDS["org_a"], IDS["org_b"])
+        for user_id, token, role in USERS.values():
+            await conn.execute(
+                """
+                INSERT INTO users (id, email, name, role, "emailVerified",
+                                   "createdAt", "updatedAt")
+                VALUES ($1, $1 || '@adversarial.test', $1, $2, true,
+                        NOW(), NOW())
+                """, user_id, role)
+            await conn.execute(
+                """
+                INSERT INTO sessions (id, token, "userId", "expiresAt",
+                                      "createdAt", "updatedAt")
+                VALUES ('sess_' || $1, $2, $1,
+                        NOW() + interval '1 hour', NOW(), NOW())
+                """, user_id, token)
+        await conn.execute(
+            """
+            INSERT INTO org_memberships
+                (id, "userId", "orgId", "orgRole", "createdAt", "updatedAt")
+            VALUES ('om_' || $1, $1, $3, 'ADMIN',  NOW(), NOW()),
+                   ('om_' || $2, $2, $3, 'MEMBER', NOW(), NOW()),
+                   ('om_' || $4, $4, $5, 'MEMBER', NOW(), NOW())
+            """,
+            USERS["a_admin"][0], USERS["a_member"][0], IDS["org_a"],
+            USERS["b_member"][0], IDS["org_b"])
+        await conn.execute(
+            """
+            INSERT INTO sites (id, name, "orgId", "createdAt", "updatedAt")
+            VALUES ($1, 'Adversarial Site A', $3, NOW(), NOW()),
+                   ($2, 'Adversarial Site B', $4, NOW(), NOW())
+            """, IDS["site_a"], IDS["site_b"], IDS["org_a"], IDS["org_b"])
+        await conn.execute(
+            """
+            INSERT INTO instances (id, "siteId", name, host, username,
+                                   password, "createdAt", "updatedAt")
+            VALUES ($1, $3, 'adv-router-a1', '192.0.2.31', 'vyos',
+                    'enc-placeholder', NOW(), NOW()),
+                   ($2, $4, 'adv-router-b1', '192.0.2.32', 'vyos',
+                    'enc-placeholder', NOW(), NOW())
+            """, IDS["instance_a"], IDS["instance_b"],
+            IDS["site_a"], IDS["site_b"])
+        await conn.execute(
+            """
+            INSERT INTO user_instance_roles
+                (id, "userId", "instanceId", role, "assignedBy",
+                 "createdAt", "updatedAt")
+            VALUES ($1, $3, $5, 'OPERATOR', 'adv_sys', NOW(), NOW()),
+                   ($2, $4, $6, 'VIEWER',   'adv_sys', NOW(), NOW())
+            """, IDS["grant_a"], IDS["grant_b"],
+            USERS["a_member"][0], USERS["b_member"][0],
+            IDS["instance_a"], IDS["instance_b"])
+        await conn.execute(
+            """
+            INSERT INTO user_feature_permissions
+                (id, "userInstanceRoleId", feature, "canEdit", "canView")
+            VALUES ('f_' || $1, $1, 'FIREWALL', true, true)
+            """, IDS["grant_a"])
+    finally:
+        await conn.close()
+
+
+async def _teardown(db_url: str) -> None:
+    import asyncpg
+
+    conn = await asyncpg.connect(db_url)
+    try:
+        # users cascade sessions/grants/tokens; instances cascade from
+        # sites; sites must go before orgs (RESTRICT FK).
+        await conn.execute("DELETE FROM users WHERE id LIKE 'adv\\_%'")
+        await conn.execute("DELETE FROM sites WHERE id LIKE 's\\_adv\\_%'")
+        await conn.execute(
+            "DELETE FROM organizations WHERE id LIKE 'adv\\_org\\_%'")
+    finally:
+        await conn.close()
+
+
+@pytest.fixture(scope="session")
+def adversarial_world():
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        pytest.skip("adversarial suite needs DATABASE_URL")
+
+    import session_cookie
+    original_secret = session_cookie._secret
+    session_cookie._secret = SECRET
+
+    from fastapi.testclient import TestClient
+    from app import app
+
+    asyncio.run(_seed(db_url))
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        session_cookie._secret = original_secret
+        asyncio.run(_teardown(db_url))

--- a/backend/tests/adversarial/test_canary.py
+++ b/backend/tests/adversarial/test_canary.py
@@ -1,0 +1,60 @@
+"""Unscoped-connection canary.
+
+Fails the build when any backend file resolves a database connection
+outside the org_scope primitives without being on the reviewed allowlist
+(canary_allowlist.py), and when an allowlist entry goes stale. Pure
+source scan - no database needed, runs everywhere.
+"""
+
+from pathlib import Path
+
+from canary_allowlist import MIGRATION_PENDING, PERMANENT_GLOBAL
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+# Direct pool access markers. org-scoped code never mentions db_pool:
+# handlers take a connection from the org_conn dependencies, and the
+# permission path goes through request_scoped_conn.
+MARKERS = ("db_pool.acquire(", "state.db_pool")
+
+EXCLUDED_DIRS = {"tests", "__pycache__", "venv", ".venv", "node_modules"}
+
+
+def scan_backend():
+    hits = set()
+    for path in BACKEND_ROOT.rglob("*.py"):
+        rel = path.relative_to(BACKEND_ROOT)
+        if any(part in EXCLUDED_DIRS for part in rel.parts):
+            continue
+        source = path.read_text(encoding="utf-8", errors="replace")
+        if any(marker in source for marker in MARKERS):
+            hits.add(str(rel))
+    return hits
+
+
+def test_no_unscoped_connections_outside_allowlist():
+    hits = scan_backend()
+    allowed = set(PERMANENT_GLOBAL) | set(MIGRATION_PENDING)
+
+    violations = sorted(hits - allowed)
+    assert not violations, (
+        "Files resolve database connections outside org_scope and are not "
+        "on the reviewed allowlist (add with justification, or migrate to "
+        f"org-scoped connections): {violations}"
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    hits = scan_backend()
+    allowed = set(PERMANENT_GLOBAL) | set(MIGRATION_PENDING)
+
+    stale = sorted(allowed - hits)
+    assert not stale, (
+        "Allowlist entries whose files no longer access the pool directly "
+        f"- remove them so the burn-down stays honest: {stale}"
+    )
+
+
+def test_permanent_and_pending_do_not_overlap():
+    overlap = sorted(set(PERMANENT_GLOBAL) & set(MIGRATION_PENDING))
+    assert not overlap, f"File cannot be both permanent and pending: {overlap}"

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -1,0 +1,117 @@
+"""Cross-organization negatives and target-state expectations.
+
+Two kinds of tests, deliberately mixed in one file so the boundary reads
+as one story:
+
+- Plain assertions: invariants that hold TODAY and must keep holding
+  through every step of the organization work. A regression here is a
+  broken build, full stop.
+
+- xfail assertions: the TARGET semantics of org roles, which arrive with
+  org enforcement. They execute the real request today and document
+  current behavior; the enforcement-flip PR converts them to strict
+  assertions. An early XPASS is a SIGNAL, not noise - it means an
+  endpoint started enforcing (or otherwise changed) ahead of the flip,
+  and must be reported and explained, whether it is good news or bad.
+"""
+
+import pytest
+
+from conftest import IDS, as_user
+
+pytestmark = pytest.mark.usefixtures("adversarial_world")
+
+ENFORCEMENT_OFF = pytest.mark.xfail(
+    reason="target org-role semantics; enforced at the org-enforcement flip",
+    strict=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Invariants that must hold today and forever
+# ---------------------------------------------------------------------------
+
+def test_member_site_listing_never_crosses_the_org_boundary(adversarial_world):
+    response = as_user(adversarial_world, "a_member").get("/session/sites")
+    assert response.status_code == 200
+    site_ids = [s["id"] for s in response.json()]
+    assert IDS["site_b"] not in site_ids
+    assert site_ids == [IDS["site_a"]]
+
+
+def test_member_cannot_connect_to_foreign_org_instance(adversarial_world):
+    response = as_user(adversarial_world, "a_member").post(
+        "/session/connect", json={"instance_id": IDS["instance_b"]})
+    assert response.status_code == 404
+
+
+def test_explicit_org_param_rejects_non_members(adversarial_world):
+    response = as_user(adversarial_world, "a_member").get(
+        "/session/sites", params={"org_id": IDS["org_b"]})
+    assert response.status_code == 403
+
+
+def test_explicit_org_param_rejects_unknown_org(adversarial_world):
+    response = as_user(adversarial_world, "a_member").get(
+        "/session/sites", params={"org_id": "adv_no_such_org"})
+    assert response.status_code == 404
+
+
+def test_member_cannot_delete_foreign_org_assignment(adversarial_world):
+    response = as_user(adversarial_world, "a_member").delete(
+        f"/user-management/assignments/{IDS['grant_b']}")
+    assert response.status_code == 403
+    # the grant must still exist: org-B member still sees their site
+    check = as_user(adversarial_world, "b_member").get("/session/sites")
+    assert [s["id"] for s in check.json()] == [IDS["site_b"]]
+
+
+def test_org_admin_membership_grants_no_deployment_powers(adversarial_world):
+    # users.role is VIEWER; orgRole ADMIN of org A must not open the
+    # deployment-wide user list. NOTE: at the flip this endpoint becomes
+    # org-scoped and the expectation changes to an org-A-only 200 - revisit
+    # there, deliberately not an xfail (the future status code is part of
+    # the org-management design, not fixed yet).
+    response = as_user(adversarial_world, "a_admin").get(
+        "/user-management/users")
+    assert response.status_code == 403
+
+
+def test_system_administrator_sees_all_orgs(adversarial_world):
+    response = as_user(adversarial_world, "sys").get("/session/sites")
+    assert response.status_code == 200
+    site_ids = {s["id"] for s in response.json()}
+    assert {IDS["site_a"], IDS["site_b"]} <= site_ids
+
+
+# ---------------------------------------------------------------------------
+# Target-state expectations (xfail until the enforcement flip)
+# ---------------------------------------------------------------------------
+
+@ENFORCEMENT_OFF
+def test_org_admin_sees_all_sites_of_their_org(adversarial_world):
+    # Composition rule: org ADMIN is at least instance-ADMIN on every
+    # instance in the org - the site listing must include all org-A sites
+    # without per-site grants.
+    response = as_user(adversarial_world, "a_admin").get("/session/sites")
+    assert response.status_code == 200
+    assert IDS["site_a"] in [s["id"] for s in response.json()]
+
+
+@ENFORCEMENT_OFF
+def test_org_admin_sees_instances_of_their_org_site(adversarial_world):
+    response = as_user(adversarial_world, "a_admin").get(
+        f"/session/sites/{IDS['site_a']}/instances")
+    assert response.status_code == 200
+    assert IDS["instance_a"] in [i["id"] for i in response.json()]
+
+
+@ENFORCEMENT_OFF
+def test_token_creation_rejects_foreign_org_instance_ids(adversarial_world):
+    # Token allowed-ids must be FK-validated and org-confined at creation.
+    response = as_user(adversarial_world, "a_member").post(
+        "/tokens",
+        json={"name": "adv-cross-org-probe", "scopes": ["read"],
+              "allowed_instance_ids": [IDS["instance_b"]],
+              "allowed_site_ids": []})
+    assert response.status_code in (400, 403, 422)


### PR DESCRIPTION
Third and final PR of the org-scoped connection plumbing stack (follows #443 and #446; organization-system groundwork, design docs to follow on docs.vyprojects.org). Tests only — no product code changes.

## What

**Two-organization fixtures** (`tests/adversarial/conftest.py`): two orgs with sites, instances, memberships (an org-A ADMIN whose deployment role is plain VIEWER, members with grants on their own org's instances) and signed sessions, seeded in SQL and torn down afterwards. Skips cleanly without `DATABASE_URL`.

**Cross-org tests** (`test_cross_org.py`), two deliberate layers:
- *Invariants that hold today and must keep holding*: member site listings never cross the org boundary; foreign-org instances unreachable; the `org_id` parameter rejects non-members (403) and unknown orgs (404); foreign grant deletion denied; org-ADMIN membership grants no deployment powers; the System Administrator sees everything.
- *Target-state expectations*, `xfail` until the enforcement flip: org ADMINs see all sites/instances of their org without per-instance grants; token `allowed_instance_ids` crossing the org boundary rejected at creation. They execute the real requests today and document current behavior; the flip PR converts them to strict assertions. **Any early XPASS is a signal to investigate and report — an endpoint started enforcing ahead of the flip — never noise to ignore.**

**Unscoped-connection canary** (`test_canary.py` + `canary_allowlist.py`): source scan failing the build when any backend file resolves a database connection outside the org_scope primitives without a reviewed allowlist entry — and when an entry goes stale, so the burn-down list cannot rot. The allowlist separates PERMANENT_GLOBAL (identity middleware, the context-creating session middleware, pool lifecycle, org_scope itself — each with its justification inline) from MIGRATION_PENDING (the streaming and remaining DB-backed surfaces of the next two conversion waves; target: empty). Additions to either list must carry a justification in the PR that makes them. Runs without a database, so it gates every CI run.

The golden-file harness is the equivalence stage of this suite and shares the pytest invocation; nothing needed wiring beyond documentation.

## Evidence

- Suite with database: **81 passed, 3 xfailed** (the three target-state tests, as designed).
- Suite without database: 69 passed, 15 skipped — canary still runs and gates.
- The canary caught `routers/show.py` (an SSE session-revalidation pool access) that the manual inventory for the wave planning had missed — added to the burn-down with justification.
- Fixture teardown verified: zero `adv_`-prefixed rows left after the run.

## For the reviewer

The allowlist is the reviewed artifact this PR creates. Read every justification in `canary_allowlist.py` and challenge any entry that reads thin — once merged, additions are supposed to hurt.