### PR TITLE
feat: organization-aware sites UI (switcher, grouping, admin label)

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -49,6 +49,8 @@ class SiteResponse(BaseModel):
     name: str
     description: Optional[str] = None
     role: str  # User's role in this site (OWNER, ADMIN, VIEWER)
+    org_id: Optional[str] = None
+    org_name: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 
@@ -519,9 +521,11 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
             # Site ADMINs see ALL sites with ADMIN role
             sites = await conn.fetch(
                 """
-                SELECT id, name, description, "createdAt", "updatedAt"
-                FROM sites
-                ORDER BY name
+                SELECT s.id, s.name, s.description, s."orgId",
+                       o.name AS org_name, s."createdAt", s."updatedAt"
+                FROM sites s
+                LEFT JOIN organizations o ON o.id = s."orgId"
+                ORDER BY o.name, s.name
                 """,
             )
 
@@ -531,6 +535,8 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
                     name=site["name"],
                     description=site["description"],
                     role="ADMIN",  # Site ADMINs have ADMIN role on all sites
+                    org_id=site["orgId"],
+                    org_name=site["org_name"],
                     created_at=site["createdAt"],
                     updated_at=site["updatedAt"],
                 )
@@ -541,7 +547,8 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
             # Role shown is the highest role the user has across all instances in that site
             sites = await conn.fetch(
                 """
-                SELECT DISTINCT s.id, s.name, s.description, s."createdAt", s."updatedAt",
+                SELECT DISTINCT s.id, s.name, s.description, s."orgId",
+                       o.name AS org_name, s."createdAt", s."updatedAt",
                        MAX(
                            CASE uir.role
                                WHEN 'ADMIN' THEN 3
@@ -562,8 +569,10 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
                 JOIN user_instance_roles uir
                     ON (uir."instanceId" = i.id OR uir."siteId" = s.id)
                     AND uir."userId" = $1
-                GROUP BY s.id, s.name, s.description, s."createdAt", s."updatedAt"
-                ORDER BY s.name
+                LEFT JOIN organizations o ON o.id = s."orgId"
+                GROUP BY s.id, s.name, s.description, s."orgId", o.name,
+                         s."createdAt", s."updatedAt"
+                ORDER BY o.name, s.name
                 """,
                 user_id,
             )
@@ -574,6 +583,8 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
                     name=site["name"],
                     description=site["description"],
                     role=site["role"],
+                    org_id=site["orgId"],
+                    org_name=site["org_name"],
                     created_at=site["createdAt"],
                     updated_at=site["updatedAt"],
                 )

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -50906,6 +50906,28 @@
             "type": "string",
             "title": "Role"
           },
+          "org_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Org Id"
+          },
+          "org_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Org Name"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",

--- a/frontend/src/app/sites/page.tsx
+++ b/frontend/src/app/sites/page.tsx
@@ -39,6 +39,8 @@ import {
 import { signOut, useSession } from "@/lib/auth-client";
 import { Site, Instance, sessionService } from "@/lib/api/session";
 import { useSessionStore } from "@/store/session-store";
+import { useOrgStore } from "@/store/org-store";
+import { OrgSwitcher } from "@/components/organizations/OrgSwitcher";
 import { InstanceCard } from "@/components/sites/InstanceCard";
 import { InstanceTableView } from "@/components/sites/InstanceTableView";
 import { SiteUpdatesPanel } from "@/components/sites/SiteUpdatesPanel";
@@ -70,6 +72,10 @@ export default function SitesPage() {
   // Zustand store
   const { activeSession, loadSession, connectToInstance, disconnectFromInstance } =
     useSessionStore();
+
+  // Organization context (org UI is suppressed for single-team deployments)
+  const { orgUiVisible, activeOrgId, loaded: orgsLoaded, loadOrganizations } =
+    useOrgStore();
 
   // Navigation state
   const [selectedSection, setSelectedSection] = useState<NavSection>("sites");
@@ -120,10 +126,17 @@ export default function SitesPage() {
   // Full backup / restore
   const [backupRestoreOpen, setBackupRestoreOpen] = useState(false);
 
+  // Load the caller's organizations first; sites load (and reload) keyed on
+  // the active org so a multi-org user's site list is org-scoped.
   useEffect(() => {
-    loadData();
+    loadOrganizations();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (orgsLoaded) loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgsLoaded, activeOrgId]);
 
   // Auto-select first site when sites load
   useEffect(() => {
@@ -288,6 +301,12 @@ export default function SitesPage() {
           {/* Navigation Items */}
           <ScrollArea className="flex-1 px-3">
             <div className="space-y-1 py-3">
+              {/* Organization switcher (multi-org users only) */}
+              {orgUiVisible && (
+                <div className="pb-2">
+                  <OrgSwitcher />
+                </div>
+              )}
               {/* Sites */}
               <button
                 onClick={() => setSelectedSection("sites")}
@@ -414,6 +433,11 @@ export default function SitesPage() {
                   <p className="text-xs font-semibold text-foreground truncate">
                     {session?.user?.name || session?.user?.email || "User"}
                   </p>
+                  {(session?.user as { role?: string })?.role === "ADMIN" && (
+                    <p className="text-[10px] text-muted-foreground truncate">
+                      System Administrator
+                    </p>
+                  )}
                 </div>
               </div>
               <Button
@@ -508,9 +532,17 @@ export default function SitesPage() {
                 </div>
               ) : (
                 <div className="space-y-1 py-3">
-                  {filteredSites.map((site) => (
+                  {filteredSites.map((site, idx) => (
+                    <div key={site.id}>
+                    {orgUiVisible && site.org_name &&
+                      (idx === 0 ||
+                        filteredSites[idx - 1].org_name !== site.org_name) && (
+                        <div className="flex items-center gap-1.5 px-2 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          <Building2 className="h-3 w-3" />
+                          {site.org_name}
+                        </div>
+                      )}
                     <div
-                      key={site.id}
                       className={cn(
                         "w-full rounded-lg transition-all relative group",
                         selectedSite?.id === site.id
@@ -588,6 +620,7 @@ export default function SitesPage() {
                           </DropdownMenu>
                         </div>
                       )}
+                    </div>
                     </div>
                   ))}
                 </div>

--- a/frontend/src/components/organizations/OrgSwitcher.tsx
+++ b/frontend/src/components/organizations/OrgSwitcher.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Building, ChevronsUpDown, Check } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useOrgStore } from "@/store/org-store";
+import { cn } from "@/lib/utils";
+
+/**
+ * Organization switcher. Renders only when the caller belongs to more than
+ * one organization (orgUiVisible); single-team deployments never see it.
+ * Picking an org sets the acting org for the admin surface.
+ */
+export function OrgSwitcher({ onChange }: { onChange?: () => void }) {
+  const { organizations, orgUiVisible, activeOrgId, setActiveOrg } =
+    useOrgStore();
+
+  if (!orgUiVisible || organizations.length < 2) return null;
+
+  const active =
+    organizations.find((o) => o.id === activeOrgId) ?? organizations[0];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className="flex w-full items-center gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-sm hover:bg-accent transition-colors"
+          aria-label="Switch organization"
+        >
+          <Building className="h-4 w-4 text-muted-foreground shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate font-medium text-foreground">
+              {active?.name}
+            </div>
+            <div className="text-xs text-muted-foreground">Organization</div>
+          </div>
+          <ChevronsUpDown className="h-4 w-4 text-muted-foreground shrink-0" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="start">
+        <DropdownMenuLabel>Organizations</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {organizations.map((org) => (
+          <DropdownMenuItem
+            key={org.id}
+            onClick={() => {
+              setActiveOrg(org.id);
+              onChange?.();
+            }}
+            className="flex items-center gap-2"
+          >
+            <Check
+              className={cn(
+                "h-4 w-4",
+                org.id === active?.id ? "opacity-100" : "opacity-0"
+              )}
+            />
+            <span className="flex-1 truncate">{org.name}</span>
+            <span className="text-xs text-muted-foreground">
+              {org.org_role}
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/lib/api/org-context.ts
+++ b/frontend/src/lib/api/org-context.ts
@@ -1,0 +1,23 @@
+/**
+ * Active organization context.
+ *
+ * Holds the org the admin surface is currently acting in, so the API service
+ * layer can attach `?org_id=` to org-scoped endpoints without importing the
+ * store (avoids a cycle). The org store is the source of truth and keeps this
+ * in sync; single-org users never set it (the endpoints default to the sole
+ * org server-side).
+ */
+let activeOrgId: string | null = null;
+
+export function getActiveOrgId(): string | null {
+  return activeOrgId;
+}
+
+export function setActiveOrgId(id: string | null): void {
+  activeOrgId = id;
+}
+
+/** `?org_id=…` when an org is selected, otherwise an empty string. */
+export function orgQuery(prefix: "?" | "&" = "?"): string {
+  return activeOrgId ? `${prefix}org_id=${encodeURIComponent(activeOrgId)}` : "";
+}

--- a/frontend/src/lib/api/session.ts
+++ b/frontend/src/lib/api/session.ts
@@ -8,6 +8,7 @@
  */
 
 import { apiClient } from "./client";
+import { orgQuery } from "./org-context";
 import { ApiError } from "@/lib/types/api";
 
 // ============================================================================
@@ -19,8 +20,21 @@ export interface Site {
   name: string;
   description?: string | null;
   role: "ADMIN" | "OPERATOR" | "VIEWER";
+  org_id?: string | null;
+  org_name?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface OrganizationMembership {
+  id: string;
+  name: string;
+  org_role: "OWNER" | "ADMIN" | "MEMBER";
+}
+
+export interface OrganizationsResponse {
+  organizations: OrganizationMembership[];
+  org_ui_visible: boolean;
 }
 
 export interface Instance {
@@ -190,10 +204,17 @@ class SessionService {
   }
 
   /**
-   * List all sites the user has access to
+   * The caller's organization memberships + whether the org UI should show.
+   */
+  async listOrganizations(): Promise<OrganizationsResponse> {
+    return apiClient.get<OrganizationsResponse>("/session/organizations");
+  }
+
+  /**
+   * List all sites the user has access to (scoped to the active org when set).
    */
   async listSites(): Promise<Site[]> {
-    return apiClient.get<Site[]>("/session/sites");
+    return apiClient.get<Site[]>(`/session/sites${orgQuery()}`);
   }
 
   /**
@@ -204,10 +225,10 @@ class SessionService {
   }
 
   /**
-   * Create a new site
+   * Create a new site (in the active org when set).
    */
   async createSite(data: SiteCreateRequest): Promise<Site> {
-    return apiClient.post<Site>("/session/sites", data);
+    return apiClient.post<Site>(`/session/sites${orgQuery()}`, data);
   }
 
   /**

--- a/frontend/src/store/org-store.ts
+++ b/frontend/src/store/org-store.ts
@@ -1,0 +1,80 @@
+/**
+ * Organization Store
+ *
+ * Loads the caller's organization memberships and tracks which org the admin
+ * surface is acting in. The org UI (grouping header, switcher) renders only
+ * when `orgUiVisible` (more than one membership), so single-team deployments
+ * never see the org layer. The active org is persisted and mirrored into
+ * org-context so the API service layer can scope its requests.
+ */
+
+import { create } from "zustand";
+import { sessionService, OrganizationMembership } from "@/lib/api/session";
+import { setActiveOrgId } from "@/lib/api/org-context";
+
+const STORAGE_KEY = "vymgr.activeOrgId";
+
+function loadPersisted(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function persist(id: string | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (id) window.localStorage.setItem(STORAGE_KEY, id);
+    else window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+interface OrgState {
+  organizations: OrganizationMembership[];
+  orgUiVisible: boolean;
+  activeOrgId: string | null;
+  loaded: boolean;
+
+  loadOrganizations: () => Promise<void>;
+  setActiveOrg: (id: string) => void;
+}
+
+export const useOrgStore = create<OrgState>((set, get) => ({
+  organizations: [],
+  orgUiVisible: false,
+  activeOrgId: null,
+  loaded: false,
+
+  loadOrganizations: async () => {
+    try {
+      const res = await sessionService.listOrganizations();
+      const persisted = loadPersisted();
+      const valid = res.organizations.some((o) => o.id === persisted);
+      // Prefer the persisted choice; otherwise the first org (stable, sorted
+      // by name server-side). Null only when the user has no memberships.
+      const active =
+        (valid ? persisted : null) ?? res.organizations[0]?.id ?? null;
+      setActiveOrgId(active);
+      persist(active);
+      set({
+        organizations: res.organizations,
+        orgUiVisible: res.org_ui_visible,
+        activeOrgId: active,
+        loaded: true,
+      });
+    } catch {
+      set({ loaded: true });
+    }
+  },
+
+  setActiveOrg: (id: string) => {
+    if (id === get().activeOrgId) return;
+    setActiveOrgId(id);
+    persist(id);
+    set({ activeOrgId: id });
+  },
+}));


### PR DESCRIPTION
Closes #478.

## What
Surfaces the organization layer in the Sites admin surface for multi-org users, while single-team deployments stay pixel-for-pixel unchanged.

### Backend — `GET /session/sites`
- Each site now carries `org_id` / `org_name` (LEFT JOIN organizations; additive `Optional` fields → non-breaking for existing clients).
- Ordered by org name then site name for a stable grouped list.

### Frontend — Sites page
- `useOrgStore` loads memberships from `GET /session/organizations`, tracks the active org (persisted to `localStorage`, mirrored into `org-context` so the API layer attaches `?org_id=` to org-scoped calls).
- `OrgSwitcher` sidebar dropdown — rendered only when `org_ui_visible` (> 1 membership). Single-team users never see it.
- Sites grouped under per-organization headers when the switcher is visible.
- `System Administrator` sub-label for global ADMIN users.

## Inert by default
Purely presentational + an optional `?org_id=` query param. With `ORG_ENFORCEMENT` off (default) the backend does not filter by org, so the site list is identical for everyone; the UI only adds grouping/labels for users who already have multiple memberships.

## Verified (local prod build + Playwright)
- **Multi-org admin** (2 memberships): switcher lists both orgs with roles (Acme Corp ADMIN ✓ / Default OWNER), sites grouped `ACME CORP` / `DEFAULT`, `System Administrator` label shown.
- **Single-org user** (1 membership): no switcher, no group headers, flat list — identical to today's UI.
- `tsc --noEmit` clean; `npm run build` succeeds.