### PR TITLE
feat: FK-validate and org-confine API token allowed-ids at creation

### DIFF
--- a/backend/routers/tokens/tokens.py
+++ b/backend/routers/tokens/tokens.py
@@ -8,7 +8,7 @@ at creation and never again; only its sha256 hash is stored.
 """
 
 from fastapi import Depends, APIRouter, HTTPException, Request
-from org_scope import org_conn_admin
+from org_scope import assert_row_in_acting_org, org_conn_admin
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime, timedelta
@@ -97,10 +97,37 @@ async def create_token(request: Request, body: TokenCreateRequest, conn: asyncpg
     if invalid:
         raise HTTPException(status_code=400, detail=f"Unknown scopes: {sorted(invalid)}")
     scopes = sorted(set(body.scopes))
-    # Enforcement intersects scope with the user's grants, so over-broad lists are
-    # harmless; we just dedupe what the caller asked for.
     allowed_instance_ids = sorted(set(body.allowed_instance_ids))
     allowed_site_ids = sorted(set(body.allowed_site_ids))
+
+    # FK-validate every allowed id and, under enforcement, confine it to the
+    # caller's organization so a token cannot be scoped across the org
+    # boundary at creation. A cross-org id is folded into "unknown" (same
+    # 400) rather than reported separately, so it does not leak existence of
+    # another org's instances/sites.
+    async def _validate_ids(ids, kind, query):
+        if not ids:
+            return
+        valid = set()
+        for row in await conn.fetch(query, ids):
+            try:
+                await assert_row_in_acting_org(request, conn, row["org_id"])
+                valid.add(row["id"])
+            except HTTPException:
+                pass  # cross-org: indistinguishable from unknown
+        unknown = set(ids) - valid
+        if unknown:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown {kind} ids: {sorted(unknown)}")
+
+    await _validate_ids(
+        allowed_instance_ids, "instance",
+        'SELECT i.id, s."orgId" AS org_id FROM instances i'
+        ' JOIN sites s ON i."siteId" = s.id WHERE i.id = ANY($1)')
+    await _validate_ids(
+        allowed_site_ids, "site",
+        'SELECT id, "orgId" AS org_id FROM sites WHERE id = ANY($1)')
 
     expires_at = (
         datetime.utcnow() + timedelta(days=body.expires_in_days)

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -108,10 +108,37 @@ def test_org_admin_sees_instances_of_their_org_site(adversarial_world):
 
 @ENFORCEMENT_OFF
 def test_token_creation_rejects_foreign_org_instance_ids(adversarial_world):
-    # Token allowed-ids must be FK-validated and org-confined at creation.
+    # Target semantics with enforcement OFF: a cross-org allowed-id is inert
+    # (FK passes, request-time grant intersection is the backstop). This
+    # xfails today and flips strict at the enforcement flip; the enforced
+    # behavior is proven in the ON test below.
     response = as_user(adversarial_world, "a_member").post(
         "/tokens",
         json={"name": "adv-cross-org-probe", "scopes": ["read"],
               "allowed_instance_ids": [IDS["instance_b"]],
               "allowed_site_ids": []})
     assert response.status_code in (400, 403, 422)
+
+
+def test_token_creation_org_confined_under_enforcement(
+        adversarial_world, monkeypatch):
+    # Token creation is member-reachable, so org confinement bites members
+    # under enforcement without waiting for the ADMIN-per-org item. A
+    # cross-org allowed-id is folded into "unknown" (400), indistinguishable
+    # from a nonexistent id so existence does not leak; a same-org id passes.
+    import org_scope
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+
+    cross = as_user(adversarial_world, "a_member").post(
+        "/tokens",
+        json={"name": "adv-cross", "scopes": ["read"],
+              "allowed_instance_ids": [IDS["instance_b"]],
+              "allowed_site_ids": []})
+    assert cross.status_code == 400
+
+    same = as_user(adversarial_world, "a_member").post(
+        "/tokens",
+        json={"name": "adv-same", "scopes": ["read"],
+              "allowed_instance_ids": [IDS["instance_a"]],
+              "allowed_site_ids": []})
+    assert same.status_code == 200


### PR DESCRIPTION
Closes #454. Second link of the organization hardening chain, behind `ORG_ENFORCEMENT` (off by default), consistent with #453.

## What

Token creation accepted `allowedInstanceIds` / `allowedSiteIds` as raw `TEXT[]` with no validation. Now, in `create_token`:

- **FK validation, unconditional:** every allowed id must resolve to a real instance/site — a nonexistent id is a 400.
- **Org confinement, under enforcement:** each id must resolve to an instance/site in the caller's organization. A cross-org id is **folded into the same `400 "Unknown ..."`** as a nonexistent id, so it does not leak the existence of another org's instances or sites.

Reuses `assert_row_in_acting_org`, so it is inert (FK-only) on single-org deployments and org-confining at the flip.

## Teeth now, not just at the flip

Unlike the by-id admin endpoints in #453 (gated by `require_super_admin`, so only System Administrators reach them and they bypass), **token creation is reachable by non-admin members** — so this confinement is load-bearing for members the moment enforcement turns on.

## Evidence

Live, two-org database:
- Flag **off**: same-org id 200; cross-org id 200 (inert — FK passes, request-time grant intersection is the runtime backstop); nonexistent id 400.
- Flag **on**, as a non-admin member: same-org id 200; cross-org instance → `400 Unknown instance ids: ['i_b']`; cross-org site → `400 Unknown site ids: ['s_b']`; nonexistent id 400. Cross-org and nonexistent are indistinguishable — no existence leak.
- Adversarial suite gains `test_token_creation_org_confined_under_enforcement` (monkeypatches the flag on, asserts member cross-org 400 / same-org 200): 8 passed + 3 designed xfails.
- Full suite green (the one golden-file failure in one run was a missing local golden artifact, not a regression).

## For the reviewer

The existence-leak fold (cross-org reported as "unknown", not a distinct 404/403) is the deliberate call — confirm you agree it belongs on the safe side.