### PR TITLE
feat: org-scope the monitoring/console WebSockets and wire revocation

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -209,6 +209,56 @@ async def org_conn_admin(
         yield conn
 
 
+def _ws_pool(websocket) -> asyncpg.Pool:
+    pool = getattr(websocket.app.state, "db_pool", None)
+    if pool is None:
+        raise RuntimeError("Database not available")
+    return pool
+
+
+@asynccontextmanager
+async def ws_conn(websocket) -> AsyncIterator[asyncpg.Connection]:
+    """Identity-resolution connection for a WebSocket, which authenticates
+    outside the HTTP middleware. No org context yet — this is the pre-org
+    "who is this and what is their active instance" lookup, the WS analogue
+    of the auth middleware. Keeping the pool access here (not in the router)
+    keeps the WS routers off the unscoped-connection canary."""
+    pool = _ws_pool(websocket)
+    async with pool.acquire() as conn:
+        yield conn
+
+
+@asynccontextmanager
+async def ws_org_conn(
+    websocket, user_id: str, instance_id: str
+) -> AsyncIterator[asyncpg.Connection]:
+    """One short org-scoped connection for a WebSocket unit of work.
+
+    Resolves the instance's org and the user's deployment role, applies the
+    org context, and yields. A WS holds a long-lived SSH stream, so — like the
+    /vyos permission path — it must take short scoped connections per unit of
+    work, never hold one across the stream.
+    """
+    pool = _ws_pool(websocket)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            row = await conn.fetchrow(
+                'SELECT s."orgId" AS org_id,'
+                ' (SELECT role FROM users WHERE id = $2) AS role'
+                ' FROM instances i JOIN sites s ON i."siteId" = s.id'
+                ' WHERE i.id = $1',
+                instance_id, user_id)
+            org_id = row["org_id"] if row else None
+            is_admin = bool(row and row["role"] == "ADMIN")
+            await conn.execute(
+                "SELECT set_config('app.org_id', $1, true),"
+                "       set_config('app.is_system_admin', $2, true)",
+                org_id or "",
+                "true" if is_admin else "false",
+            )
+            yield conn
+
+
 @asynccontextmanager
 async def request_scoped_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
     """Org-scoped connection for code called from request context.

--- a/backend/routers/console/console.py
+++ b/backend/routers/console/console.py
@@ -30,7 +30,8 @@ from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisco
 from pydantic import BaseModel
 
 from fastapi_permissions import require_read_permission
-from org_scope import request_scoped_conn
+from org_scope import request_scoped_conn, ws_conn, ws_org_conn
+import revocation_bus
 from rbac_permissions import FeatureGroup, PermissionLevel, check_permission
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key
@@ -146,7 +147,6 @@ async def websocket_console(websocket: WebSocket):
     user_id = user_info["user_id"]
     instance_id = user_info["instance_id"]
 
-    db_pool = websocket.app.state.db_pool
 
     # If the user has an existing console session, cancel it so this new one can
     # take over. This handles browser refreshes, React Strict Mode double-mount in
@@ -172,13 +172,14 @@ async def websocket_console(websocket: WebSocket):
     _active_console_sessions.pop(user_id, None)
 
     # RBAC: require SSH_CONSOLE WRITE permission
-    has_perm = await check_permission(
-        db_pool,
-        user_id,
-        instance_id,
-        FeatureGroup.SSH_CONSOLE,
-        PermissionLevel.WRITE,
-    )
+    async with ws_org_conn(websocket, user_id, instance_id) as conn:
+        has_perm = await check_permission(
+            conn,
+            user_id,
+            instance_id,
+            FeatureGroup.SSH_CONSOLE,
+            PermissionLevel.WRITE,
+        )
 
     if not has_perm:
         await websocket.send_json({
@@ -193,7 +194,7 @@ async def websocket_console(websocket: WebSocket):
     ssh_process = None
 
     try:
-        async with db_pool.acquire() as conn:
+        async with ws_org_conn(websocket, user_id, instance_id) as conn:
             instance = await conn.fetchrow(
                 """
                 SELECT host,
@@ -451,7 +452,7 @@ async def websocket_console(websocket: WebSocket):
                 await asyncio.sleep(30)
                
                 try:
-                    async with db_pool.acquire() as conn:
+                    async with ws_conn(websocket) as conn:
                         session = await conn.fetchrow(
                             """
                             SELECT s."expiresAt"
@@ -513,13 +514,15 @@ async def websocket_console(websocket: WebSocket):
 
                             return
 
-                    still_allowed = await check_permission(
-                        db_pool,
-                        user_id,
-                        instance_id,
-                        FeatureGroup.SSH_CONSOLE,
-                        PermissionLevel.WRITE,
-                    )
+                    async with ws_org_conn(
+                            websocket, user_id, instance_id) as conn:
+                        still_allowed = await check_permission(
+                            conn,
+                            user_id,
+                            instance_id,
+                            FeatureGroup.SSH_CONSOLE,
+                            PermissionLevel.WRITE,
+                        )
 
                     if not still_allowed:
                         logger.warning(
@@ -564,10 +567,39 @@ async def websocket_console(websocket: WebSocket):
 
                     return
 
+        async def watch_revocation():
+            """Close the shell instantly when a revocation removes access
+            (the 30s monitor_auth loop is the floor)."""
+            queue = revocation_bus.subscribe()
+            try:
+                while True:
+                    payload = await queue.get()
+                    if not revocation_bus.payload_matches(
+                            payload, user_id=user_id, instance_id=instance_id):
+                        continue
+                    try:
+                        async with ws_org_conn(
+                                websocket, user_id, instance_id) as conn:
+                            still = await check_permission(
+                                conn, user_id, instance_id,
+                                FeatureGroup.SSH_CONSOLE,
+                                PermissionLevel.WRITE)
+                    except Exception:
+                        still = True  # DB unavailable: do not tear down
+                    if not still:
+                        await _safe_send(websocket, {
+                            "type": "disconnected",
+                            "reason": "Permissions revoked",
+                        })
+                        return
+            finally:
+                revocation_bus.unsubscribe(queue)
+
         output_task = asyncio.create_task(stream_output())
         input_task = asyncio.create_task(forward_input())
         duration_task = asyncio.create_task(check_max_duration())
         auth_task = asyncio.create_task(monitor_auth())
+        revocation_task = asyncio.create_task(watch_revocation())
 
         done, pending = await asyncio.wait(
             [
@@ -575,6 +607,7 @@ async def websocket_console(websocket: WebSocket):
                 input_task,
                 duration_task,
                 auth_task,
+                revocation_task,
             ],
             return_when=asyncio.FIRST_COMPLETED,
         )
@@ -739,7 +772,7 @@ async def _authenticate_websocket(websocket: WebSocket) -> Optional[dict]:
         await websocket.close()
         return None
 
-    async with db_pool.acquire() as conn:
+    async with ws_conn(websocket) as conn:
         session = await conn.fetchrow(
             """
             SELECT s.id,

--- a/backend/routers/monitoring/monitoring.py
+++ b/backend/routers/monitoring/monitoring.py
@@ -23,7 +23,13 @@ from pydantic import BaseModel, Field
 from monitoring_commands import build_command, get_available_commands
 from rbac_permissions import FeatureGroup, check_permission, PermissionLevel
 from fastapi_permissions import require_read_permission, require_super_admin
-from org_scope import assert_row_in_acting_org, request_scoped_conn
+from org_scope import (
+    assert_row_in_acting_org,
+    request_scoped_conn,
+    ws_conn,
+    ws_org_conn,
+)
+import revocation_bus
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key, generate_keypair
 
@@ -283,7 +289,6 @@ async def websocket_monitor(websocket: WebSocket):
 
     user_id = user_info["user_id"]
     instance_id = user_info["instance_id"]
-    db_pool = websocket.app.state.db_pool
 
     # Check if user already has an active monitoring session
     if user_id in _active_sessions and not _active_sessions[user_id].done():
@@ -294,10 +299,12 @@ async def websocket_monitor(websocket: WebSocket):
         await websocket.close()
         return
 
-    # Check WRITE permission for MONITORING
-    has_permission = await check_permission(
-        db_pool, user_id, instance_id, FeatureGroup.MONITORING, PermissionLevel.WRITE
-    )
+    # Check WRITE permission for MONITORING on a short org-scoped connection.
+    async with ws_org_conn(websocket, user_id, instance_id) as conn:
+        has_permission = await check_permission(
+            conn, user_id, instance_id,
+            FeatureGroup.MONITORING, PermissionLevel.WRITE,
+        )
     if not has_permission:
         await websocket.send_json({
             "type": "error",
@@ -331,8 +338,8 @@ async def websocket_monitor(websocket: WebSocket):
             await websocket.close()
             return
 
-        # Get instance SSH config
-        async with db_pool.acquire() as conn:
+        # Get instance SSH config (short org-scoped connection)
+        async with ws_org_conn(websocket, user_id, instance_id) as conn:
             instance = await conn.fetchrow(
                 """
                 SELECT host, "sshPort", "sshUsername", "sshEncryptedPrivKey",
@@ -466,12 +473,35 @@ async def websocket_monitor(websocket: WebSocket):
                     })
                     return
 
+        async def watch_revocation():
+            """Close the stream when a revocation removes MONITORING access."""
+            queue = revocation_bus.subscribe()
+            try:
+                while True:
+                    payload = await queue.get()
+                    if not revocation_bus.payload_matches(
+                            payload, user_id=user_id, instance_id=instance_id):
+                        continue
+                    try:
+                        async with ws_org_conn(
+                                websocket, user_id, instance_id) as conn:
+                            still = await check_permission(
+                                conn, user_id, instance_id,
+                                FeatureGroup.MONITORING, PermissionLevel.WRITE)
+                    except Exception:
+                        still = True  # DB unavailable: do not tear down
+                    if not still:
+                        return
+            finally:
+                revocation_bus.unsubscribe(queue)
+
         output_task = asyncio.create_task(stream_output())
         stop_task = asyncio.create_task(listen_for_stop())
         duration_task = asyncio.create_task(check_max_duration())
+        revocation_task = asyncio.create_task(watch_revocation())
 
         done, pending = await asyncio.wait(
-            [output_task, stop_task, duration_task],
+            [output_task, stop_task, duration_task, revocation_task],
             return_when=asyncio.FIRST_COMPLETED,
         )
 
@@ -525,8 +555,7 @@ async def _authenticate_websocket(websocket: WebSocket) -> Optional[dict]:
     Authenticate WebSocket connection using session cookie.
     Returns user_info dict or None if auth fails.
     """
-    db_pool = getattr(websocket.app.state, "db_pool", None)
-    if not db_pool:
+    if getattr(websocket.app.state, "db_pool", None) is None:
         await websocket.send_json({"type": "error", "data": "Database not available"})
         await websocket.close()
         return None
@@ -547,7 +576,7 @@ async def _authenticate_websocket(websocket: WebSocket) -> Optional[dict]:
         await websocket.close()
         return None
 
-    async with db_pool.acquire() as conn:
+    async with ws_conn(websocket) as conn:
         session = await conn.fetchrow(
             """
             SELECT s.id, s."userId", s."expiresAt", u.email, u.name

--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -30,13 +30,9 @@ PERMANENT_GLOBAL = {
         "the same file use org-scoped connections per tick.",
 }
 
-# Files not yet migrated to org-scoped connections. Each conversion wave
-# removes its entries; the target end state is an empty dict.
-MIGRATION_PENDING = {
-    # WebSocket handlers authenticate and authorize outside the HTTP
-    # middleware stack; their org scoping lands with the SSE/WS
-    # revocation-bus hardening item. HTTP handlers in these files
-    # already use org-scoped connections.
-    "routers/monitoring/monitoring.py": "monitoring websocket sessions",
-    "routers/console/console.py": "console shell websocket sessions",
-}
+# Files not yet migrated to org-scoped connections. The conversion waves
+# have emptied this list: every backend database access now goes through an
+# org-scoped connection (org_scope), and the WebSocket surfaces resolve org
+# context via ws_org_conn. A new entry here must carry a justification in the
+# PR that adds it.
+MIGRATION_PENDING = {}

--- a/backend/tests/test_org_scope.py
+++ b/backend/tests/test_org_scope.py
@@ -133,6 +133,57 @@ def test_system_admin_flag_tristate():
 
 
 # ---------------------------------------------------------------------------
+# WebSocket org context (real database)
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_ws_org_conn_resolves_instance_org_and_role():
+    import asyncpg
+    from org_scope import ws_org_conn
+
+    async def main():
+        pool = await asyncpg.create_pool(
+            os.environ["DATABASE_URL"], min_size=1, max_size=2)
+        conn0 = await pool.acquire()
+        try:
+            await conn0.execute("DELETE FROM users WHERE id = 'u_ws'")
+            await conn0.execute("DELETE FROM sites WHERE id = 's_ws'")
+            await conn0.execute(
+                "INSERT INTO organizations (id,name,\"createdAt\",\"updatedAt\")"
+                " VALUES ('org_ws','WS Org',NOW(),NOW())"
+                " ON CONFLICT (id) DO NOTHING")
+            await conn0.execute(
+                "INSERT INTO users (id,email,name,role,\"emailVerified\","
+                "\"createdAt\",\"updatedAt\") VALUES "
+                "('u_ws','ws@t.test','WS','ADMIN',true,NOW(),NOW())")
+            await conn0.execute(
+                "INSERT INTO sites (id,name,\"orgId\",\"createdAt\",\"updatedAt\")"
+                " VALUES ('s_ws','WS Site','org_ws',NOW(),NOW())")
+            await conn0.execute(
+                "INSERT INTO instances (id,\"siteId\",name,host,username,"
+                "password,\"createdAt\",\"updatedAt\") VALUES "
+                "('i_ws','s_ws','ws-r','192.0.2.9','v','p',NOW(),NOW())")
+
+            fake_ws = SimpleNamespace(app=SimpleNamespace(
+                state=SimpleNamespace(db_pool=pool)))
+            async with ws_org_conn(fake_ws, "u_ws", "i_ws") as conn:
+                assert await conn.fetchval(
+                    "SELECT current_setting('app.org_id', true)") == "org_ws"
+                # user u_ws is a deployment ADMIN -> System Administrator flag
+                assert await conn.fetchval(
+                    "SELECT current_setting('app.is_system_admin', true)"
+                ) == "true"
+        finally:
+            await conn0.execute("DELETE FROM users WHERE id = 'u_ws'")
+            await conn0.execute("DELETE FROM sites WHERE id = 's_ws'")
+            await conn0.execute("DELETE FROM organizations WHERE id = 'org_ws'")
+            await pool.release(conn0)
+            await pool.close()
+
+    asyncio.run(main())
+
+
+# ---------------------------------------------------------------------------
 # Connection scoping (real database)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fifth hardening-chain link, **part B** (revocation bus for the WebSocket surfaces). Follows #461. **Empties the unscoped-connection canary burn-down.**

## What

The monitoring and console WebSocket handlers authenticate outside the HTTP middleware, so they resolved connections straight from the pool. They now take org context through two new `org_scope` helpers:

- **`ws_conn`** — the pre-org identity lookup (who is this, what is their active instance — the WS analogue of the auth middleware).
- **`ws_org_conn`** — one short org-scoped connection per unit of work: resolves the instance's org and the user's role and applies the `SET LOCAL` context. Like the `/vyos` permission path, a WS never holds a connection across its long-lived SSH stream.

Pool access moved into `org_scope`, so the WS routers no longer reference the pool directly.

Both WebSockets **subscribe to the revocation bus**: on a notification naming the session's user or instance, they re-check `check_permission` on a short org-scoped connection and close on failure — instant, with the existing periodic re-check (console `monitor_auth`, 30s) as the floor.

## Canary burn-down complete

`MIGRATION_PENDING` is now `{}` — every backend database access goes through an org-scoped connection. A new entry must carry a justification in the PR that adds it. The canary already caught the two files as stale once converted (proving the burn-down honesty check works).

## Evidence

- `ws_org_conn` unit-tested against a real database: resolves the instance's org into `app.org_id` and sets the deployment-admin flag correctly.
- Canary green with the empty list; full suite 96 passed, 3 xfailed.
- **Honest scope**: the full WS open-to-revoke-close path needs an SSH-reachable router (the WS SSHes into the instance) and verifies on a live deployment. The bus delivery + emit + match are proven end-to-end in #461; the WS watchdog reuses that mechanism.

## For the reviewer

Check that no WS code path holds an `ws_org_conn` across the SSH stream — each is a short `async with` around a single unit of work. And that `ws_conn` (empty org) is used only for identity reads (sessions/users/active_sessions), never org-scoped rows.