### PR TITLE
feat: context-bootstrap bypass so org resolution works under FORCE RLS

### DIFF
--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -236,35 +236,44 @@ class SessionMiddleware(BaseHTTPMiddleware):
 
         try:
             async with db_pool.acquire() as conn:
-                # Site ADMINs reach every instance; regular users need a grant.
-                user_site_role = await conn.fetchval(
-                    "SELECT role FROM users WHERE id = $1",
-                    user_id,
-                )
-                # Deployment-operator flag for org-scoped connections
-                # (org_scope.py) — resolved here anyway, so keep it.
-                request.state.user_role = user_site_role
+                # This middleware CREATES the org context by reading org-scoped
+                # tables (instances, sites) to resolve the active instance. That
+                # read happens before any org context exists, so under FORCE RLS
+                # as the fenced role it would be denied. Run the resolution in a
+                # transaction with a temporary operator bypass; every query here
+                # is scoped to this user, so the bypass cannot leak other rows.
+                async with conn.transaction():
+                    await conn.execute(
+                        "SELECT set_config('app.is_system_admin', 'true', true)")
+                    # Site ADMINs reach every instance; regular users need a grant.
+                    user_site_role = await conn.fetchval(
+                        "SELECT role FROM users WHERE id = $1",
+                        user_id,
+                    )
+                    # Deployment-operator flag for org-scoped connections
+                    # (org_scope.py) — resolved here anyway, so keep it.
+                    request.state.user_role = user_site_role
 
-                if is_token_auth:
-                    instance_id = request.headers.get("X-VyOS-Instance-Id")
-                    if instance_id:
-                        session = await self._resolve_instance_for_user(
-                            conn, user_id, user_site_role, instance_id
-                        )
-                        # Beyond the user's grant, a scoped token may only reach
-                        # the instances/sites it was restricted to.
-                        if session and not self._token_allows_instance(
-                            request, session["instance_id"], session["site_id"]
-                        ):
+                    if is_token_auth:
+                        instance_id = request.headers.get("X-VyOS-Instance-Id")
+                        if instance_id:
+                            session = await self._resolve_instance_for_user(
+                                conn, user_id, user_site_role, instance_id
+                            )
+                            # Beyond the user's grant, a scoped token may only
+                            # reach the instances/sites it was restricted to.
+                            if session and not self._token_allows_instance(
+                                request, session["instance_id"], session["site_id"]
+                            ):
+                                session = None
+                        else:
+                            # No instance named - downstream read/write handlers
+                            # report "no active instance" as for a disconnect.
                             session = None
                     else:
-                        # No instance named - downstream read/write handlers will
-                        # report "no active instance" as for a disconnected session.
-                        session = None
-                else:
-                    session = await self._resolve_cookie_instance(
-                        conn, request, path, user_id, user_site_role
-                    )
+                        session = await self._resolve_cookie_instance(
+                            conn, request, path, user_id, user_site_role
+                        )
 
                 if session:
                     # User has an active session - inject instance details.

--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -140,6 +140,15 @@ async def _handler_conn(
     user = getattr(request.state, "user", None)
     async with pool.acquire() as conn:
         async with conn.transaction():
+            # Bootstrap bypass: the org-context derivation below reads
+            # org-scoped tables (org_memberships) to find WHO/WHERE before org
+            # context exists. Under FORCE RLS as the fenced role those reads
+            # would be denied, so run them with a temporary operator bypass.
+            # The real context is set below; the derivation queries are
+            # userId-scoped, so the bypass cannot leak another user's rows.
+            await conn.execute(
+                "SELECT set_config('app.is_system_admin', 'true', true)")
+
             org_id = org_id_from_state(request)
             is_admin = is_system_admin_from_state(request)
 
@@ -242,6 +251,10 @@ async def ws_org_conn(
     pool = _ws_pool(websocket)
     async with pool.acquire() as conn:
         async with conn.transaction():
+            # Bootstrap bypass to derive the instance's org before org context
+            # exists (see _handler_conn); overwritten with real context below.
+            await conn.execute(
+                "SELECT set_config('app.is_system_admin', 'true', true)")
             row = await conn.fetchrow(
                 'SELECT s."orgId" AS org_id,'
                 ' (SELECT role FROM users WHERE id = $2) AS role'


### PR DESCRIPTION
Flip prerequisite, **found by a full-stack rehearsal** and inert on today's deployments.

## The blocker

Rehearsed the flip end to end (app connected **as the fenced runtime role**, `FORCE ROW LEVEL SECURITY` on, `ORG_ENFORCEMENT=1`). The System Administrator worked, but **every non-sysadmin user broke** — a member's `my-permissions` returned all NONE.

Cause: the paths that *derive* org context read org-scoped tables before context exists — `SessionMiddleware` resolves the active instance (`instances`/`sites`) and `org_conn_admin` resolves the caller's sole org (`org_memberships`) — with `app.org_id` empty, so the policies deny the read → context resolves empty → grants hidden. Confirmed: with `app.org_id` set the fenced role sees the grant, and `ALTER ROLE … BYPASSRLS` made the member's perm return WRITE again.

## The fix

These reads are the context-creation step (like identity resolution) and are each **scoped to the acting user**, so they run under a temporary operator bypass — `SET LOCAL app.is_system_admin='true'` for the derivation queries, immediately overwritten with the real org context before any handler query. A user-scoped query under the bypass can only return that user's own rows, so nothing leaks.

## Evidence

- **Inert today**: the app connects as the table owner (bypasses non-FORCEd RLS), so the extra `set_config` is a no-op. Backend suite 106 passed / 1 skipped.
- **Re-rehearsal, fixed** (fenced role, FORCE RLS, enforcement on, **no** BYPASSRLS): sysadmin sees the site; a member resolves their active instance (200), sees only their org's sites (`[s1]`), and gets their OPERATOR FIREWALL grant = **WRITE** (was NONE before this change).

## For the reviewer

The bypass is only ever set for user-scoped derivation reads and is always overwritten with the real `app.org_id`/`app.is_system_admin` before a handler query. Confirm no handler query runs between the bypass and the real `set_config`.