### PR TITLE
feat: extend RLS policies to the per-user authorization tables

### DIFF
--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -62,6 +62,22 @@ def test_rls_org_isolation_and_audit_append_only():
                 'password,"createdAt","updatedAt") VALUES '
                 "('rlsIA','rlsA','r','1.1.1.1','v','p',NOW(),NOW()),"
                 "('rlsIB','rlsB','r','2.2.2.2','v','p',NOW(),NOW())")
+            await owner.execute(
+                "DELETE FROM users WHERE id = 'rlsU'")
+            await owner.execute(
+                'INSERT INTO users (id,email,name,role,"emailVerified",'
+                '"createdAt","updatedAt") VALUES '
+                "('rlsU','rls@u.test','U','VIEWER',true,NOW(),NOW())")
+            await owner.execute(
+                'INSERT INTO user_instance_roles (id,"userId","instanceId",'
+                'role,"assignedBy","createdAt","updatedAt") VALUES '
+                "('rlsGA','rlsU','rlsIA','OPERATOR','rlsU',NOW(),NOW()),"
+                "('rlsGB','rlsU','rlsIB','VIEWER','rlsU',NOW(),NOW())")
+            await owner.execute(
+                'INSERT INTO user_feature_permissions (id,'
+                '"userInstanceRoleId",feature,"canEdit","canView") VALUES '
+                "('rlsFA','rlsGA','FIREWALL',true,true),"
+                "('rlsFB','rlsGB','NAT',false,true)")
 
             async def as_runtime(setup_sql, query):
                 conn = await asyncpg.connect(os.environ["DATABASE_URL"])
@@ -82,6 +98,18 @@ def test_rls_org_isolation_and_audit_append_only():
                 "SET app.org_id = 'rlsOA'; SET app.is_system_admin = 'false'",
                 "SELECT id FROM instances WHERE id IN ('rlsIA','rlsIB')")
             assert {r["id"] for r in a_inst} == {"rlsIA"}
+
+            # Per-user authz tables are org-isolated too.
+            a_grants = await as_runtime(
+                "SET app.org_id = 'rlsOA'; SET app.is_system_admin = 'false'",
+                "SELECT id FROM user_instance_roles WHERE id IN ('rlsGA','rlsGB')")
+            assert {r["id"] for r in a_grants} == {"rlsGA"}
+
+            a_perms = await as_runtime(
+                "SET app.org_id = 'rlsOA'; SET app.is_system_admin = 'false'",
+                "SELECT id FROM user_feature_permissions "
+                "WHERE id IN ('rlsFA','rlsFB')")
+            assert {r["id"] for r in a_perms} == {"rlsFA"}
 
             # Operator bypass sees both orgs.
             all_sites = await as_runtime(
@@ -106,6 +134,7 @@ def test_rls_org_isolation_and_audit_append_only():
             finally:
                 await conn.close()
         finally:
+            await owner.execute("DELETE FROM users WHERE id = 'rlsU'")
             await owner.execute("DELETE FROM sites WHERE id IN ('rlsA','rlsB')")
             await owner.execute(
                 "DELETE FROM organizations WHERE id IN ('rlsOA','rlsOB')")

--- a/frontend/prisma/migrations/20260711_rls_authz_tables/migration.sql
+++ b/frontend/prisma/migrations/20260711_rls_authz_tables/migration.sql
@@ -1,0 +1,41 @@
+-- Extend the RLS foundation (20260710) to the per-user authorization tables.
+-- Still ENABLE, not FORCE, so the table owner (the running app today) bypasses
+-- these entirely — inert until the enforcement flip. Same keying: the request's
+-- app.org_id with an app.is_system_admin operator bypass.
+
+-- A grant is in an org via its instance's site, or via its whole-site grant.
+ALTER TABLE "user_instance_roles" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "org_isolation" ON "user_instance_roles" USING (
+    current_setting('app.is_system_admin', true) = 'true'
+    OR "instanceId" IN (
+        SELECT i."id" FROM "instances" i
+        JOIN "sites" s ON i."siteId" = s."id"
+        WHERE s."orgId" = current_setting('app.org_id', true)
+    )
+    OR "siteId" IN (
+        SELECT "id" FROM "sites"
+        WHERE "orgId" = current_setting('app.org_id', true)
+    )
+);
+
+-- A feature permission inherits its grant's org (via instance or whole-site).
+ALTER TABLE "user_feature_permissions" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "org_isolation" ON "user_feature_permissions" USING (
+    current_setting('app.is_system_admin', true) = 'true'
+    OR "userInstanceRoleId" IN (
+        SELECT uir."id" FROM "user_instance_roles" uir
+        LEFT JOIN "instances" i ON uir."instanceId" = i."id"
+        LEFT JOIN "sites" si ON i."siteId" = si."id"
+        LEFT JOIN "sites" ss ON uir."siteId" = ss."id"
+        WHERE COALESCE(si."orgId", ss."orgId")
+              = current_setting('app.org_id', true)
+    )
+);
+
+-- Intentionally NOT org-policied here:
+--   api_tokens         — user-owned, no org column; confined to the owner's
+--                        org at creation (see the token-confinement change).
+--                        Row-level org isolation needs a per-user setting and
+--                        is deferred.
+--   oauth_role_mappings — SSO is deployment-global (RFC §9), so these rules
+--                        are not org-scoped.


### PR DESCRIPTION
Flip staging, **inert**. Extends the RLS foundation (#469) to `user_instance_roles` and `user_feature_permissions`.

Policies key on `app.org_id` with the `app.is_system_admin` operator bypass, deriving each row's org through its instance's site or its whole-site grant. Still `ENABLE`, not `FORCE` — the table owner (the running app today) bypasses them entirely, so this is inert until the flip.

`api_tokens` (user-owned, confined to the owner's org at creation) and `oauth_role_mappings` (SSO is deployment-global per RFC §9) are intentionally **not** org-policied; noted in the migration.

## Evidence

Live via `SET ROLE` to the runtime role: `app.org_id=orgA` sees only org-A grants (`gA`) and feature permissions (`fA`); operator bypass sees both; owner sees both (inert). The RLS proof test now covers these two tables too. Backend suite 105 passed against the migrated DB (owner unaffected).