### PR TITLE
feat: add audit context columns and audit the admin surface

### DIFF
--- a/backend/middleware/audit.py
+++ b/backend/middleware/audit.py
@@ -26,18 +26,26 @@ logger = logging.getLogger(__name__)
 class AuditMiddleware(BaseHTTPMiddleware):
     AUDITED_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
+    # Prefixes whose mutating calls are authz-relevant: VyOS config changes
+    # plus the admin surface (site/instance/user/grant/token/backup lifecycle).
+    AUDITED_PREFIXES = ("/vyos/", "/session/", "/user-management", "/tokens")
+
     def _should_audit(self, request) -> bool:
         if request.method not in self.AUDITED_METHODS:
             return False
-        # Config-mutating surface only. Reads (GET) and auth/session plumbing are
-        # excluded; the /vyos/* prefix covers every feature batch endpoint.
-        return request.url.path.startswith("/vyos/")
+        path = request.url.path
+        return any(path.startswith(p) for p in self.AUDITED_PREFIXES)
 
     @staticmethod
     def _feature_from_path(path: str) -> str:
-        # "/vyos/nat/batch" -> "nat"; "/vyos/firewall/ipv4/batch" -> "firewall"
+        # "/vyos/nat/batch" -> "nat"; "/vyos/firewall/ipv4/batch" -> "firewall";
+        # "/tokens" -> "tokens"; "/user-management/users" -> "user-management".
         parts = [p for p in path.split("/") if p]
-        return parts[1] if len(parts) >= 2 else "unknown"
+        if not parts:
+            return "unknown"
+        if parts[0] == "vyos":
+            return parts[1] if len(parts) >= 2 else "unknown"
+        return parts[0]
 
     async def dispatch(self, request, call_next):
         if not self._should_audit(request):
@@ -61,6 +69,11 @@ class AuditMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         feature = self._feature_from_path(path)
         instance = getattr(request.state, "instance", None) or {}
+        site = getattr(request.state, "site", None) or {}
+        org = getattr(request.state, "org", None) or {}
+        # Admin-surface endpoints have no active instance, so state.org is
+        # unset; the org they acted in is the org_conn_admin acting org.
+        org_id = org.get("id") or getattr(request.state, "acting_org_id", None)
         success = response.status_code < 400
 
         details = {
@@ -84,8 +97,10 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 """
                 INSERT INTO audit_logs
                     (id, "userId", "userEmail", action, resource, details,
-                     "ipAddress", "userAgent", "createdAt")
-                VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5::jsonb, $6, $7, NOW())
+                     "ipAddress", "userAgent", "orgId", "siteId", "instanceId",
+                     "createdAt")
+                VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5::jsonb, $6,
+                        $7, $8, $9, $10, NOW())
                 """,
                 user["id"],
                 user.get("email") or "",
@@ -94,4 +109,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 json.dumps(details),
                 ip,
                 user_agent,
+                org_id,
+                site.get("id"),
+                instance.get("id"),
             )

--- a/backend/tests/test_audit_coverage.py
+++ b/backend/tests/test_audit_coverage.py
@@ -1,0 +1,85 @@
+"""Audit coverage: mutating admin calls are recorded with context columns."""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import os
+
+import pytest
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="audit-coverage test needs DATABASE_URL",
+)
+
+SECRET = b"audit-coverage-secret"
+
+
+def _cookie(token):
+    sig = base64.b64encode(
+        hmac.new(SECRET, token.encode(), hashlib.sha256).digest()).decode()
+    return f"{token}.{sig}"
+
+
+@requires_db
+def test_admin_mutation_audited_with_context(monkeypatch):
+    import asyncpg
+    import session_cookie
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(session_cookie, "_secret", SECRET)
+    db = os.environ["DATABASE_URL"]
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM audit_logs")
+        await conn.execute("DELETE FROM users WHERE id = 'u_au'")
+        await conn.execute(
+            "INSERT INTO users (id,email,name,role,\"emailVerified\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('u_au','au@cov.test','AU','ADMIN',true,NOW(),NOW())")
+        await conn.execute(
+            "INSERT INTO org_memberships (id,\"userId\",\"orgId\",\"orgRole\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('om_au','u_au','default','OWNER',NOW(),NOW())")
+        await conn.execute(
+            "INSERT INTO sessions (id,token,\"userId\",\"expiresAt\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('s_au','tok_au','u_au',NOW()+interval '1 hour',NOW(),NOW())")
+        await conn.close()
+
+    async def fetch_audit():
+        conn = await asyncpg.connect(db)
+        rows = await conn.fetch(
+            'SELECT action, resource, "userEmail", "orgId"'
+            ' FROM audit_logs ORDER BY "createdAt"')
+        gets = await conn.fetchval(
+            "SELECT COUNT(*) FROM audit_logs WHERE action LIKE 'GET%'")
+        await conn.close()
+        return rows, gets
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_au'")
+        await conn.execute("DELETE FROM sites WHERE name = 'Audit Cov Site'")
+        await conn.close()
+
+    from app import app
+    asyncio.run(seed())
+    try:
+        with TestClient(app) as client:
+            client.cookies.set("better-auth.session_token", _cookie("tok_au"))
+            client.get("/user-management/users")          # read -> not audited
+            r = client.post("/session/sites",
+                            json={"name": "Audit Cov Site", "description": "x"})
+            assert r.status_code == 201
+        rows, gets = asyncio.run(fetch_audit())
+        assert gets == 0, "GET requests must not be audited"
+        actions = {r["action"] for r in rows}
+        assert "POST_SESSION" in actions
+        site_row = next(r for r in rows if r["resource"] == "/session/sites")
+        assert site_row["userEmail"] == "au@cov.test"
+        assert site_row["orgId"] == "default"
+    finally:
+        asyncio.run(cleanup())

--- a/frontend/prisma/migrations/20260709_audit_context_columns/migration.sql
+++ b/frontend/prisma/migrations/20260709_audit_context_columns/migration.sql
@@ -1,0 +1,11 @@
+-- Real context columns for audit logs. Previously the instance was only
+-- recorded inside the JSON details blob; the org/site were not captured at
+-- all. Additive and nullable — old rows and non-instance actions leave them
+-- null. The actor stays in the existing userId/userEmail columns.
+ALTER TABLE "audit_logs"
+    ADD COLUMN "orgId" TEXT,
+    ADD COLUMN "siteId" TEXT,
+    ADD COLUMN "instanceId" TEXT;
+
+CREATE INDEX "audit_logs_orgId_idx" ON "audit_logs"("orgId");
+CREATE INDEX "audit_logs_instanceId_idx" ON "audit_logs"("instanceId");

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -188,8 +188,16 @@ model AuditLog {
   userAgent String?
   createdAt DateTime @default(now())
 
+  // Real context columns (nullable): the org/site/instance the action
+  // touched. The actor is userId/userEmail above.
+  orgId      String?
+  siteId     String?
+  instanceId String?
+
   @@index([userId])
   @@index([createdAt])
+  @@index([orgId])
+  @@index([instanceId])
   @@map("audit_logs")
 }
 


### PR DESCRIPTION
Closes #458. Fourth hardening-chain link.

## What

- **Real context columns** on `audit_logs`: `orgId` / `siteId` / `instanceId` (additive, nullable). The actor stays in `userId` / `userEmail`. Migration `20260709_audit_context_columns`, schema updated, no drift.
- **Broadened coverage**: `AuditMiddleware` now records mutating methods (POST/PUT/PATCH/DELETE) on `/session`, `/user-management` and `/tokens` alongside the existing `/vyos/*`. It populates the new columns from `request.state`; the org falls back to the `org_conn_admin` acting org for admin endpoints that have no active instance.

Middleware-level, so coverage is uniform with no per-handler instrumentation.

## Evidence

Live: `POST /session/sites` and `POST /tokens` each write an `audit_logs` row with `userEmail` and `orgId='default'`; `GET /user-management/users` writes nothing. Migration applies cleanly and matches the schema. Tests: DB-gated coverage test (mutating call recorded with context, GET not) + full suite 77 passed / 18 skipped.

## Deferred

**Append-only by table privileges** (runtime role INSERT/SELECT only on `audit_logs`) depends on the fenced low-privilege role introduced with row-level security — it lands in the RLS PR. OAuth-config auditing is in the frontend Prisma routes, out of scope for this backend change.

## For the reviewer

Coverage is by URL prefix; confirm the audited admin prefixes are the right set and nothing sensitive is left unaudited among mutating admin routes.