### PR TITLE
feat: move remaining DB-backed handlers onto org-scoped connections

### DIFF
--- a/backend/middleware/audit.py
+++ b/backend/middleware/audit.py
@@ -16,6 +16,7 @@ Design notes:
 """
 
 import json
+from org_scope import request_scoped_conn
 import logging
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -57,10 +58,6 @@ class AuditMiddleware(BaseHTTPMiddleware):
             # have no identity to attribute, so there is nothing to record.
             return
 
-        db_pool = getattr(request.app.state, "db_pool", None)
-        if not db_pool:
-            return
-
         path = request.url.path
         feature = self._feature_from_path(path)
         instance = getattr(request.state, "instance", None) or {}
@@ -80,7 +77,9 @@ class AuditMiddleware(BaseHTTPMiddleware):
         ip = request.client.host if request.client else None
         user_agent = request.headers.get("user-agent")
 
-        async with db_pool.acquire() as conn:
+        # Fire-and-forget: dispatch() swallows any failure here, including
+        # an unavailable database, so auditing never breaks the request.
+        async with request_scoped_conn(request) as conn:
             await conn.execute(
                 """
                 INSERT INTO audit_logs

--- a/backend/routers/container/container.py
+++ b/backend/routers/container/container.py
@@ -27,6 +27,7 @@ from typing import List, Optional, Dict, Any
 from session_vyos_service import get_session_vyos_service
 from vyos_builders.container import ContainerBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup
 from ssh_key_manager import decrypt_private_key
 import inspect
@@ -325,9 +326,7 @@ async def _run_container_ssh_command(
         )
 
     instance_id = instance["id"]
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         row = await conn.fetchrow(
             """
             SELECT host, "sshPort", "sshUsername",
@@ -420,8 +419,7 @@ async def _get_ssh_connection(request: Request) -> tuple:
     if not instance:
         raise HTTPException(status_code=400, detail="No active instance.")
 
-    db_pool: asyncpg.Pool = request.app.state.db_pool
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         row = await conn.fetchrow(
             """SELECT host, "sshPort", "sshUsername", "sshEncryptedPrivKey", "sshKeyNonce", "sshKeyConfigured"
                FROM instances WHERE id = $1""",

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -14,6 +14,7 @@ import uuid
 
 from session_vyos_service import get_session_vyos_service
 from fastapi_permissions import require_read_permission, require_write_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup
 import logging
 logger = logging.getLogger(__name__)
@@ -69,9 +70,7 @@ async def get_dashboard_layout(request: Request):
         user_id = user["id"]
         instance_id = instance["id"]
 
-        db_pool: asyncpg.Pool = request.app.state.db_pool
-
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             result = await conn.fetchrow(
                 """
                 SELECT layout FROM dashboard_layouts
@@ -128,9 +127,7 @@ async def save_dashboard_layout(request: Request, body: DashboardLayoutRequest):
         user_id = user["id"]
         instance_id = instance["id"]
 
-        db_pool: asyncpg.Pool = request.app.state.db_pool
-
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             # Generate a unique ID for new records
             record_id = str(uuid.uuid4())
 

--- a/backend/routers/firewall/separators.py
+++ b/backend/routers/firewall/separators.py
@@ -22,6 +22,7 @@ from fastapi_permissions import (
     has_permission,
     PermissionLevel,
 )
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup
 import logging
 
@@ -130,8 +131,7 @@ async def list_separators(request: Request):
     await _require_separator_permission(request, PermissionLevel.READ)
     try:
         instance_id = _require_instance(request)
-        db_pool: asyncpg.Pool = request.app.state.db_pool
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             separators = await _fetch_separators(conn, instance_id)
         return SeparatorListResponse(separators=separators)
     except HTTPException:
@@ -160,8 +160,7 @@ async def batch_separators(request: Request, body: SeparatorBatchRequest):
                     status_code=400, detail=f"Invalid family: {up.family}"
                 )
 
-        db_pool: asyncpg.Pool = request.app.state.db_pool
-        async with db_pool.acquire() as conn:
+        async with request_scoped_conn(request) as conn:
             async with conn.transaction():
                 # Deletes are scoped to this instance so a caller can never
                 # remove another instance's separators by guessing an id.

--- a/backend/routers/site_updates/site_updates.py
+++ b/backend/routers/site_updates/site_updates.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
 from fastapi_permissions import require_read_permission
+from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup
 from system_updates import SystemUpdatesInfo, parse_system_updates
 from vyos_service import VyOSDeviceConfig, VyOSService
@@ -181,11 +182,7 @@ async def get_site_updates(request: Request, site_id: str, refresh: bool = False
         raise HTTPException(status_code=401, detail="Not authenticated")
     user_id = request.state.user["id"]
 
-    db_pool: Optional[asyncpg.Pool] = getattr(request.app.state, "db_pool", None)
-    if not db_pool:
-        raise HTTPException(status_code=503, detail="Database not available")
-
-    async with db_pool.acquire() as conn:
+    async with request_scoped_conn(request) as conn:
         # Reuse the proven RBAC-filtered enumeration: site ADMIN sees all
         # instances in the site; everyone else is limited to instances they
         # have an explicit role on (instance- or site-scoped grant).

--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -39,10 +39,4 @@ MIGRATION_PENDING = {
     # already use org-scoped connections.
     "routers/monitoring/monitoring.py": "monitoring websocket sessions",
     "routers/console/console.py": "console shell websocket sessions",
-    # Wave C - remaining DB-backed handlers
-    "middleware/audit.py": "audit log writes",
-    "routers/firewall/separators.py": "separator CRUD",
-    "routers/dashboard.py": "dashboard layouts",
-    "routers/container/container.py": "container feature state",
-    "routers/site_updates/site_updates.py": "site update polling",
 }


### PR DESCRIPTION
Wave C, the last connection-conversion batch of the organization-system groundwork (design docs to follow on docs.vyprojects.org). Behavior-invisible.

## What

- `dashboard` layouts, `firewall/separators`, `container` SSH state, `site_updates` enumeration and the audit middleware now take one org-scoped connection per DB unit of work.
- Audit inserts run inside org context; the explicit missing-pool guard is dropped because `dispatch()` already swallows every audit failure (unavailable database included) — behavior unchanged, one less direct pool reference.
- Canary burn-down after this PR: only the two websocket surfaces (monitoring monitor, console shell) remain, correctly parked for the SSE/WS revocation-bus hardening item.

## Evidence

- Golden permission output captured on beta code, compared on this branch: byte-identical.
- Endpoint probes (real app + DB), 6/6: dashboard layout get/save/roundtrip, separators list under a FIREWALL grant, a mutating /vyos call, and an audit row verified written through the org-scoped connection.
- Suite with database: 81 passed, 3 xfailed (designed). Canary green with the shrunken allowlist.

## For the reviewer

`canary_allowlist.py` is the summary artifact: PERMANENT_GLOBAL has five justified entries, MIGRATION_PENDING is down to the two websocket files.