### PR TITLE
feat: move streaming and power surfaces onto org-scoped connections

### DIFF
--- a/backend/routers/console/console.py
+++ b/backend/routers/console/console.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisco
 from pydantic import BaseModel
 
 from fastapi_permissions import require_read_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup, PermissionLevel, check_permission
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key
@@ -79,10 +80,9 @@ async def get_console_status(request: Request):
     """Check if the active instance has SSH configured for console access."""
     await require_read_permission(request, FeatureGroup.SSH_CONSOLE)
 
-    db_pool = _get_db_pool(request)
     user_id = request.state.user_id
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         active = await conn.fetchrow(
             'SELECT "instanceId" FROM active_sessions WHERE "userId" = $1',
             user_id,
@@ -686,18 +686,6 @@ async def websocket_console(websocket: WebSocket):
 # ============================================================================
 # Helper Functions
 # ============================================================================
-
-def _get_db_pool(request: Request) -> asyncpg.Pool:
-    db_pool = getattr(request.app.state, "db_pool", None)
-
-    if not db_pool:
-        raise HTTPException(
-            status_code=503,
-            detail="Database not available",
-        )
-
-    return db_pool
-
 
 async def _safe_send(websocket: WebSocket, data: dict) -> None:
     try:

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -21,6 +21,7 @@ from starlette.concurrency import run_in_threadpool
 
 from session_vyos_service import get_session_vyos_service, _session_device_registry
 from fastapi_permissions import require_read_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup
 from events.event_manager import (
     event_manager,
@@ -43,33 +44,29 @@ POLL_INTERVAL = 10  # seconds
 # Session helpers
 # ============================================================================
 
-async def _has_active_session(db_pool, user_id: str, instance_id: str) -> bool:
-    """Return True if the user still has an active VyOS instance session."""
-    try:
-        async with db_pool.acquire() as conn:
-            row = await conn.fetchrow(
-                'SELECT 1 FROM active_sessions WHERE "userId" = $1 AND "instanceId" = $2',
-                user_id,
-                instance_id,
-            )
-            return row is not None
-    except Exception:
-        return True  # assume valid when DB is unavailable
+async def _has_active_session(conn, user_id: str, instance_id: str) -> bool:
+    """Return True if the user still has an active VyOS instance session.
+
+    Takes an open connection; callers own the acquisition (request paths use
+    an org-scoped connection per tick, the background poller its own).
+    """
+    row = await conn.fetchrow(
+        'SELECT 1 FROM active_sessions WHERE "userId" = $1 AND "instanceId" = $2',
+        user_id,
+        instance_id,
+    )
+    return row is not None
 
 
-async def _get_instance_ids_with_active_sessions(db_pool, instance_ids: list[str]) -> list[str]:
+async def _get_instance_ids_with_active_sessions(conn, instance_ids: list[str]) -> list[str]:
     """Return the subset of instance_ids that have at least one active session."""
     if not instance_ids:
         return []
-    try:
-        async with db_pool.acquire() as conn:
-            rows = await conn.fetch(
-                'SELECT DISTINCT "instanceId" FROM active_sessions WHERE "instanceId" = ANY($1)',
-                instance_ids,
-            )
-            return [row["instanceId"] for row in rows]
-    except Exception:
-        return instance_ids  # assume all valid when DB is unavailable
+    rows = await conn.fetch(
+        'SELECT DISTINCT "instanceId" FROM active_sessions WHERE "instanceId" = ANY($1)',
+        instance_ids,
+    )
+    return [row["instanceId"] for row in rows]
 
 
 # ============================================================================
@@ -114,7 +111,6 @@ async def banner_events(request: Request):
 
     instance_id = instance["id"]
     user_id = request.state.user["id"]
-    db_pool = request.app.state.db_pool
     queue = event_manager.subscribe(instance_id)
 
     async def event_stream():
@@ -129,8 +125,16 @@ async def banner_events(request: Request):
                     payload = await asyncio.wait_for(queue.get(), timeout=30)
                     yield f"data: {payload}\n\n"
                 except asyncio.TimeoutError:
-                    # Close the stream if the user's session has expired
-                    if db_pool and not await _has_active_session(db_pool, user_id, instance_id):
+                    # Close the stream if the user's session has expired.
+                    # One short org-scoped connection per tick — a stream
+                    # must never hold a transaction open between ticks.
+                    try:
+                        async with request_scoped_conn(request) as conn:
+                            still_active = await _has_active_session(
+                                conn, user_id, instance_id)
+                    except Exception:
+                        still_active = True  # assume valid when DB is unavailable
+                    if not still_active:
                         break
                     yield ": keepalive\n\n"
                 except asyncio.CancelledError:
@@ -232,12 +236,8 @@ async def _get_power_status_state(request: Request) -> Dict[str, Any]:
     """Get power status from the database."""
     try:
         instance_id = request.state.instance["id"]
-        db_pool = request.app.state.db_pool
 
-        if not db_pool:
-            return {"scheduled": False}
-
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             await conn.execute(
                 """
                 DELETE FROM scheduled_power_actions
@@ -407,7 +407,12 @@ async def start_banner_poller(app_state: Any) -> None:
             # the VyOS API (and its FUSE filesystem) for signed-out users.
             db_pool = getattr(app_state, "db_pool", None)
             if db_pool:
-                instance_ids = await _get_instance_ids_with_active_sessions(db_pool, instance_ids)
+                try:
+                    async with db_pool.acquire() as conn:
+                        instance_ids = await _get_instance_ids_with_active_sessions(
+                            conn, instance_ids)
+                except Exception:
+                    pass  # assume all valid when DB is unavailable
             if not instance_ids:
                 continue
 

--- a/backend/routers/monitoring/monitoring.py
+++ b/backend/routers/monitoring/monitoring.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 from monitoring_commands import build_command, get_available_commands
 from rbac_permissions import FeatureGroup, check_permission, PermissionLevel
 from fastapi_permissions import require_read_permission, require_super_admin
+from org_scope import request_scoped_conn
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key, generate_keypair
 
@@ -86,11 +87,10 @@ class CommandsListResponse(BaseModel):
 async def generate_ssh_key(instance_id: str, request: Request):
     """Generate a new SSH keypair for an instance. Requires site ADMIN."""
     await require_super_admin(request)
-    db_pool = _get_db_pool(request)
 
     keypair = generate_keypair()
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         updated = await conn.fetchval(
             """
             UPDATE instances
@@ -120,9 +120,8 @@ async def generate_ssh_key(instance_id: str, request: Request):
 async def get_ssh_key_status(instance_id: str, request: Request):
     """Get SSH key status for an instance. Requires site ADMIN."""
     await require_super_admin(request)
-    db_pool = _get_db_pool(request)
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         row = await conn.fetchrow(
             """
             SELECT "sshPublicKey", "sshKeyConfigured", "sshPort", "sshUsername"
@@ -147,9 +146,8 @@ async def get_ssh_key_status(instance_id: str, request: Request):
 async def mark_ssh_key_configured(instance_id: str, request: Request, body: MarkConfiguredRequest):
     """Mark SSH key as configured on the VyOS device. Requires site ADMIN."""
     await require_super_admin(request)
-    db_pool = _get_db_pool(request)
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         has_key = await conn.fetchval(
             'SELECT "sshPublicKey" IS NOT NULL FROM instances WHERE id = $1',
             instance_id,
@@ -179,9 +177,8 @@ async def mark_ssh_key_configured(instance_id: str, request: Request, body: Mark
 async def delete_ssh_key(instance_id: str, request: Request):
     """Remove SSH key from an instance. Requires site ADMIN."""
     await require_super_admin(request)
-    db_pool = _get_db_pool(request)
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         updated = await conn.fetchval(
             """
             UPDATE instances
@@ -205,10 +202,9 @@ async def delete_ssh_key(instance_id: str, request: Request):
 async def get_monitoring_status(request: Request):
     """Get SSH monitoring availability for the current user's active instance. Requires MONITORING read permission."""
     await require_read_permission(request, FeatureGroup.MONITORING)
-    db_pool = _get_db_pool(request)
     user_id = request.state.user_id
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         active = await conn.fetchrow(
             'SELECT "instanceId" FROM active_sessions WHERE "userId" = $1',
             user_id,
@@ -503,14 +499,6 @@ async def websocket_monitor(websocket: WebSocket):
 # ============================================================================
 # Helper Functions
 # ============================================================================
-
-def _get_db_pool(request: Request) -> asyncpg.Pool:
-    """Get database pool from app state."""
-    db_pool = getattr(request.app.state, "db_pool", None)
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-    return db_pool
-
 
 async def _authenticate_websocket(websocket: WebSocket) -> Optional[dict]:
     """

--- a/backend/routers/power.py
+++ b/backend/routers/power.py
@@ -19,6 +19,7 @@ import uuid
 
 from session_vyos_service import get_session_vyos_service
 from fastapi_permissions import require_read_permission, require_write_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup
 from events.event_manager import event_manager, EVENT_POWER_STATUS
 import logging
@@ -163,7 +164,6 @@ async def reboot_system(request: Request, body: PowerActionRequest):
     user = request.state.user
     instance = request.state.instance
     instance_id = instance["id"]
-    db_pool: asyncpg.Pool = request.app.state.db_pool
 
     # Build VyOS command path
     if body.action == "now":
@@ -190,7 +190,7 @@ async def reboot_system(request: Request, body: PowerActionRequest):
         scheduled_time = None
 
         # Mark as cancelled in database
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             await conn.execute(
                 """
                 UPDATE scheduled_power_actions
@@ -248,7 +248,7 @@ async def reboot_system(request: Request, body: PowerActionRequest):
 
     # Store scheduled action in database (except for 'now' and 'cancel')
     if body.action in ["at", "in"] and scheduled_time:
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             # Delete any existing scheduled reboots for this instance
             await conn.execute(
                 """
@@ -321,7 +321,6 @@ async def poweroff_system(request: Request, body: PowerActionRequest):
     user = request.state.user
     instance = request.state.instance
     instance_id = instance["id"]
-    db_pool: asyncpg.Pool = request.app.state.db_pool
 
     # Build VyOS command path
     if body.action == "now":
@@ -348,7 +347,7 @@ async def poweroff_system(request: Request, body: PowerActionRequest):
         scheduled_time = None
 
         # Mark as cancelled in database
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             await conn.execute(
                 """
                 UPDATE scheduled_power_actions
@@ -426,7 +425,7 @@ async def poweroff_system(request: Request, body: PowerActionRequest):
 
     # Store scheduled action in database (except for 'now' and 'cancel')
     if body.action in ["at", "in"] and scheduled_time:
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             # Delete any existing scheduled poweroffs for this instance
             await conn.execute(
                 """
@@ -495,9 +494,8 @@ async def get_power_status(request: Request):
     service = get_session_vyos_service(request)
     instance = request.state.instance
     instance_id = instance["id"]
-    db_pool: asyncpg.Pool = request.app.state.db_pool
 
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         # First, clean up expired actions
         await conn.execute(
             """

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -20,6 +20,7 @@ import httpx
 from starlette.concurrency import run_in_threadpool
 from session_vyos_service import get_session_vyos_service
 from fastapi_permissions import has_permission, require_read_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup, PermissionLevel
 from system_updates import SystemUpdatesInfo, parse_system_updates
 from routers.qos.qos import (
@@ -1396,7 +1397,6 @@ async def dashboard_stream(request: Request):
 
     instance_id: str = service.config.instance_id
     user_id: str = request.state.user["id"]
-    db_pool = request.app.state.db_pool
 
     async def event_generator():
         from routers.events import _has_active_session
@@ -1409,8 +1409,16 @@ async def dashboard_stream(request: Request):
                 try:
                     event = await asyncio.wait_for(queue.get(), timeout=30.0)
                 except asyncio.TimeoutError:
-                    # Close the stream if the user's session has expired
-                    if db_pool and not await _has_active_session(db_pool, user_id, instance_id):
+                    # Close the stream if the user's session has expired.
+                    # One short org-scoped connection per tick - a stream
+                    # must never hold a transaction open between ticks.
+                    try:
+                        async with request_scoped_conn(request) as conn:
+                            still_active = await _has_active_session(
+                                conn, user_id, instance_id)
+                    except Exception:
+                        still_active = True  # assume valid when DB is unavailable
+                    if not still_active:
                         break
                     yield ": keep-alive\n\n"
                     continue

--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -23,21 +23,26 @@ PERMANENT_GLOBAL = {
     "org_scope.py":
         "The sanctioned primitive itself - every org-scoped "
         "acquisition goes through it.",
+    "routers/events.py":
+        "Background banner poller: no request, no org context - it "
+        "iterates every instance with active subscribers, a "
+        "deployment-wide system service. The request-path streams in "
+        "the same file use org-scoped connections per tick.",
 }
 
 # Files not yet migrated to org-scoped connections. Each conversion wave
 # removes its entries; the target end state is an empty dict.
 MIGRATION_PENDING = {
-    # Wave B - streaming/scheduling surfaces (per-tick scoped connections)
-    "routers/events.py": "SSE poll tick",
-    "routers/monitoring/monitoring.py": "SSH monitoring streams",
-    "routers/console/console.py": "console websocket sessions",
-    "routers/power.py": "scheduled power actions",
+    # WebSocket handlers authenticate and authorize outside the HTTP
+    # middleware stack; their org scoping lands with the SSE/WS
+    # revocation-bus hardening item. HTTP handlers in these files
+    # already use org-scoped connections.
+    "routers/monitoring/monitoring.py": "monitoring websocket sessions",
+    "routers/console/console.py": "console shell websocket sessions",
     # Wave C - remaining DB-backed handlers
     "middleware/audit.py": "audit log writes",
     "routers/firewall/separators.py": "separator CRUD",
     "routers/dashboard.py": "dashboard layouts",
     "routers/container/container.py": "container feature state",
     "routers/site_updates/site_updates.py": "site update polling",
-    "routers/show.py": "SSE stream session revalidation tick",
 }


### PR DESCRIPTION
Wave B of the org-scoped connection conversion (organization-system groundwork, design docs to follow on docs.vyprojects.org). Behavior-invisible.

## What

- **HTTP handlers** in `monitoring`, `console` and `power` routers: each DB unit of work is one short org-scoped connection (`request_scoped_conn`). Power's pre-command (cancel) and post-command (schedule) blocks stay separate acquisitions, so no transaction is ever held across the VyOS power call.
- **Stream ticks**: the banner SSE keepalive check (`events.py`) and the dashboard stream (`show.py`) open one org-scoped connection per tick — a stream never holds a transaction between ticks. The shared active-session helpers now take an open connection; the DB-unavailable assume-valid semantics move to the call sites unchanged.
- **Background banner poller**: keeps direct pool access, moved to the canary's PERMANENT allowlist with justification — it runs with no request and iterates every instance with active subscribers, a deployment-wide system service like the session janitor.
- **WebSocket handlers** (monitoring monitor, console shell): authenticate outside the HTTP middleware stack; they keep direct pool access and convert with the SSE/WS revocation-bus hardening item. Burn-down entries re-justified accordingly.
- Canary burn-down shrinks: `power.py`, `show.py` off the list, `events.py` reclassified; the two per-file pool helper functions are gone.

## Evidence

- Golden permission output captured on beta code, compared on this branch: byte-identical.
- Endpoint probes (real app + DB, signed cookies), 4/4: monitoring status 200 for a granted member with an active instance; console status 403 without the SSH_CONSOLE grant; both 404 without an active instance.
- Suite with database: 81 passed, 3 xfailed (the designed target-state tests). Canary green with the updated allowlist.

## For the reviewer

The per-tick pattern is the thing to check: no code path between two stream ticks may keep a connection or transaction alive.