### PR TITLE
feat: set site orgId explicitly on creation

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -676,16 +676,22 @@ async def create_site(request: Request, body: SiteCreateRequest, conn: asyncpg.C
         alphabet = string.ascii_letters + string.digits
         site_id = ''.join(secrets.choice(alphabet) for _ in range(32))
 
-        # Create site
+        # Create the site in the caller's acting organization. Set it
+        # explicitly (the org_conn_admin dependency resolved it) rather than
+        # relying on the column's DEFAULT, so the DEFAULT can be dropped at
+        # the enforcement flip. Falls back to the default org when there is
+        # no org context (single-org / pre-flip).
+        acting_org = getattr(request.state, "acting_org_id", None) or "default"
         site = await conn.fetchrow(
             """
-            INSERT INTO sites (id, name, description, "createdAt", "updatedAt")
-            VALUES ($1, $2, $3, NOW(), NOW())
+            INSERT INTO sites (id, name, description, "orgId", "createdAt", "updatedAt")
+            VALUES ($1, $2, $3, $4, NOW(), NOW())
             RETURNING id, name, description, "createdAt", "updatedAt"
             """,
             site_id,
             body.name,
             body.description,
+            acting_org,
         )
 
         return SiteResponse(


### PR DESCRIPTION
Flip staging, safe. Site creation now writes the caller's acting organization (resolved by `org_conn_admin`) into `sites.orgId` explicitly instead of relying on the column DEFAULT. This lets the `DEFAULT 'default'` scaffolding be dropped at the enforcement flip. Falls back to the default org when there's no org context (single-org / pre-flip), so behavior is unchanged today.

Live: create a site as an admin → 201, row lands with `orgId=default`. Backend suite green.