### PR TITLE
fix: close unauthenticated empty-system restore, require typed confirm

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -14,6 +14,7 @@ from typing import List, Dict, Optional, Any
 from datetime import datetime
 import asyncpg
 import json
+import os
 from vyos_service import VyOSService, VyOSDeviceConfig
 from session_vyos_service import clear_session_cache
 from session_cookie import verify_session_cookie
@@ -1273,11 +1274,18 @@ class BackupRequest(BaseModel):
     passphrase: str = Field(..., min_length=1, description="Encrypts the backup file")
 
 
-async def _require_backup_admin(conn: asyncpg.Connection, request: Request) -> None:
-    """Allow platform ADMINs, or anyone when the system has no users yet.
+def _empty_restore_enabled() -> bool:
+    return os.getenv("VYMANAGER_ALLOW_EMPTY_RESTORE", "").strip().lower() in (
+        "1", "true", "yes", "on"
+    )
 
-    The zero-users case covers disaster recovery onto a fresh install, where no
-    admin account exists to authenticate as.
+
+async def _require_backup_admin(conn: asyncpg.Connection, request: Request) -> None:
+    """Allow platform ADMINs. The zero-users case (disaster recovery onto a
+    fresh install, where no admin exists to authenticate as) is an
+    unauthenticated full-DB write, so it is closed by default and must be
+    explicitly enabled by the operator for the recovery via
+    VYMANAGER_ALLOW_EMPTY_RESTORE.
     """
     user = getattr(request.state, "user", None)
     if user:
@@ -1286,7 +1294,16 @@ async def _require_backup_admin(conn: asyncpg.Connection, request: Request) -> N
             return
     user_count = await conn.fetchval("SELECT COUNT(*) FROM users")
     if user_count == 0:
-        return
+        if _empty_restore_enabled():
+            logger.warning(
+                "Empty-system backup/restore permitted via "
+                "VYMANAGER_ALLOW_EMPTY_RESTORE")
+            return
+        raise HTTPException(
+            status_code=403,
+            detail="Restore on an empty system is disabled. Set "
+                   "VYMANAGER_ALLOW_EMPTY_RESTORE to enable disaster recovery.",
+        )
     raise HTTPException(status_code=403, detail="Only site ADMIN users can do this")
 
 
@@ -1433,11 +1450,20 @@ async def restore_backup(
     file: UploadFile = File(...),
     passphrase: str = Form(...),
     mode: str = Form("merge"),
+    confirm: str = Form(""),
     conn: asyncpg.Connection = Depends(org_conn_admin),
 ):
     """Restore a backup in "replace" (wipe + restore) or "merge" (upsert) mode."""
     if mode not in ("replace", "merge"):
         raise HTTPException(status_code=400, detail="mode must be 'replace' or 'merge'")
+
+    # Typed confirmation: the destructive action must be named back explicitly,
+    # defeating accidental and CSRF-style restores.
+    if confirm != mode:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Restore requires confirm='{mode}' to proceed",
+        )
 
     await _require_backup_admin(conn, request)
 

--- a/backend/tests/test_backup_safety.py
+++ b/backend/tests/test_backup_safety.py
@@ -1,0 +1,109 @@
+"""Restore-safety tests: empty-system close + typed confirmation.
+
+The env-helper test runs everywhere; the endpoint tests need a migrated
+database and skip without DATABASE_URL.
+"""
+
+import base64
+import hashlib
+import hmac
+import os
+
+import pytest
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="restore-safety endpoint tests need DATABASE_URL",
+)
+
+SECRET = b"backup-safety-secret"
+
+
+def test_empty_restore_enabled_env_parsing(monkeypatch):
+    import routers.session.session as S
+    for val, expected in (("1", True), ("true", True), ("ON", True),
+                          ("", False), ("0", False), ("no", False)):
+        monkeypatch.setenv("VYMANAGER_ALLOW_EMPTY_RESTORE", val)
+        assert S._empty_restore_enabled() is expected, val
+    monkeypatch.delenv("VYMANAGER_ALLOW_EMPTY_RESTORE", raising=False)
+    assert S._empty_restore_enabled() is False
+
+
+def _cookie(token):
+    sig = base64.b64encode(
+        hmac.new(SECRET, token.encode(), hashlib.sha256).digest()).decode()
+    return f"{token}.{sig}"
+
+
+@requires_db
+def test_confirm_required_and_empty_close(monkeypatch):
+    import asyncio
+
+    import asyncpg
+    import session_cookie
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(session_cookie, "_secret", SECRET)
+    db = os.environ["DATABASE_URL"]
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users")
+        await conn.execute(
+            "INSERT INTO users (id,email,name,role,\"emailVerified\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('u_bk','bk@safety.test','BK','ADMIN',true,NOW(),NOW())")
+        await conn.execute(
+            "INSERT INTO sessions (id,token,\"userId\",\"expiresAt\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('s_bk','tok_bk','u_bk',NOW()+interval '1 hour',NOW(),NOW())")
+        await conn.close()
+
+    async def wipe_users():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users")
+        await conn.close()
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_bk'")
+        await conn.close()
+
+    from app import app
+    asyncio.run(seed())
+    try:
+        with TestClient(app) as client:
+            client.cookies.set("better-auth.session_token", _cookie("tok_bk"))
+            backup = client.post("/session/backup", json={"passphrase": "pw"})
+            assert backup.status_code == 200
+            blob = backup.content
+
+            def restore(mode, confirm):
+                return client.post(
+                    "/session/restore",
+                    files={"file": ("b.vymgr", blob)},
+                    data={"passphrase": "pw", "mode": mode, "confirm": confirm})
+
+            assert restore("merge", "").status_code == 400
+            assert restore("merge", "wrong").status_code == 400
+            assert restore("merge", "merge").status_code == 200
+
+            # Empty-system close: no users, no cookie, no env -> 403.
+            asyncio.run(wipe_users())
+            with TestClient(app) as anon:
+                r = anon.post(
+                    "/session/restore",
+                    files={"file": ("b.vymgr", b"x")},
+                    data={"passphrase": "pw", "mode": "merge",
+                          "confirm": "merge"})
+                assert r.status_code == 403
+                monkeypatch.setenv("VYMANAGER_ALLOW_EMPTY_RESTORE", "1")
+                r2 = anon.post(
+                    "/session/restore",
+                    files={"file": ("b.vymgr", b"x")},
+                    data={"passphrase": "pw", "mode": "merge",
+                          "confirm": "merge"})
+                # Gate opens; the dummy file then fails to decrypt (400).
+                assert r2.status_code == 400
+    finally:
+        asyncio.run(cleanup())


### PR DESCRIPTION
Closes #456. Third hardening-chain link, part A. Two restore-safety holes, independent of org scoping and **not** gated by `ORG_ENFORCEMENT` (these are unconditional safety fixes).

## 1. Unauthenticated full-DB restore on a fresh install — closed

`_require_backup_admin` allowed **anyone** when `users` was empty. On a fresh install before onboarding, an unauthenticated attacker could `POST /session/restore` with a crafted backup and seize the deployment. The zero-users disaster-recovery path is now **closed by default** and must be enabled by the operator for the recovery via `VYMANAGER_ALLOW_EMPTY_RESTORE`; unset → empty-system restore is 403, and the enablement is logged.

## 2. Typed confirmation on restore

Restore requires a `confirm` field equal to the mode (`replace`/`merge`); a mismatch is 400 — defeats accidental and CSRF-style restores of a destructive operation.

## Evidence

Live, two databases:
- Admin restore: no confirm → 400; wrong confirm → 400; `confirm=merge` → 200; `confirm=replace` (replace mode) → 200.
- Empty-system, unauthenticated: **403 closed** without the env; with `VYMANAGER_ALLOW_EMPTY_RESTORE=1` the gate opens (dummy file then 400 on decrypt, proving the gate passed).
- Tests: env-helper parsing (no DB) + DB-gated integration for both holes. Full suite 77 passed / 17 skipped.

## Deferred

Org-scoped **export** (single-org backup for an org ADMIN vs whole-DB for a System Administrator) is split to its own issue — it needs a scoping-semantics decision for global rows (users, oauth providers).

## For the reviewer

The default-deny on empty-system restore changes disaster-recovery ergonomics: operators must now set an env var to restore onto a truly empty install. That is the intended trade — an unauthenticated full-DB write should not be silently available.