### PR TITLE
feat: relocate SSO grant reconciliation to a backend endpoint (DO NOT MERGE yet)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -60,6 +60,7 @@ from routers.site_updates import site_updates as site_updates_router
 from routers import dashboard as dashboard_router
 from routers import user_management as user_management_router
 from routers.tokens import tokens as tokens_router
+from routers.internal import sso_reconcile as sso_reconcile_router
 from routers.operations import operations as operations_router
 from routers.monitoring import monitoring as monitoring_router
 from routers.high_availability import high_availability as high_availability_router
@@ -401,6 +402,7 @@ app.include_router(site_updates_router.router)
 app.include_router(dashboard_router.router)
 app.include_router(user_management_router.router)
 app.include_router(tokens_router.router)
+app.include_router(sso_reconcile_router.router)
 app.include_router(operations_router.router)
 app.include_router(monitoring_router.router)
 app.include_router(high_availability_router.router)

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -40,6 +40,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         "/session/onboarding-status",  # Must be public to check if first-time setup is needed
         "/vyos/monitoring/ws/monitor",  # WebSocket auth handled inside handler
         "/vyos/version/check",  # Version check is public
+        "/internal/sso-reconcile",  # Internal shared-secret auth (not a session)
     }
 
     # Endpoints that authenticate if a session is present but are NOT rejected

--- a/backend/routers/internal/sso_reconcile.py
+++ b/backend/routers/internal/sso_reconcile.py
@@ -1,0 +1,287 @@
+"""Backend-owned SSO grant reconciliation (Golden Rule, RFC 3.3).
+
+The frontend is banned from writing authorization tables. On an OAuth login
+it notifies this endpoint with only a user reference; the backend re-derives
+the IdP group claims from the user's STORED account token and applies the
+oauth_role_mappings itself, then reconciles user_instance_roles /
+user_feature_permissions. Any claims in the request body are ignored by
+construction — the body carries none.
+
+This is a port of the frontend's sso-role-mapping.resolveRoleMapping and
+auth.ts reconcileGrants, with claim extraction moved server-side.
+"""
+
+import base64
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+import asyncpg
+from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/internal", tags=["internal"])
+
+SSO_ASSIGNED_BY = "sso"
+DEFAULT_GROUPS_CLAIM = "groups"
+SITE_ROLE_RANK = {"ADMIN": 2, "VIEWER": 1}
+INSTANCE_ROLE_RANK = {"ADMIN": 3, "OPERATOR": 2, "EDITOR": 2, "VIEWER": 1}
+
+
+class SsoReconcileRequest(BaseModel):
+    user_id: str
+    # Note: no claims field by design. The backend derives claims itself.
+
+
+def _internal_secret() -> str:
+    return os.getenv("INTERNAL_API_SECRET") or os.getenv("BETTER_AUTH_SECRET") or ""
+
+
+def _require_internal_auth(x_internal_auth: Optional[str]) -> None:
+    import hmac
+
+    expected = _internal_secret()
+    if not expected:
+        raise HTTPException(status_code=500,
+                            detail="Server is not configured for internal requests")
+    if not x_internal_auth or not hmac.compare_digest(x_internal_auth, expected):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+# ---------------------------------------------------------------------------
+# Claim extraction from a stored JWT id_token (no request-body trust)
+# ---------------------------------------------------------------------------
+
+def _decode_jwt_claims(id_token: str) -> Dict[str, Any]:
+    """Decode a JWT payload without signature verification. The token was
+    already verified by Better Auth during the OAuth code exchange and stored
+    server-side; this reads claims from that stored state."""
+    try:
+        payload_b64 = id_token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)  # pad base64url
+        return json.loads(base64.urlsafe_b64decode(payload_b64))
+    except Exception:
+        return {}
+
+
+def extract_claim_values(profile: Dict[str, Any], claim_name: str) -> List[str]:
+    raw = profile.get(claim_name)
+    if isinstance(raw, list):
+        return [v for v in raw if isinstance(v, str) and v]
+    if isinstance(raw, str):
+        return [v for v in raw.replace(",", " ").split() if v]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Mapping resolution (port of resolveRoleMapping / buildGrants)
+# ---------------------------------------------------------------------------
+
+def _merge_perms(base: List[dict], extra: List[dict]) -> List[dict]:
+    by_feature: Dict[str, dict] = {}
+    for perm in list(base) + list(extra):
+        f = perm["feature"]
+        cur = by_feature.get(f)
+        if not cur:
+            by_feature[f] = dict(perm)
+        else:
+            cur["canEdit"] = cur["canEdit"] or perm["canEdit"]
+            cur["canView"] = cur["canView"] or perm["canView"]
+    return list(by_feature.values())
+
+
+def _build_grants(matched: List[dict], key: str) -> List[dict]:
+    by_id: Dict[str, dict] = {}
+    for rule in matched:
+        ident = rule.get(key)
+        role = rule.get("instanceRole")
+        if not ident or not role:
+            continue
+        perms = rule.get("featurePermissions") or []
+        cur = by_id.get(ident)
+        if not cur:
+            by_id[ident] = {"id": ident, "instanceRole": role,
+                            "featurePermissions": _merge_perms([], perms)}
+            continue
+        if INSTANCE_ROLE_RANK.get(role, 0) > INSTANCE_ROLE_RANK.get(cur["instanceRole"], 0):
+            cur["instanceRole"] = role
+        cur["featurePermissions"] = _merge_perms(cur["featurePermissions"], perms)
+    return list(by_id.values())
+
+
+def resolve_role_mapping(enabled: bool, rules: List[dict],
+                         claim_values: List[str]) -> dict:
+    if not enabled:
+        return {"denied": False, "siteRole": None,
+                "instanceGrants": [], "siteGrants": []}
+    claim_set = set(claim_values)
+    matched = [r for r in rules if r["claimValue"] in claim_set]
+    if not matched:
+        return {"denied": True, "siteRole": None,
+                "instanceGrants": [], "siteGrants": []}
+
+    site_role, best = None, 0
+    for rule in matched:
+        sr = rule.get("siteRole")
+        if sr and SITE_ROLE_RANK.get(sr, 0) > best:
+            best, site_role = SITE_ROLE_RANK[sr], sr
+
+    is_admin = site_role == "ADMIN"
+    instance_grants = [] if is_admin else [
+        {"instanceId": g["id"], "instanceRole": g["instanceRole"],
+         "featurePermissions": g["featurePermissions"]}
+        for g in _build_grants(matched, "instanceId")]
+    site_grants = [] if is_admin else [
+        {"siteId": g["id"], "instanceRole": g["instanceRole"],
+         "featurePermissions": g["featurePermissions"]}
+        for g in _build_grants(matched, "siteId")]
+    return {"denied": False, "siteRole": site_role,
+            "instanceGrants": instance_grants, "siteGrants": site_grants}
+
+
+# ---------------------------------------------------------------------------
+# Grant reconciliation (port of auth.ts reconcileGrants), server-side
+# ---------------------------------------------------------------------------
+
+async def _reconcile_grants(conn: asyncpg.Connection, user_id: str,
+                            instance_grants: List[dict],
+                            site_grants: List[dict]) -> None:
+    desired: Dict[str, dict] = {}
+
+    def add(instance_id: str, role: str, perms: List[dict]) -> None:
+        cur = desired.get(instance_id)
+        if not cur:
+            desired[instance_id] = {"instanceRole": role,
+                                    "featurePermissions": _merge_perms([], perms)}
+            return
+        if INSTANCE_ROLE_RANK.get(role, 0) > INSTANCE_ROLE_RANK.get(cur["instanceRole"], 0):
+            cur["instanceRole"] = role
+        cur["featurePermissions"] = _merge_perms(cur["featurePermissions"], perms)
+
+    if site_grants:
+        by_site = {g["siteId"]: g for g in site_grants}
+        rows = await conn.fetch(
+            'SELECT id, "siteId" FROM instances WHERE "siteId" = ANY($1)',
+            list(by_site.keys()))
+        for row in rows:
+            g = by_site.get(row["siteId"])
+            if g:
+                add(row["id"], g["instanceRole"], g["featurePermissions"])
+    for g in instance_grants:
+        add(g["instanceId"], g["instanceRole"], g["featurePermissions"])
+
+    valid = set()
+    if desired:
+        rows = await conn.fetch(
+            "SELECT id FROM instances WHERE id = ANY($1)", list(desired.keys()))
+        valid = {r["id"] for r in rows}
+
+    # Remove SSO-managed assignments no longer desired.
+    existing = await conn.fetch(
+        'SELECT id, "instanceId" FROM user_instance_roles'
+        ' WHERE "userId" = $1 AND "assignedBy" = $2',
+        user_id, SSO_ASSIGNED_BY)
+    for a in existing:
+        if not a["instanceId"] or a["instanceId"] not in valid:
+            await conn.execute(
+                "DELETE FROM user_instance_roles WHERE id = $1", a["id"])
+
+    # Upsert each desired assignment and rebuild its feature permissions.
+    for instance_id, grant in desired.items():
+        if instance_id not in valid:
+            continue
+        assignment_id = await conn.fetchval(
+            '''
+            INSERT INTO user_instance_roles
+                (id, "userId", "instanceId", role, "assignedBy",
+                 "createdAt", "updatedAt")
+            VALUES (gen_random_uuid()::text, $1, $2, $3, $4, NOW(), NOW())
+            ON CONFLICT ("userId", "instanceId")
+            DO UPDATE SET role = EXCLUDED.role,
+                          "assignedBy" = EXCLUDED."assignedBy",
+                          "updatedAt" = NOW()
+            RETURNING id
+            ''',
+            user_id, instance_id, grant["instanceRole"], SSO_ASSIGNED_BY)
+
+        await conn.execute(
+            'DELETE FROM user_feature_permissions WHERE "userInstanceRoleId" = $1',
+            assignment_id)
+        if grant["instanceRole"] != "ADMIN" and grant["featurePermissions"]:
+            await conn.executemany(
+                '''
+                INSERT INTO user_feature_permissions
+                    (id, "userInstanceRoleId", feature, "canEdit", "canView",
+                     "createdAt")
+                VALUES (gen_random_uuid()::text, $1, $2, $3, $4, NOW())
+                ON CONFLICT ("userInstanceRoleId", feature) DO NOTHING
+                ''',
+                [(assignment_id, fp["feature"], fp["canEdit"], fp["canView"])
+                 for fp in grant["featurePermissions"]])
+
+
+@router.post("/sso-reconcile")
+async def sso_reconcile(
+    request: Request,
+    body: SsoReconcileRequest,
+    x_internal_auth: Optional[str] = Header(default=None),
+) -> dict:
+    """Re-derive the user's SSO grants from their stored account and apply
+    oauth_role_mappings server-side. The request body carries no claims."""
+    _require_internal_auth(x_internal_auth)
+
+    pool: asyncpg.Pool = request.app.state.db_pool
+    if pool is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            # The user's OAuth accounts (providerId + stored id_token).
+            accounts = await conn.fetch(
+                'SELECT "providerId", "idToken" FROM accounts WHERE "userId" = $1',
+                body.user_id)
+            if not accounts:
+                return {"reconciled": False, "reason": "no oauth account"}
+
+            applied = False
+            for acc in accounts:
+                provider = await conn.fetchrow(
+                    'SELECT "providerId", enabled, "roleMappingEnabled",'
+                    ' "groupsClaim" FROM oauth_providers'
+                    ' WHERE "providerId" = $1 AND enabled = true',
+                    acc["providerId"])
+                if not provider or not provider["roleMappingEnabled"]:
+                    continue
+
+                claim_name = provider["groupsClaim"] or DEFAULT_GROUPS_CLAIM
+                claims = _decode_jwt_claims(acc["idToken"] or "")
+                claim_values = extract_claim_values(claims, claim_name)
+
+                rules = [dict(r) for r in await conn.fetch(
+                    'SELECT "claimValue", "siteRole", "instanceId", "siteId",'
+                    ' "instanceRole", "featurePermissions"'
+                    ' FROM oauth_role_mappings WHERE "providerId" = $1',
+                    provider["providerId"])]
+                for r in rules:
+                    fp = r.get("featurePermissions")
+                    r["featurePermissions"] = (
+                        json.loads(fp) if isinstance(fp, str) else fp)
+
+                resolved = resolve_role_mapping(True, rules, claim_values)
+                if resolved["denied"]:
+                    # Mapping enabled but no claim matched: strip SSO grants.
+                    await _reconcile_grants(conn, body.user_id, [], [])
+                    applied = True
+                    continue
+
+                if resolved["siteRole"]:
+                    await conn.execute(
+                        'UPDATE users SET role = $1, "updatedAt" = NOW()'
+                        ' WHERE id = $2',
+                        resolved["siteRole"], body.user_id)
+                await _reconcile_grants(
+                    conn, body.user_id,
+                    resolved["instanceGrants"], resolved["siteGrants"])
+                applied = True
+
+    return {"reconciled": applied}

--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -23,6 +23,11 @@ PERMANENT_GLOBAL = {
     "org_scope.py":
         "The sanctioned primitive itself - every org-scoped "
         "acquisition goes through it.",
+    "routers/internal/sso_reconcile.py":
+        "Backend-owned SSO grant reconciliation: a deployment-level "
+        "system operation triggered by the IdP (SSO is deployment-global "
+        "per the RFC), reconciling a user's grants across all their "
+        "providers - not an org-scoped user request.",
     "routers/events.py":
         "Background banner poller: no request, no org context - it "
         "iterates every instance with active subscribers, a "

--- a/backend/tests/test_sso_reconcile.py
+++ b/backend/tests/test_sso_reconcile.py
@@ -1,0 +1,146 @@
+"""Backend SSO reconciliation: mapping resolution, grant writes, and the
+forged-claims property (request body carries no authority)."""
+
+import asyncio
+import base64
+import json
+import os
+
+import pytest
+
+from routers.internal.sso_reconcile import (
+    extract_claim_values,
+    resolve_role_mapping,
+    _decode_jwt_claims,
+)
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="SSO reconcile endpoint test needs DATABASE_URL",
+)
+
+SECRET = "sso-reconcile-secret"
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (no DB)
+# ---------------------------------------------------------------------------
+
+def _jwt(payload: dict) -> str:
+    def b64(d):
+        return base64.urlsafe_b64encode(json.dumps(d).encode()).rstrip(b"=").decode()
+    return f"{b64({'alg': 'none'})}.{b64(payload)}.sig"
+
+
+def test_decode_jwt_claims_reads_groups():
+    token = _jwt({"groups": ["admins", "ops"], "email": "a@b.c"})
+    claims = _decode_jwt_claims(token)
+    assert claims["groups"] == ["admins", "ops"]
+
+
+def test_extract_claim_values_shapes():
+    assert extract_claim_values({"groups": ["a", "b"]}, "groups") == ["a", "b"]
+    assert extract_claim_values({"groups": "a b,c"}, "groups") == ["a", "b", "c"]
+    assert extract_claim_values({}, "groups") == []
+
+
+def test_resolve_no_match_denies():
+    rules = [{"claimValue": "admins", "siteRole": "ADMIN",
+              "instanceId": None, "siteId": None,
+              "instanceRole": None, "featurePermissions": None}]
+    assert resolve_role_mapping(True, rules, ["nobody"])["denied"] is True
+
+
+def test_resolve_instance_grant():
+    rules = [{"claimValue": "ops", "siteRole": None,
+              "instanceId": "i1", "siteId": None, "instanceRole": "OPERATOR",
+              "featurePermissions": [{"feature": "FIREWALL",
+                                      "canEdit": True, "canView": True}]}]
+    r = resolve_role_mapping(True, rules, ["ops"])
+    assert r["denied"] is False
+    assert r["instanceGrants"][0]["instanceId"] == "i1"
+    assert r["instanceGrants"][0]["instanceRole"] == "OPERATOR"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint (real DB): reconciliation + forged-claims property
+# ---------------------------------------------------------------------------
+
+@requires_db
+def test_endpoint_reconciles_and_ignores_body_claims(monkeypatch):
+    import asyncpg
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("BETTER_AUTH_SECRET", SECRET)
+    db = os.environ["DATABASE_URL"]
+
+    # Stored token grants the "ops" group -> OPERATOR on i_sso.
+    id_token = _jwt({"groups": ["ops"], "email": "sso@rec.test"})
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_sso'")
+        await conn.execute("DELETE FROM sites WHERE id = 's_sso'")
+        await conn.execute("DELETE FROM oauth_providers WHERE \"providerId\" = 'idp'")
+        await conn.execute("""
+            INSERT INTO users (id,email,name,role,"emailVerified","createdAt","updatedAt")
+            VALUES ('u_sso','sso@rec.test','SSO','VIEWER',true,NOW(),NOW())""")
+        await conn.execute("""
+            INSERT INTO sites (id,name,"orgId","createdAt","updatedAt")
+            VALUES ('s_sso','SSO Site','default',NOW(),NOW())""")
+        await conn.execute("""
+            INSERT INTO instances (id,"siteId",name,host,username,password,"createdAt","updatedAt")
+            VALUES ('i_sso','s_sso','r','1.1.1.1','v','p',NOW(),NOW())""")
+        await conn.execute("""
+            INSERT INTO oauth_providers (id,"providerId","displayName",enabled,"clientId","clientSecret","roleMappingEnabled","groupsClaim","createdAt","updatedAt")
+            VALUES ('op1','idp','IdP',true,'cid','csec',true,'groups',NOW(),NOW())""")
+        await conn.execute("""
+            INSERT INTO oauth_role_mappings (id,"providerId","claimValue","instanceId","instanceRole","featurePermissions",priority,"createdAt","updatedAt")
+            VALUES ('m1','idp','ops','i_sso','OPERATOR','[{"feature":"FIREWALL","canEdit":true,"canView":true}]'::jsonb,0,NOW(),NOW())""")
+        await conn.execute("""
+            INSERT INTO accounts (id,"accountId","providerId","userId","idToken","createdAt","updatedAt")
+            VALUES ('a1','acc1','idp','u_sso',$1,NOW(),NOW())""", id_token)
+        await conn.close()
+
+    async def grants():
+        conn = await asyncpg.connect(db)
+        rows = await conn.fetch(
+            'SELECT "instanceId", role FROM user_instance_roles WHERE "userId" = $1',
+            "u_sso")
+        await conn.close()
+        return {(r["instanceId"], r["role"]) for r in rows}
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_sso'")
+        await conn.execute("DELETE FROM sites WHERE id = 's_sso'")
+        await conn.execute("DELETE FROM oauth_providers WHERE \"providerId\" = 'idp'")
+        await conn.close()
+
+    from app import app
+    asyncio.run(seed())
+    try:
+        with TestClient(app) as client:
+            hdr = {"X-Internal-Auth": SECRET}
+
+            # No auth header -> 401.
+            assert client.post("/internal/sso-reconcile",
+                               json={"user_id": "u_sso"}).status_code == 401
+
+            # Reconcile: derives "ops" from the STORED token -> OPERATOR on i_sso.
+            r = client.post("/internal/sso-reconcile",
+                            json={"user_id": "u_sso"}, headers=hdr)
+            assert r.status_code == 200 and r.json()["reconciled"] is True
+            assert asyncio.run(grants()) == {("i_sso", "OPERATOR")}
+
+            # Forged claims in the body must be ignored: even asserting an
+            # ADMIN group, the result still reflects the stored token (ops).
+            r2 = client.post(
+                "/internal/sso-reconcile",
+                json={"user_id": "u_sso", "groups": ["admins"],
+                      "claims": {"groups": ["admins"]}, "role": "ADMIN"},
+                headers=hdr)
+            assert r2.status_code == 200
+            assert asyncio.run(grants()) == {("i_sso", "OPERATOR")}
+    finally:
+        asyncio.run(cleanup())

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,7 +1,7 @@
 import { betterAuth } from "better-auth";
 import { genericOAuth } from "better-auth/plugins";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { PrismaClient, type InstanceRole } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import {
   extractClaimValues,
   resolveRoleMapping,
@@ -14,11 +14,6 @@ import {
 
 const prisma = new PrismaClient();
 
-// Marks UserInstanceRole rows that are managed by SSO group mapping, so the
-// reconciler only ever adds/removes its own assignments and never deletes
-// instance access an admin granted manually.
-const SSO_ASSIGNED_BY = "sso";
-
 // New users don't exist yet when mapProfileToUser runs, so their resolved
 // grants are stashed by email and consumed in the user.create.after hook once
 // the row exists. Keyed by email; entries are short-lived (set and consumed
@@ -28,134 +23,44 @@ const pendingGrants = new Map<
   { instanceGrants: ResolvedInstanceGrant[]; siteGrants: ResolvedSiteGrant[] }
 >();
 
-// Most-privileged role wins when an instance is granted more than once (e.g. via
-// a whole-site grant plus an explicit instance grant).
-const INSTANCE_ROLE_RANK: Record<string, number> = {
-  ADMIN: 3,
-  OPERATOR: 2,
-  EDITOR: 2,
-  VIEWER: 1,
-};
-
-function mergePerms(
-  base: InstanceFeaturePermission[],
-  extra: InstanceFeaturePermission[],
-): InstanceFeaturePermission[] {
-  const byFeature = new Map<string, InstanceFeaturePermission>();
-  for (const p of [...base, ...extra]) {
-    const ex = byFeature.get(p.feature);
-    if (!ex) byFeature.set(p.feature, { ...p });
-    else {
-      ex.canEdit = ex.canEdit || p.canEdit;
-      ex.canView = ex.canView || p.canView;
-    }
-  }
-  return Array.from(byFeature.values());
-}
-
-interface DesiredGrant {
-  instanceRole: InstanceRole;
-  featurePermissions: InstanceFeaturePermission[];
-}
-
 /**
- * Reconcile a user's SSO-managed instance assignments (issue #359). Site grants
- * are expanded to every instance in the site, then explicit instance grants are
- * merged on top (most-privileged role + union of feature permissions). The IdP
- * is authoritative: SSO-managed rows not in the desired set are removed. Manual
- * (non-SSO) assignments are left intact unless SSO also grants that instance.
+ * Notify the backend to reconcile a user's SSO-managed grants (Golden Rule,
+ * RFC 3.3). The frontend is banned from writing authorization tables
+ * (user_instance_roles / user_feature_permissions); it no longer computes or
+ * writes grants here. It only tells the backend that an SSO login happened,
+ * by user reference. The backend re-derives the IdP claims from the user's
+ * stored account token — never from anything the frontend asserts — and
+ * applies oauth_role_mappings itself.
+ *
+ * TIMING (verify on a live IdP before merge): the backend reads the stored
+ * account id_token, so this notification must fire AFTER Better Auth has
+ * persisted the fresh token for this login. If a reconcile lags one login,
+ * move this call to an account.create/update after-hook.
  */
-async function reconcileGrants(
-  userId: string,
-  instanceGrants: ResolvedInstanceGrant[],
-  siteGrants: ResolvedSiteGrant[],
-): Promise<void> {
-  const desired = new Map<string, DesiredGrant>();
-  const add = (
-    instanceId: string,
-    role: InstanceRole,
-    perms: InstanceFeaturePermission[],
-  ) => {
-    const ex = desired.get(instanceId);
-    if (!ex) {
-      desired.set(instanceId, { instanceRole: role, featurePermissions: mergePerms([], perms) });
-      return;
-    }
-    if ((INSTANCE_ROLE_RANK[role] ?? 0) > (INSTANCE_ROLE_RANK[ex.instanceRole] ?? 0)) {
-      ex.instanceRole = role;
-    }
-    ex.featurePermissions = mergePerms(ex.featurePermissions, perms);
-  };
-
-  // Expand whole-site grants to each instance in the site.
-  if (siteGrants.length) {
-    const bySite = new Map(siteGrants.map((g) => [g.siteId, g]));
-    const instances = await prisma.instance.findMany({
-      where: { siteId: { in: [...bySite.keys()] } },
-      select: { id: true, siteId: true },
-    });
-    for (const inst of instances) {
-      const g = bySite.get(inst.siteId);
-      if (g) add(inst.id, g.instanceRole, g.featurePermissions);
-    }
+async function reconcileGrants(userId: string): Promise<void> {
+  const backendUrl = process.env.BACKEND_URL;
+  const secret =
+    process.env.INTERNAL_API_SECRET || process.env.BETTER_AUTH_SECRET;
+  if (!backendUrl || !secret) {
+    console.error(
+      "[SSO] BACKEND_URL / internal secret missing; cannot reconcile grants",
+    );
+    return;
   }
-  for (const g of instanceGrants) add(g.instanceId, g.instanceRole, g.featurePermissions);
-
-  // Only act on instances that still exist (avoids FK errors on stale rules).
-  const validInstanceIds = new Set<string>();
-  if (desired.size) {
-    const rows = await prisma.instance.findMany({
-      where: { id: { in: [...desired.keys()] } },
-      select: { id: true },
-    });
-    for (const r of rows) validInstanceIds.add(r.id);
-  }
-
-  // Remove SSO-managed assignments no longer desired (validInstanceIds is the
-  // intersection of desired and existing).
-  const ssoAssignments = await prisma.userInstanceRole.findMany({
-    where: { userId, assignedBy: SSO_ASSIGNED_BY },
-    select: { id: true, instanceId: true },
-  });
-  for (const assignment of ssoAssignments) {
-    if (!assignment.instanceId || !validInstanceIds.has(assignment.instanceId)) {
-      // Cascade deletes the assignment's UserFeaturePermission rows.
-      await prisma.userInstanceRole.delete({ where: { id: assignment.id } });
-    }
-  }
-
-  // Upsert each desired assignment and rebuild its feature permissions.
-  for (const [instanceId, grant] of desired) {
-    if (!validInstanceIds.has(instanceId)) continue;
-
-    const assignment = await prisma.userInstanceRole.upsert({
-      where: { userId_instanceId: { userId, instanceId } },
-      update: { role: grant.instanceRole, assignedBy: SSO_ASSIGNED_BY },
-      create: {
-        userId,
-        instanceId,
-        role: grant.instanceRole,
-        assignedBy: SSO_ASSIGNED_BY,
+  try {
+    const res = await fetch(`${backendUrl.replace(/\/$/, "")}/internal/sso-reconcile`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Auth": secret,
       },
+      body: JSON.stringify({ user_id: userId }),
     });
-
-    // Feature permissions only apply to OPERATOR/VIEWER; ADMIN = full access.
-    await prisma.userFeaturePermission.deleteMany({
-      where: { userInstanceRoleId: assignment.id },
-    });
-    if (grant.instanceRole !== "ADMIN" && grant.featurePermissions.length) {
-      // `feature` is a free-text column; values come from the frontend
-      // FeatureGroup taxonomy and are validated by the UI / API, not here.
-      await prisma.userFeaturePermission.createMany({
-        data: grant.featurePermissions.map((fp) => ({
-          userInstanceRoleId: assignment.id,
-          feature: fp.feature,
-          canEdit: fp.canEdit,
-          canView: fp.canView,
-        })),
-        skipDuplicates: true,
-      });
+    if (!res.ok) {
+      console.error(`[SSO] backend reconcile failed: ${res.status}`);
     }
+  } catch (e) {
+    console.error("[SSO] backend reconcile request error:", e);
   }
 }
 
@@ -255,7 +160,7 @@ async function buildAuth() {
           data: { role: resolved.siteRole },
         });
       }
-      await reconcileGrants(existing.id, resolved.instanceGrants, resolved.siteGrants);
+      await reconcileGrants(existing.id);
     } else if (
       email &&
       (resolved.instanceGrants.length > 0 || resolved.siteGrants.length > 0)
@@ -319,7 +224,7 @@ async function buildAuth() {
             const grants = pendingGrants.get(email);
             if (!grants) return;
             pendingGrants.delete(email);
-            await reconcileGrants(user.id, grants.instanceGrants, grants.siteGrants);
+            await reconcileGrants(user.id);
           },
         },
       },


### PR DESCRIPTION
Closes #467. Eighth and final hardening-chain link — the Golden Rule (RFC 3.3).

## ⚠️ DO NOT MERGE without IdP-backed verification

The full OAuth login flow can't be tested without a real IdP. The **backend endpoint is proven** (below), but the **frontend hook timing** — ensuring the notification fires after Better Auth persists the fresh account token — needs verification on a live IdP (see the `TIMING` note in `auth.ts`). If a reconcile lags one login, the call moves to an `account.create/update` after-hook. Merging blind risks SSO grants lagging a login.

## What

The frontend is banned from writing authz tables. `auth.ts reconcileGrants` no longer computes or writes `user_instance_roles` / `user_feature_permissions` — it POSTs a **user reference** to a new backend `POST /internal/sso-reconcile` (internal shared-secret auth, same as #464). The backend:

- re-derives the IdP group claims from the user's **stored** `accounts.id_token` — never from the request body;
- applies `oauth_role_mappings` server-side (Python port of `resolveRoleMapping`);
- reconciles the grants (port of `reconcileGrants`), sets the site role.

The request body carries **no claims by construction**, so a compromised frontend can't mint grants. Site-role resolution + access-deny stay in the login hook (Better Auth core table). The endpoint is exempt from session-auth (own shared secret) and is on the canary allowlist as a deployment-level system op (SSO is deployment-global per the RFC §9 closure).

## Evidence

- Mapping resolution + claim extraction: unit-tested (JWT decode, claim shapes, deny, instance grant).
- **Endpoint against a seeded database**: reconciles `ops` group from the stored token → OPERATOR grant on the instance; no-header → 401.
- **Forged-claims property (RFC §8)**: calling the endpoint with a body asserting `{"groups":["admins"],"role":"ADMIN"}` leaves the grant as OPERATOR — the body is ignored, the stored token is authority. ✅
- Backend suite 87 passed / 22 skipped; canary green (new allowlist entry justified); `tsc` + `eslint` clean on `auth.ts`.

## Follow-ups (documented, not in this PR)

- Full JWKS signature re-verification of the stored token (it's already Better-Auth-verified + stored server-side, so deriving claims from it is deriving-from-stored-state).
- Structural Golden Rule enforcement (strip the frontend Postgres role's INSERT/UPDATE/DELETE on authz tables) lands with the RLS PR.

## For the reviewer

The load-bearing security property is the forged-claims test. The open question is purely the frontend hook timing — please verify against your IdP before merging.