### PR TITLE
fix: three defects found in live-router testing

### DIFF
--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -54,7 +54,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
     # These are background polling endpoints - not real user activity
     POLLING_ENDPOINTS = {
         "/vyos/config/diff",
-        "/vyos/config/snapshots",
+        "/vyos/config/snapshot",
         "/session/current",
         "/vyos/power/status",
     }

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -237,12 +237,14 @@ async def _get_power_status_state(request: Request) -> Dict[str, Any]:
     try:
         instance_id = request.state.instance["id"]
 
+        # scheduledTime is naive UTC; compare against UTC, not a tz-aware
+        # NOW(), or a non-UTC DB session timezone hides pending actions.
         async with request_scoped_conn(request) as conn:
             await conn.execute(
                 """
                 DELETE FROM scheduled_power_actions
                 WHERE "instanceId" = $1
-                  AND "scheduledTime" < NOW()
+                  AND "scheduledTime" < (NOW() AT TIME ZONE 'UTC')
                 """,
                 instance_id,
             )
@@ -253,7 +255,7 @@ async def _get_power_status_state(request: Request) -> Dict[str, Any]:
                        cancelled, "cancelledBy", "cancelledByName"
                 FROM scheduled_power_actions
                 WHERE "instanceId" = $1
-                  AND "scheduledTime" > NOW()
+                  AND "scheduledTime" > (NOW() AT TIME ZONE 'UTC')
                 ORDER BY "createdAt" DESC
                 LIMIT 1
                 """,
@@ -347,7 +349,7 @@ async def _poll_banner_state_for_instance(
                     """
                     DELETE FROM scheduled_power_actions
                     WHERE "instanceId" = $1
-                      AND "scheduledTime" < NOW()
+                      AND "scheduledTime" < (NOW() AT TIME ZONE 'UTC')
                     """,
                     instance_id,
                 )
@@ -358,7 +360,7 @@ async def _poll_banner_state_for_instance(
                            cancelled, "cancelledBy", "cancelledByName"
                     FROM scheduled_power_actions
                     WHERE "instanceId" = $1
-                      AND "scheduledTime" > NOW()
+                      AND "scheduledTime" > (NOW() AT TIME ZONE 'UTC')
                     ORDER BY "createdAt" DESC
                     LIMIT 1
                     """,

--- a/backend/routers/local_route/local_route.py
+++ b/backend/routers/local_route/local_route.py
@@ -101,7 +101,7 @@ class VyOSResponse(BaseModel):
 
 
 @router.get("/capabilities", response_model=LocalRouteCapabilitiesResponse)
-async def get_local_route_capabilities(request: Request):
+async def get_local_route_capabilities(http_request: Request):
     """
     Get feature capabilities based on device VyOS version.
 
@@ -114,9 +114,9 @@ async def get_local_route_capabilities(request: Request):
         capabilities = builder.get_capabilities()
 
         # Add instance info
-        if hasattr(request.state, "instance") and request.state.instance:
-            capabilities["instance_name"] = request.state.instance.get("name")
-            capabilities["instance_id"] = request.state.instance.get("id")
+        if hasattr(http_request.state, "instance") and http_request.state.instance:
+            capabilities["instance_name"] = http_request.state.instance.get("name")
+            capabilities["instance_id"] = http_request.state.instance.get("id")
         return capabilities
     except Exception as e:
         logger.exception("Unhandled error")

--- a/backend/routers/power.py
+++ b/backend/routers/power.py
@@ -496,12 +496,16 @@ async def get_power_status(request: Request):
     instance_id = instance["id"]
 
     async with request_scoped_conn(request) as conn:
+        # scheduledTime is stored as naive UTC (see parse_scheduled_time and
+        # the utcnow() writes), so it must be compared against UTC, not a
+        # tz-aware NOW(): under a non-UTC database session timezone a bare
+        # NOW() shifts the comparison by the offset and hides pending actions.
         # First, clean up expired actions
         await conn.execute(
             """
             DELETE FROM scheduled_power_actions
             WHERE "instanceId" = $1
-              AND "scheduledTime" < NOW()
+              AND "scheduledTime" < (NOW() AT TIME ZONE 'UTC')
             """,
             instance_id,
         )
@@ -513,7 +517,7 @@ async def get_power_status(request: Request):
                    cancelled, "cancelledBy", "cancelledByName"
             FROM scheduled_power_actions
             WHERE "instanceId" = $1
-              AND "scheduledTime" > NOW()
+              AND "scheduledTime" > (NOW() AT TIME ZONE 'UTC')
             ORDER BY "createdAt" DESC
             LIMIT 1
             """,
@@ -550,7 +554,7 @@ async def get_power_status(request: Request):
                     DELETE FROM scheduled_power_actions
                     WHERE "instanceId" = $1
                       AND "actionType" = $2
-                      AND "scheduledTime" > NOW()
+                      AND "scheduledTime" > (NOW() AT TIME ZONE 'UTC')
                     """,
                     instance_id,
                     result["actionType"],


### PR DESCRIPTION
Three independent pre-existing defects surfaced while exercising every feature end-to-end against live VyOS routers (1.4.4 sagitta and a 2026.05 rolling build). One commit each.

## 1. `local-route/capabilities` returned 500 on every call
`get_local_route_capabilities` referenced `http_request` while its parameter was named `request` — a `NameError` on every request. The endpoint has been dead since it was written (the sibling `config` handler uses `http_request` correctly). Fixed by renaming the parameter.

## 2. Scheduled power actions invisible under a non-UTC database timezone
The impactful one. `scheduledTime` is stored as **naive UTC** (both `datetime.utcnow()` writes and `parse_scheduled_time` return naive UTC), but the power-status and SSE-poller queries filtered it with a bare `NOW()`, which is timezone-aware. Under any database session timezone other than UTC, Postgres reinterprets the naive column value in the session zone and shifts the comparison by the offset — so a genuinely scheduled reboot/poweroff is treated as already past. **The router reboots, but the status banner shows nothing and the in-UI cancel never appears.** Fixed by comparing against `NOW() AT TIME ZONE 'UTC'` at all seven filter sites (power.py + events.py).

Reproduced and verified at the DB level under `Europe/Berlin` (UTC+2): a reboot scheduled 10 minutes out returns **0 rows** with the old `NOW()` filter and **1 row** with the fix.

## 3. Snapshot path typo in the activity-timestamp skip list
`POLLING_ENDPOINTS` listed `/vyos/config/snapshots` but the route is `/vyos/config/snapshot` (singular), so polling it bumped the session's last-activity timestamp and defeated the inactivity timeout.

## Testing
- Backend suite: 69 passed, 15 skipped (no regressions).
- Defect 2 proven against Postgres under a non-UTC session timezone (old query hides the row, fixed query returns it).
- Defects 1 and 3 were observed live before the fix (500 on the capabilities endpoint; a real reboot scheduled on the router with an empty status banner).

## For the reviewer
All three are unrelated to the organization groundwork and touch no org code. Defect 2 is a data-correctness/safety issue worth prioritizing.