### PR TITLE
feat: add GET /session/organizations for the org UI

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -204,6 +204,22 @@ async def org_conn(request: Request) -> AsyncIterator[asyncpg.Connection]:
         yield conn
 
 
+async def org_conn_self(request: Request) -> AsyncIterator[asyncpg.Connection]:
+    """Connection for endpoints that read only the caller's OWN rows
+    (userId-scoped, e.g. listing the caller's organization memberships).
+
+    Sets the operator bypass so those reads succeed under RLS without needing
+    a single acting org; safe because every query on this connection is scoped
+    to the caller's user id, so nothing else can be returned.
+    """
+    pool = _require_pool(request)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "SELECT set_config('app.is_system_admin', 'true', true)")
+            yield conn
+
+
 async def org_conn_admin(
     request: Request,
     org_id: Optional[str] = Query(

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -6,7 +6,7 @@ Handles connect/disconnect operations and instance selection.
 """
 
 from fastapi import Depends, APIRouter, HTTPException, Request, UploadFile, File, Form
-from org_scope import assert_row_in_acting_org, org_conn_admin
+from org_scope import assert_row_in_acting_org, org_conn_admin, org_conn_self
 from starlette.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -51,6 +51,23 @@ class SiteResponse(BaseModel):
     role: str  # User's role in this site (OWNER, ADMIN, VIEWER)
     created_at: datetime
     updated_at: datetime
+
+
+class OrganizationMembership(BaseModel):
+    """An organization the caller belongs to, with their role in it."""
+
+    id: str
+    name: str
+    org_role: str  # OWNER, ADMIN, or MEMBER
+
+
+class OrganizationsResponse(BaseModel):
+    """The caller's organizations. org_ui_visible mirrors the frontend rule
+    (more than one membership) so the org UI is suppressed for single-team
+    deployments without the client re-deriving it."""
+
+    organizations: List[OrganizationMembership]
+    org_ui_visible: bool
 
 
 class SiteCreateRequest(BaseModel):
@@ -440,6 +457,37 @@ async def disconnect_from_instance(request: Request, conn: asyncpg.Connection = 
 # ============================================================================
 # Endpoint: List User's Sites
 # ============================================================================
+
+
+@router.get("/organizations", response_model=OrganizationsResponse)
+async def list_user_organizations(request: Request, conn: asyncpg.Connection = Depends(org_conn_self)):
+    """The caller's organization memberships.
+
+    Backs the frontend's org UI: the grouping header and switcher render only
+    when the caller belongs to more than one organization (org_ui_visible),
+    so single-team deployments never see the org layer.
+    """
+    if not hasattr(request.state, "user") or not request.state.user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    rows = await conn.fetch(
+        """
+        SELECT o.id, o.name, m."orgRole" AS org_role
+        FROM org_memberships m
+        JOIN organizations o ON o.id = m."orgId"
+        WHERE m."userId" = $1
+        ORDER BY o.name
+        """,
+        request.state.user["id"],
+    )
+    orgs = [
+        OrganizationMembership(id=r["id"], name=r["name"], org_role=r["org_role"])
+        for r in rows
+    ]
+    return OrganizationsResponse(
+        organizations=orgs,
+        org_ui_visible=len(orgs) > 1,
+    )
 
 
 @router.get("/sites", response_model=List[SiteResponse])

--- a/backend/tests/test_organizations_endpoint.py
+++ b/backend/tests/test_organizations_endpoint.py
@@ -1,0 +1,82 @@
+"""GET /session/organizations — the caller's memberships + org_ui_visible."""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import os
+
+import pytest
+
+requires_db = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="organizations endpoint test needs DATABASE_URL")
+
+SECRET = b"orgs-endpoint-secret"
+
+
+def _cookie(token):
+    sig = base64.b64encode(
+        hmac.new(SECRET, token.encode(), hashlib.sha256).digest()).decode()
+    return f"{token}.{sig}"
+
+
+@requires_db
+def test_org_ui_visible_tracks_membership_count(monkeypatch):
+    import asyncpg
+    import session_cookie
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(session_cookie, "_secret", SECRET)
+    db = os.environ["DATABASE_URL"]
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id IN ('u_one','u_two')")
+        await conn.execute(
+            "DELETE FROM organizations WHERE id = 'org_extra'")
+        await conn.execute(
+            'INSERT INTO organizations (id,name,"createdAt","updatedAt")'
+            " VALUES ('org_extra','Extra Org',NOW(),NOW())")
+        for uid in ("u_one", "u_two"):
+            await conn.execute(
+                'INSERT INTO users (id,email,name,role,"emailVerified",'
+                '"createdAt","updatedAt") VALUES '
+                f"('{uid}','{uid}@t.test','U','VIEWER',true,NOW(),NOW())")
+            await conn.execute(
+                'INSERT INTO sessions (id,token,"userId","expiresAt",'
+                '"createdAt","updatedAt") VALUES '
+                f"('s_{uid}','tok_{uid}','{uid}',NOW()+interval '1 h',"
+                "NOW(),NOW())")
+        # u_one: one membership; u_two: two.
+        await conn.execute(
+            'INSERT INTO org_memberships (id,"userId","orgId","orgRole",'
+            '"createdAt","updatedAt") VALUES '
+            "('mo1','u_one','default','MEMBER',NOW(),NOW()),"
+            "('mo2','u_two','default','MEMBER',NOW(),NOW()),"
+            "('mo3','u_two','org_extra','ADMIN',NOW(),NOW())")
+        await conn.close()
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id IN ('u_one','u_two')")
+        await conn.execute("DELETE FROM organizations WHERE id = 'org_extra'")
+        await conn.close()
+
+    from app import app
+    asyncio.run(seed())
+    try:
+        with TestClient(app) as client:
+            client.cookies.set("better-auth.session_token", _cookie("tok_u_one"))
+            one = client.get("/session/organizations").json()
+            assert one["org_ui_visible"] is False
+            assert [o["name"] for o in one["organizations"]] == ["Default"]
+            assert one["organizations"][0]["org_role"] == "MEMBER"
+
+            client.cookies.set("better-auth.session_token", _cookie("tok_u_two"))
+            two = client.get("/session/organizations").json()
+            assert two["org_ui_visible"] is True
+            assert {o["name"] for o in two["organizations"]} == {
+                "Default", "Extra Org"}
+    finally:
+        asyncio.run(cleanup())


### PR DESCRIPTION
Backend groundwork for the org UI. Returns the caller's organization memberships (id, name, org role) plus `org_ui_visible = membership count > 1`, mirroring the frontend rule so the grouping header and switcher render only for users in more than one organization — single-team deployments never see the org layer, and the client doesn't re-derive the flag.

Adds `org_conn_self`, a connection dependency for endpoints that read only the caller's own rows: it sets the operator bypass so the `userId`-scoped read works under RLS **without** requiring a single acting org (`org_conn_admin` raises when the caller belongs to multiple orgs — exactly the case this endpoint must list). Safe because every query on that connection is scoped to the caller's user id.

## Evidence

Live: a one-membership user → `org_ui_visible=false`, `['Default']`; a two-membership user → `org_ui_visible=true`, `['Default','Extra Org']`. DB-gated test covers both. Backend suite 107 passed / 2 skipped.

The frontend components that consume this (grouping header, switcher) are the remaining UI follow-up; this is the endpoint they need.