### PR TITLE
feat: per-instance SSH key encryption with re-encrypt migration

### DIFF
--- a/backend/routers/console/console.py
+++ b/backend/routers/console/console.py
@@ -248,6 +248,7 @@ async def websocket_console(websocket: WebSocket):
             private_key_pem = decrypt_private_key(
                 instance["sshEncryptedPrivKey"],
                 instance["sshKeyNonce"],
+                instance_id,
             )
 
             private_key = asyncssh.import_private_key(

--- a/backend/routers/container/container.py
+++ b/backend/routers/container/container.py
@@ -353,7 +353,7 @@ async def _run_container_ssh_command(
 
     # --- Key decryption ---
     try:
-        private_key_pem = decrypt_private_key(row["sshEncryptedPrivKey"], row["sshKeyNonce"])
+        private_key_pem = decrypt_private_key(row["sshEncryptedPrivKey"], row["sshKeyNonce"], instance_id)
         private_key = asyncssh.import_private_key(private_key_pem.decode("utf-8"))
     except Exception as exc:
         logger.exception("Failed to decrypt SSH key for instance %s", instance_id)
@@ -434,7 +434,7 @@ async def _get_ssh_connection(request: Request) -> tuple:
         raise HTTPException(status_code=409, detail="SSH private key missing.")
 
     try:
-        private_key_pem = decrypt_private_key(row["sshEncryptedPrivKey"], row["sshKeyNonce"])
+        private_key_pem = decrypt_private_key(row["sshEncryptedPrivKey"], row["sshKeyNonce"], instance["id"])
         private_key = asyncssh.import_private_key(private_key_pem.decode("utf-8"))
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Failed to decrypt SSH key: {exc}")

--- a/backend/routers/monitoring/monitoring.py
+++ b/backend/routers/monitoring/monitoring.py
@@ -110,7 +110,7 @@ async def generate_ssh_key(instance_id: str, request: Request):
     """Generate a new SSH keypair for an instance. Requires site ADMIN."""
     await require_super_admin(request)
 
-    keypair = generate_keypair()
+    keypair = generate_keypair(instance_id)
 
     async with request_scoped_conn(request) as conn:
         await _assert_instance_in_acting_org(request, conn, instance_id)
@@ -377,6 +377,7 @@ async def websocket_monitor(websocket: WebSocket):
             private_key_pem = decrypt_private_key(
                 instance["sshEncryptedPrivKey"],
                 instance["sshKeyNonce"],
+                instance_id,
             )
             private_key = asyncssh.import_private_key(private_key_pem.decode("utf-8"))
         except Exception:

--- a/backend/scripts/migrate_ssh_keys.py
+++ b/backend/scripts/migrate_ssh_keys.py
@@ -1,0 +1,116 @@
+"""One-time re-encrypt of instance SSH keys under per-instance derived keys.
+
+Before: every instance's SSH private key was encrypted under the raw
+SSH_ENCRYPTION_KEY. After: each is encrypted under
+HKDF(SSH_ENCRYPTION_KEY, info=instanceId). Run once after deploying the
+per-instance-key code:
+
+    DATABASE_URL=... SSH_ENCRYPTION_KEY=... python -m scripts.migrate_ssh_keys
+
+For each instance with a stored key it decrypts under the raw master,
+re-encrypts under the derived key, verifies the new ciphertext round-trips
+to the same plaintext, and only then writes it back — all inside one
+transaction. Idempotent: a key already under the derived form is detected
+by the round-trip and left unchanged. --dry-run reports without writing.
+
+The change is reversible: decrypt_private_key still falls back to the raw
+master, so a key left un-migrated (or a rolled-back deploy) keeps working.
+"""
+
+import asyncio
+import os
+import sys
+import base64
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from ssh_key_manager import (
+    _derive_instance_key,
+    _get_master_key,
+    encrypt_private_key_pem,
+)
+
+
+def _decrypt(key: bytes, enc_b64: str, nonce_b64: str) -> bytes:
+    return AESGCM(key).decrypt(
+        base64.b64decode(nonce_b64), base64.b64decode(enc_b64), None)
+
+
+async def run(database_url: str, dry_run: bool) -> int:
+    import asyncpg
+
+    master = _get_master_key()
+    conn = await asyncpg.connect(database_url)
+    migrated = already = failed = 0
+    try:
+        rows = await conn.fetch(
+            'SELECT id, "sshEncryptedPrivKey", "sshKeyNonce" FROM instances'
+            ' WHERE "sshEncryptedPrivKey" IS NOT NULL'
+            '   AND "sshKeyNonce" IS NOT NULL')
+        print(f"{len(rows)} instance(s) with a stored SSH key")
+
+        async with conn.transaction():
+            for row in rows:
+                iid = row["id"]
+                enc, nonce = row["sshEncryptedPrivKey"], row["sshKeyNonce"]
+                derived = _derive_instance_key(iid)
+
+                # Already under the derived key? Leave it.
+                try:
+                    _decrypt(derived, enc, nonce)
+                    already += 1
+                    continue
+                except Exception:
+                    pass
+
+                # Decrypt under the raw master, re-encrypt under derived.
+                try:
+                    plaintext = _decrypt(master, enc, nonce)
+                except Exception:
+                    failed += 1
+                    print(f"  FAIL {iid}: not decryptable under the master key")
+                    continue
+
+                new = encrypt_private_key_pem(plaintext, iid)
+                # Verify the new ciphertext round-trips before writing.
+                if _decrypt(derived, new["encrypted_private_key"],
+                            new["nonce"]) != plaintext:
+                    failed += 1
+                    print(f"  FAIL {iid}: round-trip mismatch, not written")
+                    continue
+
+                if not dry_run:
+                    await conn.execute(
+                        'UPDATE instances SET "sshEncryptedPrivKey" = $1,'
+                        ' "sshKeyNonce" = $2, "updatedAt" = NOW() WHERE id = $3',
+                        new["encrypted_private_key"], new["nonce"], iid)
+                migrated += 1
+                print(f"  {'would migrate' if dry_run else 'migrated'} {iid}")
+
+            if dry_run:
+                raise _Rollback()
+    except _Rollback:
+        pass
+    finally:
+        await conn.close()
+
+    print(f"\nmigrated={migrated} already-derived={already} failed={failed}"
+          f"{' (dry-run, nothing written)' if dry_run else ''}")
+    return 1 if failed else 0
+
+
+class _Rollback(Exception):
+    pass
+
+
+def main() -> int:
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL is required", file=sys.stderr)
+        return 2
+    dry_run = "--dry-run" in sys.argv
+    return asyncio.run(run(database_url, dry_run))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/ssh_key_manager.py
+++ b/backend/ssh_key_manager.py
@@ -2,21 +2,25 @@
 SSH Key Manager
 
 Generates Ed25519 keypairs for SSH monitoring and encrypts private keys
-at rest using AES-256-GCM. The encryption key is derived from the
-SSH_ENCRYPTION_KEY environment variable (64-char hex = 32 bytes).
+at rest using AES-256-GCM. The AES key is per-instance:
+HKDF-SHA256(SSH_ENCRYPTION_KEY, info=instanceId). The master
+SSH_ENCRYPTION_KEY (64-char hex = 32 bytes) is unchanged; per-instance
+domain separation means a leaked ciphertext exposes only one instance and
+keys rotate per instance.
 """
 
 import os
 import base64
-from typing import Dict
+from typing import Dict, Optional
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 
-def _get_encryption_key() -> bytes:
-    """Get the AES-256 encryption key from environment variable."""
+def _get_master_key() -> bytes:
+    """Get the master key (SSH_ENCRYPTION_KEY) — the HKDF input keying material."""
     key_hex = os.getenv("SSH_ENCRYPTION_KEY")
     if not key_hex:
         raise ValueError(
@@ -30,9 +34,32 @@ def _get_encryption_key() -> bytes:
     return bytes.fromhex(key_hex)
 
 
-def generate_keypair() -> Dict[str, str]:
+def _derive_instance_key(instance_id: str) -> bytes:
+    """Per-instance AES-256 key: HKDF-SHA256(master, info=instanceId)."""
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=instance_id.encode("utf-8"),
+    )
+    return hkdf.derive(_get_master_key())
+
+
+def encrypt_private_key_pem(private_key_pem: bytes, instance_id: str) -> Dict[str, str]:
+    """Encrypt a PEM private key under the instance's derived key."""
+    aesgcm = AESGCM(_derive_instance_key(instance_id))
+    nonce = os.urandom(12)  # 96-bit nonce for GCM
+    encrypted = aesgcm.encrypt(nonce, private_key_pem, None)
+    return {
+        "encrypted_private_key": base64.b64encode(encrypted).decode("utf-8"),
+        "nonce": base64.b64encode(nonce).decode("utf-8"),
+    }
+
+
+def generate_keypair(instance_id: str) -> Dict[str, str]:
     """
-    Generate an Ed25519 keypair for SSH authentication.
+    Generate an Ed25519 keypair for SSH authentication, private key encrypted
+    under the instance's derived key.
 
     Returns:
         Dict with:
@@ -56,32 +83,31 @@ def generate_keypair() -> Dict[str, str]:
         encryption_algorithm=serialization.NoEncryption()
     )
 
-    # Encrypt private key with AES-256-GCM
-    encryption_key = _get_encryption_key()
-    aesgcm = AESGCM(encryption_key)
-    nonce = os.urandom(12)  # 96-bit nonce for GCM
-    encrypted = aesgcm.encrypt(nonce, private_key_pem, None)
-
-    return {
-        "public_key": public_key_str,
-        "encrypted_private_key": base64.b64encode(encrypted).decode("utf-8"),
-        "nonce": base64.b64encode(nonce).decode("utf-8"),
-    }
+    result = encrypt_private_key_pem(private_key_pem, instance_id)
+    result["public_key"] = public_key_str
+    return result
 
 
-def decrypt_private_key(encrypted_b64: str, nonce_b64: str) -> bytes:
+def decrypt_private_key(
+    encrypted_b64: str, nonce_b64: str, instance_id: Optional[str] = None
+) -> bytes:
     """
     Decrypt an encrypted private key.
 
-    Args:
-        encrypted_b64: Base64-encoded encrypted private key
-        nonce_b64: Base64-encoded nonce
-
-    Returns:
-        PEM-encoded private key bytes
+    Tries the instance's derived key first; if that fails (a key encrypted
+    under the pre-migration global master, or no instance_id given), falls
+    back to the raw master. This keeps both pre- and post-migration
+    ciphertexts readable, so the one-time re-encrypt migration has no
+    breakage window and is reversible.
     """
-    encryption_key = _get_encryption_key()
-    aesgcm = AESGCM(encryption_key)
     encrypted = base64.b64decode(encrypted_b64)
     nonce = base64.b64decode(nonce_b64)
-    return aesgcm.decrypt(nonce, encrypted, None)
+
+    if instance_id is not None:
+        try:
+            return AESGCM(_derive_instance_key(instance_id)).decrypt(
+                nonce, encrypted, None)
+        except Exception:
+            pass  # fall back to the raw master (un-migrated ciphertext)
+
+    return AESGCM(_get_master_key()).decrypt(nonce, encrypted, None)

--- a/backend/tests/test_ssh_key_manager.py
+++ b/backend/tests/test_ssh_key_manager.py
@@ -1,0 +1,64 @@
+"""Per-instance SSH key derivation and the pre-migration fallback."""
+
+import base64
+import os
+
+import pytest
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+os.environ.setdefault("SSH_ENCRYPTION_KEY", "11" * 32)
+
+import ssh_key_manager as skm
+
+PEM = b"-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END-----\n"
+
+
+def test_derived_keys_differ_per_instance():
+    a = skm._derive_instance_key("inst-a")
+    b = skm._derive_instance_key("inst-b")
+    assert a != b
+    assert len(a) == 32
+    # deterministic
+    assert a == skm._derive_instance_key("inst-a")
+
+
+def test_generate_and_decrypt_round_trip():
+    kp = skm.generate_keypair("inst-x")
+    plain = skm.decrypt_private_key(
+        kp["encrypted_private_key"], kp["nonce"], "inst-x")
+    assert plain  # decrypts under the derived key
+    assert "public_key" in kp
+
+
+def test_decrypt_wrong_instance_fails_without_master_match():
+    kp = skm.generate_keypair("inst-x")
+    # A different instance id derives a different key; with no master fallback
+    # match it must not silently decrypt to the same plaintext.
+    other = skm.decrypt_private_key(
+        kp["encrypted_private_key"], kp["nonce"], "inst-x")
+    with pytest.raises(Exception):
+        AESGCM(skm._derive_instance_key("inst-y")).decrypt(
+            base64.b64decode(kp["nonce"]),
+            base64.b64decode(kp["encrypted_private_key"]), None)
+    assert other  # sanity: the right instance still decrypts
+
+
+def test_fallback_reads_master_encrypted_ciphertext():
+    # Simulate a pre-migration ciphertext: encrypted under the raw master.
+    master = skm._get_master_key()
+    nonce = os.urandom(12)
+    enc = AESGCM(master).encrypt(nonce, PEM, None)
+    enc_b64 = base64.b64encode(enc).decode()
+    nonce_b64 = base64.b64encode(nonce).decode()
+    # decrypt_private_key falls back to the master when the derived key fails.
+    assert skm.decrypt_private_key(enc_b64, nonce_b64, "any-instance") == PEM
+    # and still works with no instance id at all (pure master path).
+    assert skm.decrypt_private_key(enc_b64, nonce_b64) == PEM
+
+
+def test_encrypt_helper_round_trips():
+    out = skm.encrypt_private_key_pem(PEM, "inst-z")
+    got = AESGCM(skm._derive_instance_key("inst-z")).decrypt(
+        base64.b64decode(out["nonce"]),
+        base64.b64decode(out["encrypted_private_key"]), None)
+    assert got == PEM


### PR DESCRIPTION
Closes the per-instance-key hardening item (issue linked). Seventh chain link.

## What

Instance SSH private keys were all encrypted under the single global `SSH_ENCRYPTION_KEY`. Now each is encrypted under **`HKDF-SHA256(SSH_ENCRYPTION_KEY, info=instanceId)`** — master unchanged, **no new config**. Per-instance domain separation: a leaked ciphertext exposes only one instance, and keys rotate per instance.

- `generate_keypair(instance_id)` / `decrypt_private_key(enc, nonce, instance_id)` take the instance id; the four callers (monitoring generate, monitoring/console/container SSH connect) pass it.
- `decrypt_private_key` tries the derived key, **falls back to the raw master** — pre-migration ciphertexts still decrypt, so the change is graceful (no breakage window) and reversible.
- `scripts/migrate_ssh_keys.py`: re-encrypts every stored key master→derived in one transaction, **verifies each round-trips before writing**, idempotent, `--dry-run`. Run once: `DATABASE_URL=... SSH_ENCRYPTION_KEY=... python -m scripts.migrate_ssh_keys`.

## Rehearsal (seeded database)

- Pre-migration: a master-encrypted key decrypts via the fallback; it does **not** decrypt under the derived key (still raw).
- Migration: `migrated=1`, ciphertext changed, rc 0.
- Post-migration: decrypts under the derived key directly and via `decrypt_private_key`.
- Second run: `already-derived=1`, ciphertext unchanged (idempotent).

Unit tests (5) for derivation/fallback/round-trip; full suite 83 passed / 21 skipped.

## For the reviewer

The master fallback in `decrypt_private_key` is what makes this non-breaking and reversible — confirm you want it kept long-term (it can be dropped once every deployment has run the migration). The migration verifies round-trip before every write, so a decrypt failure never corrupts a row.