### PR TITLE
feat: row-level-security foundation for organization isolation

### DIFF
--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -1,0 +1,123 @@
+"""Row-level-security proof.
+
+Requires DATABASE_URL and the ability to CREATE ROLE (superuser / CREATEROLE);
+skips otherwise. Creates the low-privilege runtime role, applies the same
+grants the ops step does, and verifies through it:
+
+  - a request sees only its org's rows (app.org_id filter),
+  - the operator bypass (app.is_system_admin) sees everything,
+  - audit_logs is append-only for the runtime role.
+
+The running app connects as the table owner, which bypasses ENABLEd
+(non-FORCEd) RLS, so these policies are inert until the enforcement flip.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="RLS proof needs DATABASE_URL")
+
+RUNTIME = "vym_rls_proof_role"
+
+
+@requires_db
+def test_rls_org_isolation_and_audit_append_only():
+    import asyncpg
+
+    async def main():
+        owner = await asyncpg.connect(os.environ["DATABASE_URL"])
+        try:
+            try:
+                await owner.execute(f"DROP ROLE IF EXISTS {RUNTIME}")
+                await owner.execute(
+                    f"CREATE ROLE {RUNTIME} NOLOGIN")
+            except asyncpg.InsufficientPrivilegeError:
+                pytest.skip("no privilege to CREATE ROLE for the RLS proof")
+
+            # The ops-step grants (mirrors the migration's guarded block).
+            await owner.execute(f"GRANT USAGE ON SCHEMA public TO {RUNTIME}")
+            await owner.execute(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES "
+                f"IN SCHEMA public TO {RUNTIME}")
+            await owner.execute(
+                f'REVOKE UPDATE, DELETE ON "audit_logs" FROM {RUNTIME}')
+
+            # Two orgs with a site + instance each.
+            await owner.execute("DELETE FROM sites WHERE id IN ('rlsA','rlsB')")
+            await owner.execute(
+                "DELETE FROM organizations WHERE id IN ('rlsOA','rlsOB')")
+            await owner.execute(
+                'INSERT INTO organizations (id,name,"createdAt","updatedAt")'
+                " VALUES ('rlsOA','A',NOW(),NOW()),('rlsOB','B',NOW(),NOW())")
+            await owner.execute(
+                'INSERT INTO sites (id,name,"orgId","createdAt","updatedAt")'
+                " VALUES ('rlsA','SA','rlsOA',NOW(),NOW()),"
+                "('rlsB','SB','rlsOB',NOW(),NOW())")
+            await owner.execute(
+                'INSERT INTO instances (id,"siteId",name,host,username,'
+                'password,"createdAt","updatedAt") VALUES '
+                "('rlsIA','rlsA','r','1.1.1.1','v','p',NOW(),NOW()),"
+                "('rlsIB','rlsB','r','2.2.2.2','v','p',NOW(),NOW())")
+
+            async def as_runtime(setup_sql, query):
+                conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+                try:
+                    await conn.execute(f"SET ROLE {RUNTIME}")
+                    await conn.execute(setup_sql)
+                    return await conn.fetch(query)
+                finally:
+                    await conn.close()
+
+            # app.org_id = rlsOA -> only org A's rows.
+            a_sites = await as_runtime(
+                "SET app.org_id = 'rlsOA'; SET app.is_system_admin = 'false'",
+                "SELECT id FROM sites WHERE id IN ('rlsA','rlsB')")
+            assert {r["id"] for r in a_sites} == {"rlsA"}
+
+            a_inst = await as_runtime(
+                "SET app.org_id = 'rlsOA'; SET app.is_system_admin = 'false'",
+                "SELECT id FROM instances WHERE id IN ('rlsIA','rlsIB')")
+            assert {r["id"] for r in a_inst} == {"rlsIA"}
+
+            # Operator bypass sees both orgs.
+            all_sites = await as_runtime(
+                "SET app.org_id = ''; SET app.is_system_admin = 'true'",
+                "SELECT id FROM sites WHERE id IN ('rlsA','rlsB')")
+            assert {r["id"] for r in all_sites} == {"rlsA", "rlsB"}
+
+            # No org context, not operator -> sees nothing (deny by default).
+            none_sites = await as_runtime(
+                "SET app.org_id = ''; SET app.is_system_admin = 'false'",
+                "SELECT id FROM sites WHERE id IN ('rlsA','rlsB')")
+            assert none_sites == []
+
+            # audit_logs append-only for the runtime role.
+            conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+            try:
+                await conn.execute(f"SET ROLE {RUNTIME}")
+                with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                    await conn.execute("UPDATE audit_logs SET action = 'x'")
+                with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                    await conn.execute("DELETE FROM audit_logs")
+            finally:
+                await conn.close()
+        finally:
+            await owner.execute("DELETE FROM sites WHERE id IN ('rlsA','rlsB')")
+            await owner.execute(
+                "DELETE FROM organizations WHERE id IN ('rlsOA','rlsOB')")
+            await owner.execute(
+                "GRANT UPDATE, DELETE ON ALL TABLES IN SCHEMA public "
+                f"TO {RUNTIME}")  # harmless if role about to drop
+            await owner.execute(
+                "REVOKE ALL ON ALL TABLES IN SCHEMA public "
+                f"FROM {RUNTIME}")
+            await owner.execute(
+                f"REVOKE USAGE ON SCHEMA public FROM {RUNTIME}")
+            await owner.execute(f"DROP ROLE IF EXISTS {RUNTIME}")
+            await owner.close()
+
+    asyncio.run(main())

--- a/docs-site/docs/architecture/organizations.md
+++ b/docs-site/docs/architecture/organizations.md
@@ -59,10 +59,37 @@ file that resolves a database connection outside the sanctioned org-scoped
 path fails the suite unless it is on a reviewed allowlist that carries a
 justification per entry.
 
+## Row-level security (foundation in place, inert)
+
+The database carries row-level-security policies on the organization-hierarchy
+tables (`organizations`, `sites`, `org_memberships`, `instances`), keyed on the
+request's `app.org_id` with an operator bypass on `app.is_system_admin` — the
+same settings the org-scoped connections apply. RLS is `ENABLE`d but not
+`FORCE`d, so the table owner (the role the app connects as today) bypasses it
+entirely: **the policies are inert until the app connects as a separate,
+low-privilege runtime role at the enforcement flip.**
+
+That runtime role is created out of band — it needs a login credential and
+`CREATEROLE`, which the app's own database role usually lacks — so it is not
+created by the migration. When you are ready to enforce, create it and grant
+least privilege (audit logs stay append-only):
+
+```sql
+CREATE ROLE vym_runtime LOGIN PASSWORD '…';
+GRANT USAGE ON SCHEMA public TO vym_runtime;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO vym_runtime;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO vym_runtime;
+REVOKE UPDATE, DELETE ON "audit_logs" FROM vym_runtime;  -- append-only
+```
+
+At the flip the app connects as `vym_runtime` (Prisma keeps migrating as the
+owner), policies get `FORCE`d, and the policy coverage extends to the remaining
+authz tables.
+
 ## What is deliberately not here yet
 
-Organization management UI and APIs, org-scoped enforcement, row-level
-security and the related security hardening ship in later releases, each
-gated by an adversarial test suite that already runs today (cross-org
-negatives execute on every CI run; the target-state expectations are marked
-expected-fail until enforcement turns on).
+Organization management UI and APIs, org-scoped enforcement, the fenced-role
+connection and `FORCE` RLS, and the related security hardening ship in later
+releases, each gated by an adversarial test suite that already runs today
+(cross-org negatives execute on every CI run; the target-state expectations are
+marked expected-fail until enforcement turns on).

--- a/frontend/prisma/migrations/20260710_rls_foundation/migration.sql
+++ b/frontend/prisma/migrations/20260710_rls_foundation/migration.sql
@@ -1,0 +1,67 @@
+-- Row-level-security foundation, inert by design.
+--
+-- Policies are keyed on the request's org context (app.org_id) with an
+-- operator bypass (app.is_system_admin), both set as SET LOCAL by the
+-- org_conn plumbing. RLS is ENABLEd but NOT FORCEd, so the table owner — the
+-- role Prisma and the app connect as today — bypasses it entirely. Nothing
+-- changes for the running app until it connects as a separate low-privilege
+-- runtime role (the enforcement flip), at which point these policies become
+-- the deny-by-default backstop.
+--
+-- The low-privilege runtime role itself is created out of band (it needs a
+-- login credential and CREATEROLE, which the app's own DB role usually lacks),
+-- so it is NOT created here — a migration that tried would fail on most
+-- deployments. The exact ops SQL is in the PR / docs. This migration only
+-- (a) enables RLS + policies, which the table owner can always do, and
+-- (b) grants least privilege to the runtime role IF it already exists.
+
+-- ---------------------------------------------------------------------------
+-- Org policies (SELECT/ALL) on the org-hierarchy tables
+-- ---------------------------------------------------------------------------
+
+-- current_setting(..., true) is missing-ok: returns NULL when unset. An empty
+-- app.org_id (the no-context sentinel) matches no real orgId, so a non-operator
+-- request with no org context sees nothing — deny by default.
+
+ALTER TABLE "organizations" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "org_isolation" ON "organizations" USING (
+    current_setting('app.is_system_admin', true) = 'true'
+    OR "id" = current_setting('app.org_id', true)
+);
+
+ALTER TABLE "sites" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "org_isolation" ON "sites" USING (
+    current_setting('app.is_system_admin', true) = 'true'
+    OR "orgId" = current_setting('app.org_id', true)
+);
+
+ALTER TABLE "org_memberships" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "org_isolation" ON "org_memberships" USING (
+    current_setting('app.is_system_admin', true) = 'true'
+    OR "orgId" = current_setting('app.org_id', true)
+);
+
+ALTER TABLE "instances" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "org_isolation" ON "instances" USING (
+    current_setting('app.is_system_admin', true) = 'true'
+    OR "siteId" IN (
+        SELECT "id" FROM "sites"
+        WHERE "orgId" = current_setting('app.org_id', true)
+    )
+);
+
+-- ---------------------------------------------------------------------------
+-- Least-privilege grants to the runtime role, only if it already exists.
+-- audit_logs is append-only: SELECT + INSERT, never UPDATE/DELETE.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'vym_runtime') THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA public TO vym_runtime';
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO vym_runtime';
+        EXECUTE 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO vym_runtime';
+        -- Append-only audit: revoke mutation, keep read + insert.
+        EXECUTE 'REVOKE UPDATE, DELETE ON "audit_logs" FROM vym_runtime';
+    END IF;
+END $$;


### PR DESCRIPTION
PR 4 of the organization sequence — the RLS backstop, **inert by design**.

## What

Row-level-security policies on the org-hierarchy tables (`organizations`, `sites`, `org_memberships`, `instances`), keyed on the request's `app.org_id` with an operator bypass on `app.is_system_admin` — the same settings the org-scoped connections already apply. RLS is `ENABLE`d but **not** `FORCE`d, so the table owner (the role the app connects as today) bypasses it entirely. **The policies are inert until the app connects as a separate low-privilege runtime role at the enforcement flip.**

The runtime role is created **out of band** — it needs a login credential and `CREATEROLE`, which the app's own DB role usually lacks — so the migration does not create it (one that tried would fail on most deployments; the app role has no `CREATEROLE`, verified). The migration only enables RLS + policies (which the owner can always do) and grants least privilege to the runtime role *if it already exists*, keeping `audit_logs` append-only (no UPDATE/DELETE). The ops SQL is in the organizations architecture doc.

## Evidence (live, via `SET ROLE` to the runtime role)

- `app.org_id = orgA` → sees only org A's sites/instances; org B invisible.
- `app.is_system_admin = true` → bypass, sees both orgs.
- empty context, not operator → sees nothing (**deny by default**).
- `audit_logs`: UPDATE/DELETE → `permission denied`; INSERT → allowed (**append-only**).
- **Owner (the running app) bypasses all of it** → backend suite unchanged against an RLS-migrated database (100 passed, golden aside).
- RLS proof test (`test_rls.py`): runs where role creation is permitted, skips otherwise. Docs site builds clean.

## Scope / what lands at the flip (PR 5)

- App connects as `vym_runtime` (Prisma keeps migrating as owner).
- Policies get `FORCE`d; coverage extends to the remaining authz tables (`user_instance_roles`, `user_feature_permissions`, `api_tokens`, `oauth_role_mappings`).
- Golden Rule DB-grant stripping of the frontend role.

## For the reviewer

The load-bearing safety property: RLS is **not FORCEd** and the app connects as the **owner**, so this cannot affect the running app — confirm both. The policy expressions use `current_setting(..., true)` (missing-ok) so an unset context is a clean deny, not an error.