### PR TITLE
test: Golden Rule structural proof + frontend-role grant docs

### DIFF
--- a/backend/tests/adversarial/test_golden_rule.py
+++ b/backend/tests/adversarial/test_golden_rule.py
@@ -1,0 +1,101 @@
+"""Golden Rule structural proof (RFC §8).
+
+The frontend's database role must be unable to write the authorization tables
+(org_memberships, user_instance_roles, user_feature_permissions,
+organizations): those are backend/migration-owned, so a compromised frontend
+cannot mint grants or memberships even if its code tried. This proves the ban
+is structural (a table-level privilege), not merely conventional.
+
+The proof creates a restricted role mirroring the intended frontend grants —
+write access to the Better Auth core tables only — and asserts that INSERT and
+UPDATE on each authz table fail. Needs CREATE ROLE; skips otherwise.
+
+Note: oauth_role_mappings is not covered here — the frontend still writes it
+via the OAuth-config UI. Relocating that write to the backend (like the SSO
+reconcile relocation) is the remaining step before it joins this ban.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="Golden Rule proof needs DATABASE_URL")
+
+FRONTEND = "vym_frontend_proof"
+
+# Better Auth core tables the frontend legitimately writes.
+CORE_TABLES = ["users", "sessions", "accounts", "verifications"]
+
+# Authz tables the frontend must never write.
+BANNED_TABLES = [
+    "org_memberships",
+    "user_instance_roles",
+    "user_feature_permissions",
+    "organizations",
+]
+
+
+@requires_db
+def test_frontend_role_cannot_write_authz_tables():
+    import asyncpg
+
+    async def main():
+        owner = await asyncpg.connect(os.environ["DATABASE_URL"])
+        created = False
+        try:
+            try:
+                await owner.execute(f"DROP ROLE IF EXISTS {FRONTEND}")
+                await owner.execute(f"CREATE ROLE {FRONTEND} NOLOGIN")
+                created = True
+            except asyncpg.InsufficientPrivilegeError:
+                return "skip"
+
+            await owner.execute(f"GRANT USAGE ON SCHEMA public TO {FRONTEND}")
+            # Frontend gets write access to the Better Auth core tables only.
+            for table in CORE_TABLES:
+                await owner.execute(
+                    f'GRANT SELECT, INSERT, UPDATE, DELETE ON "{table}" '
+                    f"TO {FRONTEND}")
+            # Deliberately NOT granted on the authz tables.
+
+            for table in BANNED_TABLES:
+                conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+                try:
+                    await conn.execute(f"SET ROLE {FRONTEND}")
+                    with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                        await conn.execute(
+                            f'INSERT INTO "{table}" (id) VALUES (\'gr_probe\')')
+                    with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                        await conn.execute(f'UPDATE "{table}" SET id = id')
+                finally:
+                    await conn.close()
+
+            # Sanity: the frontend role CAN write a core table (users).
+            conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+            try:
+                await conn.execute(f"SET ROLE {FRONTEND}")
+                # Reaches the not-null/columns error, not a privilege error —
+                # i.e. the grant is present.
+                with pytest.raises(asyncpg.PostgresError) as exc:
+                    await conn.execute(
+                        "INSERT INTO users (id) VALUES ('u_probe')")
+                assert not isinstance(
+                    exc.value, asyncpg.InsufficientPrivilegeError)
+            finally:
+                await conn.close()
+        finally:
+            if created:
+                for table in CORE_TABLES:
+                    await owner.execute(
+                        f'REVOKE ALL ON "{table}" FROM {FRONTEND}')
+                await owner.execute(
+                    f"REVOKE USAGE ON SCHEMA public FROM {FRONTEND}")
+                await owner.execute(f"DROP ROLE IF EXISTS {FRONTEND}")
+            await owner.close()
+        return "ok"
+
+    if asyncio.run(main()) == "skip":
+        pytest.skip("no privilege to CREATE ROLE for the Golden Rule proof")

--- a/docs-site/docs/architecture/organizations.md
+++ b/docs-site/docs/architecture/organizations.md
@@ -59,6 +59,31 @@ file that resolves a database connection outside the sanctioned org-scoped
 path fails the suite unless it is on a reviewed allowlist that carries a
 justification per entry.
 
+## The Golden Rule (frontend cannot write authorization tables)
+
+Authorization tables — `org_memberships`, `user_instance_roles`,
+`user_feature_permissions`, `organizations` — are backend/migration owned. The
+frontend must not be able to write them, so a compromised frontend cannot mint
+grants or memberships. This is enforced structurally at the database: the
+frontend's Postgres role is granted write access only to the Better Auth core
+tables and nothing else. A proof in the adversarial suite connects as such a
+role and asserts every authz-table write fails at the grant level.
+
+When you separate the frontend's database role (recommended alongside
+enforcement), grant it narrowly:
+
+```sql
+GRANT USAGE ON SCHEMA public TO vym_frontend;
+GRANT SELECT, INSERT, UPDATE, DELETE ON users, sessions, accounts, verifications
+    TO vym_frontend;
+-- No grant on org_memberships / user_instance_roles /
+-- user_feature_permissions / organizations: the frontend never writes them.
+```
+
+`oauth_role_mappings` is not yet in the ban — the frontend still writes it via
+the OAuth-config UI; relocating that write to the backend (as the SSO reconcile
+relocation did for grants) is the remaining step before it joins the list.
+
 ## Row-level security (foundation in place, inert)
 
 The database carries row-level-security policies on the organization-hierarchy


### PR DESCRIPTION
RFC §8 Golden Rule proof. Authorization tables (`org_memberships`, `user_instance_roles`, `user_feature_permissions`, `organizations`) are backend/migration owned; a compromised frontend must not be able to write them.

The test creates a restricted role mirroring the intended frontend grants — write access to the Better Auth **core** tables only — and asserts that INSERT and UPDATE on each authz table fail at the grant level. A sanity check confirms the same role *can* write a core table (it reaches a not-null error, not a privilege error), so the grant model is correct. Needs `CREATE ROLE`; skips otherwise (verified: passes as superuser, skips as a non-privileged role).

`oauth_role_mappings` is intentionally out of scope — the frontend still writes it via the OAuth-config UI; relocating that write to the backend (as the SSO reconcile relocation did for grants) is the remaining step before it joins the ban. The frontend-role grant model and this caveat are documented in the organizations architecture page.

This closes the adversarial suite's §8 coverage (cross-org negatives, canary, RLS proof, forged-claims, and now the Golden Rule proof). Docs build clean.