### PR TITLE
feat: org ADMIN gets full access on their org's instances (flag-gated)

### DIFF
--- a/backend/rbac_permissions.py
+++ b/backend/rbac_permissions.py
@@ -17,6 +17,8 @@ from typing import Dict, List, Optional, Union
 from enum import Enum
 import asyncpg
 
+import org_scope
+
 
 # Resolver entry points accept either a pool (acquire per call, the historic
 # shape) or an already org-scoped connection (org_scope.py), so permission
@@ -707,8 +709,27 @@ async def get_user_permissions(
             user_id
         )
 
-        # Site ADMINs have full access to everything
-        if site_role == "ADMIN":
+        # Deployment ADMIN (System Administrator) has full access to
+        # everything. Under org enforcement, an org ADMIN/OWNER of the
+        # instance's organization also gets full access on that org's
+        # instances (org ADMIN superset instance-ADMIN). Inert while
+        # ORG_ENFORCEMENT is off.
+        full_access = site_role == "ADMIN"
+        if not full_access and org_scope.ORG_ENFORCEMENT:
+            org_role = await conn.fetchval(
+                """
+                SELECT m."orgRole"
+                FROM org_memberships m
+                JOIN sites s ON s."orgId" = m."orgId"
+                JOIN instances i ON i."siteId" = s."id"
+                WHERE m."userId" = $1 AND i."id" = $2
+                """,
+                user_id, instance_id,
+            )
+            if org_role in ("ADMIN", "OWNER"):
+                full_access = True
+
+        if full_access:
             all_features = [
                 FeatureGroup.FIREWALL,
                 FeatureGroup.FIREWALL_GROUPS,

--- a/backend/tests/test_org_admin.py
+++ b/backend/tests/test_org_admin.py
@@ -1,0 +1,81 @@
+"""Org ADMIN/OWNER grants full access on their org's instances, under the flag.
+
+Inert when ORG_ENFORCEMENT is off (an org ADMIN with no instance grant sees
+nothing); load-bearing when on.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+import org_scope
+from rbac_permissions import FeatureGroup, PermissionLevel, get_user_permissions
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="org-admin test needs DATABASE_URL")
+
+
+@requires_db
+def test_org_admin_full_access_gated_by_flag(monkeypatch):
+    import asyncpg
+
+    db = os.environ["DATABASE_URL"]
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_oadm'")
+        await conn.execute("DELETE FROM sites WHERE id = 's_oadm'")
+        await conn.execute("DELETE FROM organizations WHERE id = 'o_oadm'")
+        await conn.execute(
+            'INSERT INTO organizations (id,name,"createdAt","updatedAt")'
+            " VALUES ('o_oadm','OAdm',NOW(),NOW())")
+        # users.role = VIEWER -> NOT a System Administrator.
+        await conn.execute(
+            'INSERT INTO users (id,email,name,role,"emailVerified",'
+            '"createdAt","updatedAt") VALUES '
+            "('u_oadm','oadm@t.test','OAdm','VIEWER',true,NOW(),NOW())")
+        # ... but org ADMIN of o_oadm.
+        await conn.execute(
+            'INSERT INTO org_memberships (id,"userId","orgId","orgRole",'
+            '"createdAt","updatedAt") VALUES '
+            "('om_oadm','u_oadm','o_oadm','ADMIN',NOW(),NOW())")
+        await conn.execute(
+            'INSERT INTO sites (id,name,"orgId","createdAt","updatedAt")'
+            " VALUES ('s_oadm','SOAdm','o_oadm',NOW(),NOW())")
+        await conn.execute(
+            'INSERT INTO instances (id,"siteId",name,host,username,'
+            'password,"createdAt","updatedAt") VALUES '
+            "('i_oadm','s_oadm','r','1.1.1.1','v','p',NOW(),NOW())")
+        await conn.close()
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_oadm'")
+        await conn.execute("DELETE FROM sites WHERE id = 's_oadm'")
+        await conn.execute("DELETE FROM organizations WHERE id = 'o_oadm'")
+        await conn.close()
+
+    async def perms():
+        pool = await asyncpg.create_pool(db, min_size=1, max_size=2)
+        try:
+            return await get_user_permissions(pool, "u_oadm", "i_oadm")
+        finally:
+            await pool.close()
+
+    asyncio.run(seed())
+    try:
+        # Flag OFF: org ADMIN with no instance grant -> nothing.
+        monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", False)
+        off = asyncio.run(perms())
+        assert off[FeatureGroup.FIREWALL] == PermissionLevel.NONE
+        assert off[FeatureGroup.SYSTEM] == PermissionLevel.NONE
+
+        # Flag ON: org ADMIN gets full access on their org's instance.
+        monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+        on = asyncio.run(perms())
+        assert on[FeatureGroup.FIREWALL] == PermissionLevel.WRITE
+        assert on[FeatureGroup.USER_MANAGEMENT] == PermissionLevel.WRITE
+    finally:
+        asyncio.run(cleanup())


### PR DESCRIPTION
Flip staging, **inert** when `ORG_ENFORCEMENT` is off.

`get_user_permissions` grants the full feature grid not only to the deployment ADMIN (System Administrator, `users.role=ADMIN`) but also — under `ORG_ENFORCEMENT` — to a user who is `ADMIN` or `OWNER` of the instance's organization by membership. That's the RFC's "org ADMIN ⊇ instance-ADMIN on every instance in the org."

**Inert while the flag is off**: an org ADMIN with no instance grant still resolves to no access, so permissions are unchanged on today's single-org deployments. This is what makes the #453 by-id row-checks load-bearing at the flip — an org ADMIN reaches the admin surface scoped to their org, and the row-checks keep them inside it.

## Evidence

- Flag **off**: an org-ADMIN (membership `orgRole=ADMIN`, `users.role=VIEWER`) with no instance grant → all features NONE.
- Flag **on**: same user → FIREWALL/USER_MANAGEMENT/... WRITE on their org's instance.
- Backend suite 106 passed. Flag read via `org_scope.ORG_ENFORCEMENT` (live/patchable), no import cycle.