### PR TITLE
feat: assert row organization on by-id admin mutations

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -24,11 +24,20 @@ dependency; the permission check path is read-only and uses one short
 acquisition of its own.
 """
 
+import os
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
 
 import asyncpg
 from fastapi import HTTPException, Query, Request
+
+
+# Master switch for organization enforcement. Off by default: the whole
+# hardening chain lands behind it so each step is inert on today's single-org
+# deployments and only becomes load-bearing when this flips on.
+ORG_ENFORCEMENT = os.getenv("ORG_ENFORCEMENT", "").strip().lower() in (
+    "1", "true", "yes", "on"
+)
 
 
 def _require_pool(request: Request) -> asyncpg.Pool:
@@ -169,6 +178,9 @@ async def _handler_conn(
                 org_id or "",
                 "true" if is_admin else "false",
             )
+            # Exposed for by-id row-org checks (assert_row_in_acting_org).
+            request.state.acting_org_id = org_id
+            request.state.is_system_admin = is_admin
             request.state.org_conn = conn
             try:
                 yield conn
@@ -229,3 +241,40 @@ async def request_scoped_conn(request: Request) -> AsyncIterator[asyncpg.Connect
         pool, org_id_from_state(request), known_admin
     ) as conn:
         yield conn
+
+
+async def assert_row_in_acting_org(
+    request: Request,
+    conn: asyncpg.Connection,
+    row_org_id: Optional[str],
+) -> None:
+    """Assert a by-id target belongs to the caller's acting organization.
+
+    The deny-by-default half of the IDOR defense: a mutation keyed on a
+    user-supplied id must confirm the target row is in the caller's org, not
+    only that the caller has the role. Returns 404 (not 403) on a cross-org
+    id so row existence does not leak.
+
+    Inert unless ORG_ENFORCEMENT is on, so it is a no-op on today's single-org
+    deployments and only becomes load-bearing at the enforcement flip. System
+    Administrators bypass. RLS is the eventual backstop for the same class.
+    """
+    if not ORG_ENFORCEMENT:
+        return
+    if await _resolve_system_admin(conn, request):
+        return
+
+    acting = (getattr(request.state, "acting_org_id", None)
+              or org_id_from_state(request))
+    if acting is None:
+        user = getattr(request.state, "user", None)
+        if user:
+            rows = await conn.fetch(
+                'SELECT "orgId" FROM org_memberships WHERE "userId" = $1'
+                ' ORDER BY "orgId" LIMIT 2',
+                user["id"])
+            if len(rows) == 1:
+                acting = rows[0]["orgId"]
+
+    if row_org_id is None or acting is None or row_org_id != acting:
+        raise HTTPException(status_code=404, detail="Not found")

--- a/backend/routers/monitoring/monitoring.py
+++ b/backend/routers/monitoring/monitoring.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field
 from monitoring_commands import build_command, get_available_commands
 from rbac_permissions import FeatureGroup, check_permission, PermissionLevel
 from fastapi_permissions import require_read_permission, require_super_admin
-from org_scope import request_scoped_conn
+from org_scope import assert_row_in_acting_org, request_scoped_conn
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key, generate_keypair
 
@@ -83,6 +83,22 @@ class CommandsListResponse(BaseModel):
 # SSH Key Management Endpoints (instance-id based, site ADMIN required)
 # ============================================================================
 
+async def _assert_instance_in_acting_org(request, conn, instance_id: str) -> None:
+    """Confirm a path instance_id belongs to the caller's organization.
+
+    These SSH-key endpoints take an instance id in the path rather than the
+    caller's active instance, so the id must be org-checked directly.
+    """
+    org_id = await conn.fetchval(
+        'SELECT s."orgId" FROM instances i'
+        ' JOIN sites s ON i."siteId" = s.id WHERE i.id = $1',
+        instance_id,
+    )
+    if org_id is None:
+        raise HTTPException(status_code=404, detail="Instance not found")
+    await assert_row_in_acting_org(request, conn, org_id)
+
+
 @router.post("/instances/{instance_id}/ssh-key/generate", response_model=SSHKeyGenerateResponse)
 async def generate_ssh_key(instance_id: str, request: Request):
     """Generate a new SSH keypair for an instance. Requires site ADMIN."""
@@ -91,6 +107,7 @@ async def generate_ssh_key(instance_id: str, request: Request):
     keypair = generate_keypair()
 
     async with request_scoped_conn(request) as conn:
+        await _assert_instance_in_acting_org(request, conn, instance_id)
         updated = await conn.fetchval(
             """
             UPDATE instances
@@ -122,6 +139,7 @@ async def get_ssh_key_status(instance_id: str, request: Request):
     await require_super_admin(request)
 
     async with request_scoped_conn(request) as conn:
+        await _assert_instance_in_acting_org(request, conn, instance_id)
         row = await conn.fetchrow(
             """
             SELECT "sshPublicKey", "sshKeyConfigured", "sshPort", "sshUsername"
@@ -148,6 +166,7 @@ async def mark_ssh_key_configured(instance_id: str, request: Request, body: Mark
     await require_super_admin(request)
 
     async with request_scoped_conn(request) as conn:
+        await _assert_instance_in_acting_org(request, conn, instance_id)
         has_key = await conn.fetchval(
             'SELECT "sshPublicKey" IS NOT NULL FROM instances WHERE id = $1',
             instance_id,
@@ -179,6 +198,7 @@ async def delete_ssh_key(instance_id: str, request: Request):
     await require_super_admin(request)
 
     async with request_scoped_conn(request) as conn:
+        await _assert_instance_in_acting_org(request, conn, instance_id)
         updated = await conn.fetchval(
             """
             UPDATE instances

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -6,7 +6,7 @@ Handles connect/disconnect operations and instance selection.
 """
 
 from fastapi import Depends, APIRouter, HTTPException, Request, UploadFile, File, Form
-from org_scope import org_conn_admin
+from org_scope import assert_row_in_acting_org, org_conn_admin
 from starlette.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -729,14 +729,15 @@ async def update_site(request: Request, site_id: str, body: SiteUpdateRequest, c
                 detail="Only site ADMIN users can update sites"
             )
 
-        # Verify site exists
-        site_exists = await conn.fetchval(
-            "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+        # Verify site exists and belongs to the caller's organization
+        site_org = await conn.fetchval(
+            'SELECT "orgId" FROM sites WHERE id = $1',
             site_id
         )
 
-        if not site_exists:
+        if site_org is None:
             raise HTTPException(status_code=404, detail="Site not found")
+        await assert_row_in_acting_org(request, conn, site_org)
 
         # Build update query dynamically
         updates = []
@@ -812,14 +813,15 @@ async def delete_site(request: Request, site_id: str, conn: asyncpg.Connection =
                 detail="Only site ADMIN users can delete sites"
             )
 
-        # Verify site exists
-        site_exists = await conn.fetchval(
-            "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+        # Verify site exists and belongs to the caller's organization
+        site_org = await conn.fetchval(
+            'SELECT "orgId" FROM sites WHERE id = $1',
             site_id
         )
 
-        if not site_exists:
+        if site_org is None:
             raise HTTPException(status_code=404, detail="Site not found")
+        await assert_row_in_acting_org(request, conn, site_org)
 
         async with conn.transaction():
             # Delete will cascade to instances and user_instance_roles
@@ -876,14 +878,15 @@ async def create_instance(request: Request, body: InstanceCreateRequest, conn: a
                 detail="Only site ADMIN users can create instances"
             )
 
-        # Verify site exists
-        site_exists = await conn.fetchval(
-            "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+        # Verify target site exists and belongs to the caller's organization
+        site_org = await conn.fetchval(
+            'SELECT "orgId" FROM sites WHERE id = $1',
             body.site_id
         )
 
-        if not site_exists:
+        if site_org is None:
             raise HTTPException(status_code=404, detail="Site not found")
+        await assert_row_in_acting_org(request, conn, site_org)
 
         # Generate instance ID
         import secrets
@@ -985,23 +988,27 @@ async def update_instance(request: Request, instance_id: str, body: InstanceUpda
                 detail="Only site ADMIN users can update instances"
             )
 
-        # Verify instance exists
-        instance_exists = await conn.fetchval(
-            "SELECT EXISTS(SELECT 1 FROM instances WHERE id = $1)",
+        # Verify instance exists and its site is in the caller's organization
+        instance_org = await conn.fetchval(
+            'SELECT s."orgId" FROM instances i'
+            ' JOIN sites s ON i."siteId" = s.id WHERE i.id = $1',
             instance_id
         )
 
-        if not instance_exists:
+        if instance_org is None:
             raise HTTPException(status_code=404, detail="Instance not found")
+        await assert_row_in_acting_org(request, conn, instance_org)
 
-        # If moving to a different site, verify target site exists
+        # If moving to a different site, verify the target site exists and
+        # is in the caller's organization (no cross-org moves).
         if body.site_id:
-            target_site_exists = await conn.fetchval(
-                "SELECT EXISTS(SELECT 1 FROM sites WHERE id = $1)",
+            target_site_org = await conn.fetchval(
+                'SELECT "orgId" FROM sites WHERE id = $1',
                 body.site_id
             )
-            if not target_site_exists:
+            if target_site_org is None:
                 raise HTTPException(status_code=404, detail="Target site not found")
+            await assert_row_in_acting_org(request, conn, target_site_org)
 
         # Build update query dynamically
         updates = []
@@ -1176,14 +1183,16 @@ async def delete_instance(request: Request, instance_id: str, conn: asyncpg.Conn
                 detail="Only site ADMIN users can delete instances"
             )
 
-        # Verify instance exists
-        instance_exists = await conn.fetchval(
-            "SELECT EXISTS(SELECT 1 FROM instances WHERE id = $1)",
+        # Verify instance exists and its site is in the caller's organization
+        instance_org = await conn.fetchval(
+            'SELECT s."orgId" FROM instances i'
+            ' JOIN sites s ON i."siteId" = s.id WHERE i.id = $1',
             instance_id
         )
 
-        if not instance_exists:
+        if instance_org is None:
             raise HTTPException(status_code=404, detail="Instance not found")
+        await assert_row_in_acting_org(request, conn, instance_org)
 
         # Delete instance
         result = await conn.execute(

--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -7,7 +7,7 @@ ADMIN only.
 import os
 
 from fastapi import Depends, APIRouter, HTTPException, Request
-from org_scope import org_conn_admin
+from org_scope import assert_row_in_acting_org, org_conn_admin
 from pydantic import BaseModel, Field, EmailStr
 from typing import List, Dict, Optional, Any
 from datetime import datetime
@@ -585,10 +585,22 @@ async def remove_assignment(request: Request, assignment_id: str, conn: asyncpg.
     """Remove a user's access to an instance."""
     await require_super_admin(request)
 
-    # Check if assignment exists
-    existing = await conn.fetchval("SELECT id FROM user_instance_roles WHERE id = $1", assignment_id)
-    if not existing:
+    # Resolve the grant's organization (via its instance's site, or its
+    # whole-site grant) and confirm it is in the caller's org before deleting.
+    grant_org = await conn.fetchval(
+        '''
+        SELECT COALESCE(si."orgId", ss."orgId")
+        FROM user_instance_roles uir
+        LEFT JOIN instances i ON uir."instanceId" = i.id
+        LEFT JOIN sites si ON i."siteId" = si.id
+        LEFT JOIN sites ss ON uir."siteId" = ss.id
+        WHERE uir.id = $1
+        ''',
+        assignment_id,
+    )
+    if grant_org is None:
         raise HTTPException(status_code=404, detail="Assignment not found")
+    await assert_row_in_acting_org(request, conn, grant_org)
 
     # Delete assignment
     await conn.execute("DELETE FROM user_instance_roles WHERE id = $1", assignment_id)

--- a/backend/tests/test_org_scope.py
+++ b/backend/tests/test_org_scope.py
@@ -9,8 +9,14 @@ import os
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
-from org_scope import is_system_admin_from_state, org_id_from_state
+import org_scope
+from org_scope import (
+    assert_row_in_acting_org,
+    is_system_admin_from_state,
+    org_id_from_state,
+)
 
 requires_db = pytest.mark.skipif(
     not os.environ.get("DATABASE_URL"),
@@ -34,6 +40,89 @@ def test_org_id_from_state_reads_middleware_org():
 def test_org_id_from_state_none_without_org():
     assert org_id_from_state(request_with_state(org=None)) is None
     assert org_id_from_state(request_with_state()) is None
+
+
+# ---------------------------------------------------------------------------
+# assert_row_in_acting_org — the by-id IDOR row check (no DB; fake conn)
+# ---------------------------------------------------------------------------
+
+class FakeConn:
+    """Minimal asyncpg-conn stand-in for the row-check branches."""
+
+    def __init__(self, role="ADMIN", membership_orgs=None):
+        self._role = role
+        self._orgs = membership_orgs or []
+
+    async def fetchval(self, query, *args):
+        # _resolve_system_admin's "SELECT role FROM users WHERE id = $1"
+        return self._role
+
+    async def fetch(self, query, *args):
+        # sole-membership lookup
+        return [{"orgId": o} for o in self._orgs]
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_row_check_noop_when_enforcement_off(monkeypatch):
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", False)
+    req = request_with_state(user={"id": "u1"}, acting_org_id="orgA")
+    # Cross-org id, but enforcement off → must not raise.
+    run(assert_row_in_acting_org(req, FakeConn(role="VIEWER"), "orgB"))
+
+
+def test_row_check_system_admin_bypasses(monkeypatch):
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+    req = request_with_state(user={"id": "u1"}, acting_org_id="orgA")
+    # role ADMIN → System Administrator → bypass even on a cross-org id.
+    run(assert_row_in_acting_org(req, FakeConn(role="ADMIN"), "orgB"))
+
+
+def test_row_check_same_org_passes(monkeypatch):
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+    req = request_with_state(user={"id": "u1"}, acting_org_id="orgA")
+    run(assert_row_in_acting_org(req, FakeConn(role="VIEWER"), "orgA"))
+
+
+def test_row_check_cross_org_404(monkeypatch):
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+    req = request_with_state(user={"id": "u1"}, acting_org_id="orgA")
+    with pytest.raises(HTTPException) as exc:
+        run(assert_row_in_acting_org(req, FakeConn(role="VIEWER"), "orgB"))
+    assert exc.value.status_code == 404
+
+
+def test_row_check_falls_back_to_sole_membership(monkeypatch):
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+    # No acting_org_id/state.org; resolve from the sole membership.
+    req = request_with_state(user={"id": "u1"})
+    run(assert_row_in_acting_org(
+        req, FakeConn(role="VIEWER", membership_orgs=["orgA"]), "orgA"))
+    with pytest.raises(HTTPException) as exc:
+        run(assert_row_in_acting_org(
+            req, FakeConn(role="VIEWER", membership_orgs=["orgA"]), "orgB"))
+    assert exc.value.status_code == 404
+
+
+def test_row_check_null_row_org_404(monkeypatch):
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+    req = request_with_state(user={"id": "u1"}, acting_org_id="orgA")
+    with pytest.raises(HTTPException) as exc:
+        run(assert_row_in_acting_org(req, FakeConn(role="VIEWER"), None))
+    assert exc.value.status_code == 404
+
+
+def test_enforcement_flag_env_parsing(monkeypatch):
+    import importlib
+    for val, expected in (("1", True), ("true", True), ("ON", True),
+                          ("", False), ("0", False), ("no", False)):
+        monkeypatch.setenv("ORG_ENFORCEMENT", val)
+        reloaded = importlib.reload(org_scope)
+        assert reloaded.ORG_ENFORCEMENT is expected, val
+    monkeypatch.delenv("ORG_ENFORCEMENT", raising=False)
+    importlib.reload(org_scope)
 
 
 def test_system_admin_flag_tristate():


### PR DESCRIPTION
Closes #452. First link of the organization security-hardening chain. Behind a new `ORG_ENFORCEMENT` flag, **off by default** — inert on today's single-org deployments, load-bearing only at the enforcement flip.

## What

By-id mutations on the admin surface authorized by role alone. Each now resolves the target row's owning organization and asserts it equals the caller's acting org before mutating — returning **404 (not 403)** on a cross-org id so row existence does not leak. Sites covered:

- `session.py`: site update/delete, instance update/delete, instance create + move-to-site target.
- `user_management.py`: assignment delete (resolves the grant's org via its instance's site or whole-site grant).
- `monitoring.py`: the four SSH-key endpoints that take a **path** instance id (generate / status / mark-configured / delete).

Separator and power actions are already bound to the caller's active instance, so they carry no user-supplied cross-org id and need no extra check.

`assert_row_in_acting_org` (in `org_scope`): no-op when the flag is off, System Administrators bypass, otherwise the row's org must equal the acting org — resolved from the `org_conn_admin` context, the middleware-derived `state.org`, or the caller's sole membership. RLS is the eventual backstop for the same class; this is the app-layer half that lands first so the adversarial suite has something to assert against.

## An honest scoping note

These endpoints still gate on `require_super_admin`, so **every current caller is a System Administrator and bypasses the check by design.** The row check becomes fully load-bearing when a later chain item scopes the ADMIN branch per-org. It ships now as the mechanism.

## Evidence

- Helper logic unit-tested across every branch (flag off → no-op; sysadmin bypass; same-org pass; cross-org 404; sole-membership fallback; null row-org 404; env-flag parsing). Suite: **76 passed, 15 skipped**.
- Live, `ORG_ENFORCEMENT=1`, two-org DB: a System Administrator still lists both orgs and acts on either (bypass intact — no regression).
- Live wiring proof, same DB, simulating the future org-ADMIN (pass the role gate, non-sysadmin): **same-org site update 200, cross-org site update 404, cross-org instance delete 404, cross-org ssh-key 404, same-org ssh-key 200.** The check fires in the real handlers.

## For the reviewer

The flag default (off) and the 404-not-403 choice are the load-bearing decisions. Confirm no by-id admin mutation was missed — grep for handlers that fetch/mutate by a path id under `require_super_admin`.