### PR TITLE
docs: document organization groundwork and upgrade verification

### DIFF
--- a/docs-site/docs/architecture/multi-site.md
+++ b/docs-site/docs/architecture/multi-site.md
@@ -16,7 +16,7 @@ A site is a logical group of routers — a location, a customer, a role. An inst
 - `commitConfirmEnabled`, `commitConfirmMinutes` — per-instance commit-confirm settings
 - `isActive` — inactive instances refuse connections
 
-Sites and instances are managed in Site Manager by global admins. Access for other users is granted per instance or per site — see [RBAC and permissions](rbac).
+Sites and instances are managed in Site Manager by global admins. Access for other users is granted per instance or per site — see [RBAC and permissions](rbac). An organization layer above sites is being built incrementally and is inert today — see [Organization groundwork](organizations).
 
 ## One active instance at a time
 

--- a/docs-site/docs/architecture/organizations.md
+++ b/docs-site/docs/architecture/organizations.md
@@ -1,0 +1,68 @@
+---
+id: organizations
+title: Organization groundwork
+sidebar_position: 6
+---
+
+# Organization groundwork
+
+VyManager is growing an organization layer above sites: users will belong to
+one or more organizations with org-level roles, sites will live inside an
+organization, and per-instance RBAC will keep working exactly as today but
+fenced within the org. The groundwork for this is landing incrementally and
+is deliberately **inert**: nothing changes for any deployment until an
+explicit enforcement switch turns on in a future release, and single-team
+deployments will never see the org layer at all.
+
+This page documents what already exists, because parts of it are visible in
+the schema and useful during upgrades.
+
+## Data model
+
+Three schema elements exist today:
+
+- `organizations` — a fixed `default` organization is created by the
+  migration.
+- `org_memberships` — every user is a member of the default org. Deployment
+  admins (`users.role = ADMIN`) were backfilled as org `ADMIN`s, everyone
+  else as `MEMBER`, and the earliest-created admin holds the org `OWNER`
+  role. The deployment-wide `users.role` is untouched and remains what it
+  always was; in org terminology that account is the **System
+  Administrator** — the operator who sees all organizations and manages the
+  deployment itself.
+- `sites.orgId` — every site belongs to an organization; existing and new
+  sites land in the default org automatically.
+
+The migration is transparent: no admin action, no permission changes. The
+[permission equivalence check](../operations/upgrades.md#verifying-an-upgrade)
+exists to let you prove that on your own deployment.
+
+## Org-scoped database access
+
+Every backend database unit of work runs inside a transaction that carries
+the request's organization context as PostgreSQL settings (`app.org_id`,
+`app.is_system_admin`), applied with `SET LOCAL` so they die with the
+transaction. Today nothing filters on them; they are the substrate that
+row-level security will key on when enforcement lands, giving deny-by-default
+scoping even for a handler that forgets to filter.
+
+The org context is derived, not stored: the active instance determines the
+organization (instance → site → org), so feature pages never need to know
+organizations exist. Admin endpoints that operate without an active instance
+(site listing, user management, tokens, backup) accept an optional `org_id`
+query parameter that must name an organization the caller belongs to; when
+omitted it defaults to the caller's sole organization, which today is always
+the default org.
+
+A build-failing test (the "canary") keeps this boundary honest: any backend
+file that resolves a database connection outside the sanctioned org-scoped
+path fails the suite unless it is on a reviewed allowlist that carries a
+justification per entry.
+
+## What is deliberately not here yet
+
+Organization management UI and APIs, org-scoped enforcement, row-level
+security and the related security hardening ship in later releases, each
+gated by an adversarial test suite that already runs today (cross-org
+negatives execute on every CI run; the target-state expectations are marked
+expected-fail until enforcement turns on).

--- a/docs-site/docs/operations/upgrades.md
+++ b/docs-site/docs/operations/upgrades.md
@@ -22,6 +22,58 @@ The dashboard header checks for new releases (`/vyos/version/check` compares the
 
 Manual installs upgrade with `git pull`, then reinstall dependencies (`pip install -r requirements.txt`, `npm install`), run `npx prisma migrate deploy`, rebuild the frontend and restart both services.
 
+## Failed migrations stop the container
+
+A failed schema migration is fatal by design: the frontend container prints
+the Prisma error, points at `npx prisma migrate status`, and exits nonzero
+instead of starting. It never marks migrations as applied without running
+them — a container that refuses to boot is recoverable; a database that
+misrepresents its own schema is not. If a deploy fails, inspect the state
+with `npx prisma migrate status`, resolve the failed migration (Prisma's
+troubleshooting guide covers the cases), restore from your pre-upgrade
+backup if needed, and restart.
+
+## Verifying an upgrade
+
+Two checks let you prove an upgrade changed nothing it should not have.
+Both run against your live database and need `DATABASE_URL` (and a checkout
+of the backend with its requirements installed, or a shell in the backend
+container).
+
+**Permission equivalence.** Before upgrading, snapshot the resolved
+permissions of every (user, instance) pair into a local golden file:
+
+```bash
+GOLDEN_PERMISSIONS_MODE=capture DATABASE_URL=postgresql://... \
+    pytest tests/test_permission_golden.py -v
+```
+
+After upgrading, compare — identical output proves zero permission changes:
+
+```bash
+GOLDEN_PERMISSIONS_ALLOW_VERSION_MISMATCH=1 DATABASE_URL=postgresql://... \
+    pytest tests/test_permission_golden.py -v
+```
+
+The golden file records which app version captured it; the compare refuses a
+version mismatch unless the override flag is set, so a stale or foreign file
+cannot pass as evidence. Across an upgrade the mismatch is expected — the
+flag is you confirming which two versions are being compared. Failures are
+reported per user, per instance, per feature.
+
+**Organization backfill.** Upgrades that introduce the
+[organization groundwork](../architecture/organizations.md) backfill new
+tables. Right after such a migration, assert the backfill invariants:
+
+```bash
+DATABASE_URL=postgresql://... python -m scripts.verify_org_migration
+```
+
+It exits nonzero and names the violated rule if anything is off (missing
+default org, a site without an organization, memberships not matching users,
+an org with members but no owner). Run it once right after the migration —
+one of its rules is a migration-time invariant, not a recurring check.
+
 ## VyOS router updates
 
 VyManager reports but does not install router updates. The Sites page shows a per-site rollup of `show system updates` across all reachable instances (see [Sites](../user-guide/sites#fleet-updates)). Install VyOS images through your normal router upgrade process.


### PR DESCRIPTION
Documentation for the organization-system groundwork now on beta, plus the operator-facing upgrade runbook.

## What

- **New architecture page — Organization groundwork**: the inert org layer as it exists today (default organization, membership backfill and the OWNER rule, `sites.orgId`, "System Administrator" naming), the org-scoped connection design it prepares for row-level security, the derived org-context model, and an explicit list of what deliberately does not exist yet. Linked from the multi-site page.
- **Upgrades page**: two new sections — *Failed migrations stop the container* (the by-design behavior and recovery steps) and *Verifying an upgrade* (the golden permission capture/compare runbook with the version-mismatch override explained, and the organization backfill verifier).

## Verified

`npm run build` in `docs-site`: clean, including Docusaurus's broken-link check.