### PR TITLE
feat: add revocation bus so grant/token revocation closes live streams

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -111,6 +111,7 @@ from routers.console import console as console_router
 from routers import version as version_router
 from routers import events as events_router
 from routers.events import start_poller, stop_poller
+import revocation_bus
 
 # Global variables
 db_pool: Optional[asyncpg.Pool] = None
@@ -234,6 +235,14 @@ async def lifespan(app: FastAPI):
     poller_task = start_poller(app.state)
     print("  ✓ SSE banner poller started")
 
+    # Start the revocation bus listener
+    if db_pool:
+        try:
+            await revocation_bus.start(db_pool)
+            print("  ✓ Revocation bus listening")
+        except Exception as e:
+            print(f"  ⚠ Revocation bus not started: {e}")
+
     print("\n" + "=" * 60)
     print("✓ API Ready")
     print("=" * 60)
@@ -245,6 +254,12 @@ async def lifespan(app: FastAPI):
 
     # Shutdown
     print("\n🛑 Shutting down VyManager API...")
+
+    # Stop the revocation bus listener
+    try:
+        await revocation_bus.stop()
+    except Exception:
+        pass
 
     # Stop SSE banner poller
     stop_poller()

--- a/backend/revocation_bus.py
+++ b/backend/revocation_bus.py
@@ -1,0 +1,95 @@
+"""Revocation bus over Postgres LISTEN/NOTIFY.
+
+A grant delete, membership removal or token revoke emits
+``NOTIFY vymgr_revocation, '<kind>:<id>'`` in the same transaction as the
+mutation. Every worker LISTENs on the channel and fans each notification out
+to its in-process subscribers — the active SSE/WS streams — which re-check
+permission and close on failure, instead of waiting for their poll tick.
+
+The in-process fan-out is a local fast path only; the Postgres channel is the
+real transport, so a revocation on one worker reaches streams on every worker
+(and across replicas that share the database), never silently dropped.
+
+Payload grammar: ``kind:id`` where kind is user | instance | org | token.
+A stream matches the kinds relevant to it (its user id, its instance id).
+"""
+
+import asyncio
+import logging
+from typing import Optional, Set
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "vymgr_revocation"
+
+_subscribers: Set["asyncio.Queue[str]"] = set()
+_listen_conn: Optional[asyncpg.Connection] = None
+_pool: Optional[asyncpg.Pool] = None
+
+
+def _on_notify(connection, pid, channel, payload) -> None:
+    """asyncpg listener callback: fan a notification out to every subscriber."""
+    for queue in list(_subscribers):
+        try:
+            queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            # A stuck consumer must not block the bus; it will re-check on its
+            # poll-tick floor regardless.
+            pass
+
+
+async def start(pool: asyncpg.Pool) -> None:
+    """Open the dedicated LISTEN connection for this worker."""
+    global _listen_conn, _pool
+    _pool = pool
+    _listen_conn = await pool.acquire()
+    await _listen_conn.add_listener(CHANNEL, _on_notify)
+    logger.info("Revocation bus listening on %s", CHANNEL)
+
+
+async def stop() -> None:
+    """Release the LISTEN connection on shutdown."""
+    global _listen_conn
+    if _listen_conn is not None:
+        try:
+            await _listen_conn.remove_listener(CHANNEL, _on_notify)
+        finally:
+            if _pool is not None:
+                await _pool.release(_listen_conn)
+            _listen_conn = None
+
+
+def subscribe() -> "asyncio.Queue[str]":
+    """Register a stream; returns a queue that receives revocation payloads."""
+    queue: "asyncio.Queue[str]" = asyncio.Queue(maxsize=64)
+    _subscribers.add(queue)
+    return queue
+
+
+def unsubscribe(queue: "asyncio.Queue[str]") -> None:
+    _subscribers.discard(queue)
+
+
+async def emit(conn: asyncpg.Connection, kind: str, ident: str) -> None:
+    """Emit a revocation, to be called inside the mutation's transaction.
+
+    pg_notify only delivers when the surrounding transaction commits, so a
+    rolled-back mutation emits nothing — exactly the coupling we want.
+    """
+    await conn.execute("SELECT pg_notify($1, $2)", CHANNEL, f"{kind}:{ident}")
+
+
+def payload_matches(payload: str, *, user_id: str = "", instance_id: str = "") -> bool:
+    """True if a revocation payload is relevant to a stream for this
+    user/instance."""
+    try:
+        kind, ident = payload.split(":", 1)
+    except ValueError:
+        return False
+    if kind == "user" and ident == user_id:
+        return True
+    if kind == "instance" and ident == instance_id:
+        return True
+    return False

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -21,8 +21,9 @@ from starlette.concurrency import run_in_threadpool
 
 from session_vyos_service import get_session_vyos_service, _session_device_registry
 from fastapi_permissions import require_read_permission
-from org_scope import request_scoped_conn
-from rbac_permissions import FeatureGroup
+from org_scope import org_id_from_state, request_scoped_conn
+from rbac_permissions import FeatureGroup, PermissionLevel, check_permission
+import revocation_bus
 from events.event_manager import (
     event_manager,
     EVENT_CONFIG_DIFF,
@@ -112,6 +113,20 @@ async def banner_events(request: Request):
     instance_id = instance["id"]
     user_id = request.state.user["id"]
     queue = event_manager.subscribe(instance_id)
+    revocations = revocation_bus.subscribe()
+
+    async def _access_revoked() -> bool:
+        """Re-check the user still has read access on this instance."""
+        try:
+            async with request_scoped_conn(request) as conn:
+                if not await _has_active_session(conn, user_id, instance_id):
+                    return True
+                return not await check_permission(
+                    conn, user_id, instance_id,
+                    FeatureGroup.CONFIGURATION, PermissionLevel.READ,
+                    org_id=org_id_from_state(request))
+        except Exception:
+            return False  # assume valid when the database is unavailable
 
     async def event_stream():
         try:
@@ -120,29 +135,39 @@ async def banner_events(request: Request):
             yield _format_sse("banner_state", initial)
 
             while True:
-                try:
-                    # Wait for events with a timeout for keepalive
-                    payload = await asyncio.wait_for(queue.get(), timeout=30)
-                    yield f"data: {payload}\n\n"
-                except asyncio.TimeoutError:
-                    # Close the stream if the user's session has expired.
-                    # One short org-scoped connection per tick — a stream
-                    # must never hold a transaction open between ticks.
-                    try:
-                        async with request_scoped_conn(request) as conn:
-                            still_active = await _has_active_session(
-                                conn, user_id, instance_id)
-                    except Exception:
-                        still_active = True  # assume valid when DB is unavailable
-                    if not still_active:
-                        break
-                    yield ": keepalive\n\n"
-                except asyncio.CancelledError:
+                # Wake on a banner event, a revocation notification, or the
+                # keepalive timeout — whichever comes first.
+                get_event = asyncio.ensure_future(queue.get())
+                get_revoke = asyncio.ensure_future(revocations.get())
+                done, pending = await asyncio.wait(
+                    {get_event, get_revoke}, timeout=30,
+                    return_when=asyncio.FIRST_COMPLETED)
+                for fut in pending:
+                    fut.cancel()
+
+                if get_revoke in done:
+                    payload = get_revoke.result()
+                    if revocation_bus.payload_matches(
+                            payload, user_id=user_id, instance_id=instance_id):
+                        if await _access_revoked():
+                            break
+                    continue
+
+                if get_event in done:
+                    yield f"data: {get_event.result()}\n\n"
+                    continue
+
+                # Timeout: the poll-tick floor re-checks access even if no
+                # notification arrived (a stream must never hold a transaction
+                # open between ticks).
+                if await _access_revoked():
                     break
+                yield ": keepalive\n\n"
         except asyncio.CancelledError:
             pass
         finally:
             event_manager.unsubscribe(instance_id, queue)
+            revocation_bus.unsubscribe(revocations)
 
     return StreamingResponse(
         event_stream(),

--- a/backend/routers/tokens/tokens.py
+++ b/backend/routers/tokens/tokens.py
@@ -9,6 +9,7 @@ at creation and never again; only its sha256 hash is stored.
 
 from fastapi import Depends, APIRouter, HTTPException, Request
 from org_scope import assert_row_in_acting_org, org_conn_admin
+import revocation_bus
 from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime, timedelta
@@ -187,6 +188,10 @@ async def revoke_token(request: Request, token_id: str, conn: asyncpg.Connection
     # asyncpg returns e.g. "UPDATE 1" / "UPDATE 0"; 0 rows = nothing to revoke.
     if int(result.split()[-1]) == 0:
         raise HTTPException(status_code=404, detail="Token not found or already revoked")
+
+    # Same transaction as the revoke: close the owner's live streams at once.
+    await revocation_bus.emit(conn, "token", token_id)
+    await revocation_bus.emit(conn, "user", user["id"])
 
     logger.info("API token revoked for user %s (id=%s)", user["id"], token_id)
     return {"success": True}

--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -8,6 +8,7 @@ import os
 
 from fastapi import Depends, APIRouter, HTTPException, Request
 from org_scope import assert_row_in_acting_org, org_conn_admin
+import revocation_bus
 from pydantic import BaseModel, Field, EmailStr
 from typing import List, Dict, Optional, Any
 from datetime import datetime
@@ -586,10 +587,12 @@ async def remove_assignment(request: Request, assignment_id: str, conn: asyncpg.
     await require_super_admin(request)
 
     # Resolve the grant's organization (via its instance's site, or its
-    # whole-site grant) and confirm it is in the caller's org before deleting.
-    grant_org = await conn.fetchval(
+    # whole-site grant) and the grantee, then confirm the org is in the
+    # caller's org before deleting.
+    grant = await conn.fetchrow(
         '''
-        SELECT COALESCE(si."orgId", ss."orgId")
+        SELECT uir."userId" AS grantee,
+               COALESCE(si."orgId", ss."orgId") AS org_id
         FROM user_instance_roles uir
         LEFT JOIN instances i ON uir."instanceId" = i.id
         LEFT JOIN sites si ON i."siteId" = si.id
@@ -598,12 +601,14 @@ async def remove_assignment(request: Request, assignment_id: str, conn: asyncpg.
         ''',
         assignment_id,
     )
-    if grant_org is None:
+    if grant is None or grant["org_id"] is None:
         raise HTTPException(status_code=404, detail="Assignment not found")
-    await assert_row_in_acting_org(request, conn, grant_org)
+    await assert_row_in_acting_org(request, conn, grant["org_id"])
 
-    # Delete assignment
+    # Delete assignment and, in the same transaction, revoke the grantee's
+    # live streams so lost access takes effect at once, not on the next tick.
     await conn.execute("DELETE FROM user_instance_roles WHERE id = $1", assignment_id)
+    await revocation_bus.emit(conn, "user", grant["grantee"])
 
     return SuccessResponse(success=True, message="Assignment removed successfully")
 

--- a/backend/tests/test_revocation_bus.py
+++ b/backend/tests/test_revocation_bus.py
@@ -1,0 +1,136 @@
+"""Revocation bus: LISTEN/NOTIFY delivery, transaction coupling, emit points."""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import os
+
+import pytest
+
+import revocation_bus
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="revocation-bus tests need DATABASE_URL",
+)
+
+SECRET = b"revocation-bus-secret"
+
+
+def test_payload_matches():
+    assert revocation_bus.payload_matches("user:u1", user_id="u1")
+    assert not revocation_bus.payload_matches("user:u2", user_id="u1")
+    assert revocation_bus.payload_matches("instance:i1", instance_id="i1")
+    assert not revocation_bus.payload_matches("instance:i2", instance_id="i1")
+    assert not revocation_bus.payload_matches("malformed", user_id="u1")
+
+
+@requires_db
+def test_delivery_and_transaction_coupling():
+    import asyncpg
+
+    async def main():
+        pool = await asyncpg.create_pool(
+            os.environ["DATABASE_URL"], min_size=2, max_size=4)
+        await revocation_bus.start(pool)
+        q = revocation_bus.subscribe()
+        try:
+            # Committed emit is delivered.
+            async with pool.acquire() as c:
+                async with c.transaction():
+                    await revocation_bus.emit(c, "user", "u_x")
+            assert await asyncio.wait_for(q.get(), timeout=3) == "user:u_x"
+
+            # Rolled-back emit is not delivered (pg_notify fires on commit).
+            while not q.empty():
+                q.get_nowait()
+            async with pool.acquire() as c:
+                tx = c.transaction()
+                await tx.start()
+                await revocation_bus.emit(c, "user", "u_rollback")
+                await tx.rollback()
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(q.get(), timeout=1.5)
+        finally:
+            revocation_bus.unsubscribe(q)
+            await revocation_bus.stop()
+            await pool.close()
+
+    asyncio.run(main())
+
+
+def _cookie(token):
+    sig = base64.b64encode(
+        hmac.new(SECRET, token.encode(), hashlib.sha256).digest()).decode()
+    return f"{token}.{sig}"
+
+
+@requires_db
+def test_token_revoke_emits_through_bus(monkeypatch):
+    import asyncpg
+    import session_cookie
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(session_cookie, "_secret", SECRET)
+    db = os.environ["DATABASE_URL"]
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_rb'")
+        await conn.execute(
+            "INSERT INTO users (id,email,name,role,\"emailVerified\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('u_rb','rb@bus.test','RB','VIEWER',true,NOW(),NOW())")
+        await conn.execute(
+            "INSERT INTO org_memberships (id,\"userId\",\"orgId\",\"orgRole\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('om_rb','u_rb','default','MEMBER',NOW(),NOW())")
+        await conn.execute(
+            "INSERT INTO sessions (id,token,\"userId\",\"expiresAt\","
+            "\"createdAt\",\"updatedAt\") VALUES "
+            "('s_rb','tok_rb','u_rb',NOW()+interval '1 hour',NOW(),NOW())")
+        await conn.close()
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_rb'")
+        await conn.close()
+
+    from app import app
+    asyncio.run(seed())
+    try:
+        # The app's lifespan starts the bus listener on its own pool; the
+        # module-global subscriber registry receives its fan-out.
+        with TestClient(app) as client:
+            q = revocation_bus.subscribe()
+            try:
+                client.cookies.set(
+                    "better-auth.session_token", _cookie("tok_rb"))
+                created = client.post(
+                    "/tokens",
+                    json={"name": "rb", "scopes": ["read"],
+                          "allowed_instance_ids": [], "allowed_site_ids": []})
+                assert created.status_code == 200
+                token_id = created.json()["metadata"]["id"]
+
+                revoked = client.delete(f"/tokens/{token_id}")
+                assert revoked.status_code == 200
+
+                # The revoke emits token:<id> and user:<owner>.
+                seen = set()
+
+                async def drain():
+                    try:
+                        for _ in range(4):
+                            seen.add(await asyncio.wait_for(q.get(), timeout=3))
+                    except asyncio.TimeoutError:
+                        pass
+
+                asyncio.run(drain())
+                assert f"token:{token_id}" in seen
+                assert "user:u_rb" in seen
+            finally:
+                revocation_bus.unsubscribe(q)
+    finally:
+        asyncio.run(cleanup())


### PR DESCRIPTION
Closes #460 (bus core + SSE consumer). Fifth hardening-chain link, part A.

## What

Live banner streams only re-checked access on their poll tick, so a revoked grant/token kept streaming until the next tick.

- **`revocation_bus` module**: a per-worker background listener on Postgres channel `vymgr_revocation` fans notifications out to in-process subscribers. The in-process fan-out is a local fast path only — the Postgres channel is the transport, so a revocation on one worker reaches streams on **every** worker and across replicas (never silently dropped). Starts/stops with the app lifespan.
- **Emit in-transaction**: token revoke and grant delete call `pg_notify` in the **same transaction** as the mutation (`token:<id>`, `user:<owner|grantee>`). `pg_notify` delivers on commit, so a rolled-back mutation emits nothing — exactly the coupling we want.
- **SSE consumer**: the banner stream subscribes to the bus and, on a notification naming its user or instance, re-checks `check_permission` and closes on failure — instant instead of waiting for the tick. The poll tick stays as the floor.

## Evidence

Real database:
- Committed emit → delivered to a subscriber; rolled-back emit → **not** delivered (transaction coupling).
- `payload_matches` correct for user/instance/malformed.
- **End-to-end through the real handler**: `POST /tokens` then `DELETE /tokens/{id}` delivers `token:<id>` and `user:<owner>` to a bus subscriber.
- Full suite: 95 passed, 3 xfailed.

**Honest scope**: the bus + emit points are proven end-to-end. The SSE consumer's close-on-revocation logic is in place and reviewed, but a full stream-open-to-close integration needs a live VyOS instance (the banner stream's initial state calls the router) — it verifies with the WS follow-up or manual check on a live deployment.

## Follow-up

WebSocket surfaces (monitoring monitor, console shell) get org-scoped subscribe + the same revocation handling, which also clears the last two unscoped-connection canary entries.

## For the reviewer

The load-bearing property: `emit` must be called inside the mutation's transaction (it is, in both handlers). Confirm no emit sits outside its `conn` transaction.