### PR TITLE
fix: require a shared secret on internal API routes

### DIFF
--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -336,7 +336,16 @@ async def create_user(request: Request, body: CreateUserRequest, conn: asyncpg.C
                     "password": body.password,
                     "name": body.name,
                 },
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    # Shared secret for the internal route; both services have
+                    # BETTER_AUTH_SECRET, so no new configuration is required.
+                    "X-Internal-Auth": (
+                        os.getenv("INTERNAL_API_SECRET")
+                        or os.getenv("BETTER_AUTH_SECRET")
+                        or ""
+                    ),
+                },
             )
 
             if response.status_code != 200:

--- a/frontend/src/app/api/internal/create-user/route.ts
+++ b/frontend/src/app/api/internal/create-user/route.ts
@@ -1,14 +1,41 @@
 import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "crypto";
 import { getAuth } from "@/lib/auth";
 import { ApiError } from "@/lib/types/api";
+
+/**
+ * Guard an internal route with a shared secret. The secret is
+ * INTERNAL_API_SECRET, falling back to BETTER_AUTH_SECRET (which both the
+ * frontend and backend already have, so no new configuration is needed).
+ * Returns a NextResponse to short-circuit on failure, or null when allowed.
+ */
+export function requireInternalAuth(request: NextRequest): NextResponse | null {
+  const expected =
+    process.env.INTERNAL_API_SECRET || process.env.BETTER_AUTH_SECRET;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Server is not configured for internal requests" },
+      { status: 500 }
+    );
+  }
+  const provided = request.headers.get("x-internal-auth") || "";
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
 
 /**
  * Internal API endpoint for creating users from the backend.
  * Uses Better Auth's internal user creation to ensure proper password hashing.
  *
- * This endpoint should only be accessible from the backend container.
+ * This endpoint is only reachable with the internal shared secret.
  */
 export async function POST(request: NextRequest) {
+  const unauthorized = requireInternalAuth(request);
+  if (unauthorized) return unauthorized;
   try {
     const body = await request.json();
     const { email, password, name } = body;

--- a/frontend/src/app/api/internal/hash-password/route.ts
+++ b/frontend/src/app/api/internal/hash-password/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
+import { requireInternalAuth } from "../create-user/route";
 
 /**
  * Internal API endpoint for generating bcryptjs-compatible password hashes.
  * Used by the backend user management system to create Better Auth compatible users.
  *
- * This endpoint should only be accessible from the backend container (not public).
+ * This endpoint is only reachable with the internal shared secret.
  */
 export async function POST(request: NextRequest) {
+  const unauthorized = requireInternalAuth(request);
+  if (unauthorized) return unauthorized;
   try {
     const body = await request.json();
     const { password } = body;


### PR DESCRIPTION
Closes #463. Sixth hardening-chain link.

## What

`/api/internal/create-user` created a user (Better Auth `signUpEmail`) with **no authentication**; `/api/internal/hash-password` had the same open pattern. Anything able to reach the frontend container could create accounts or mint password hashes. The backend `create_user` handler is already gated by `require_super_admin`, so authorized creation is fine — the hole was the internal routes being open standalone.

Both routes now require an `X-Internal-Auth` header matching a shared secret (constant-time compare). Secret = `INTERNAL_API_SECRET`, falling back to `BETTER_AUTH_SECRET` — which **both services already have**, so the hole closes on every existing deployment with **zero new config**. Neither set → fail closed (500). The backend sends the header when calling create-user.

## Evidence

- Guard decision logic tested (node): correct header 200, wrong/missing 401, no-secret 500, `INTERNAL_API_SECRET` override 200 — 5/5.
- `tsc --noEmit` clean on the frontend (no errors in the changed routes). Backend suite 78 passed / 21 skipped.
- Full create-user e2e (backend → frontend → Better Auth) verifies on a running frontend build; the header wiring and guard are covered above.

## For the reviewer

The fallback to `BETTER_AUTH_SECRET` is what makes this non-breaking on upgrade. Confirm you're comfortable reusing that secret for the internal channel (both services already hold it); set `INTERNAL_API_SECRET` to separate them if preferred.