### PR TITLE
chore: drop the inert-phase DEFAULT on sites.orgId

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -1582,6 +1582,11 @@ async def restore_backup(
             inserted = updated = skipped = 0
 
             for row in rows:
+                # Pre-org backups predate sites.orgId; the column has no DEFAULT
+                # anymore, so land those sites in the default org (never wiped by
+                # a restore, so the FK always resolves).
+                if table == "sites" and "orgId" in types and not row.get("orgId"):
+                    row = {**row, "orgId": "default"}
                 columns = [c for c in row.keys() if c in types]
                 if not columns:
                     continue

--- a/backend/tests/test_org_scope.py
+++ b/backend/tests/test_org_scope.py
@@ -288,8 +288,8 @@ def test_middleware_derives_org_from_active_instance():
                     NOW() + interval '1 hour', NOW(), NOW())
         """)
         await conn.execute("""
-            INSERT INTO sites (id, name, "createdAt", "updatedAt")
-            VALUES ('s_orgscope', 'Org Scope Site', NOW(), NOW())
+            INSERT INTO sites (id, name, "orgId", "createdAt", "updatedAt")
+            VALUES ('s_orgscope', 'Org Scope Site', 'default', NOW(), NOW())
         """)
         await conn.execute("""
             INSERT INTO instances (id, "siteId", name, host, username,

--- a/frontend/prisma/migrations/20260712_drop_site_org_default/migration.sql
+++ b/frontend/prisma/migrations/20260712_drop_site_org_default/migration.sql
@@ -1,0 +1,6 @@
+-- Drop the inert-phase DEFAULT on sites.orgId. The column stays NOT NULL, but
+-- every insert path now supplies the organization explicitly (site creation,
+-- the seed, and backup restore). Keeping the DEFAULT would let a future insert
+-- that forgets orgId silently land a site in the default org once enforcement
+-- is on; without it the same mistake fails closed.
+ALTER TABLE "sites" ALTER COLUMN "orgId" DROP DEFAULT;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -210,11 +210,10 @@ model Site {
   id          String   @id @default(cuid())
   name        String   @unique
   description String?
-  // DEFAULT "default" is inert-phase scaffolding: it keeps site creation,
-  // seeding and pre-org backup restores working while nothing reads orgs.
-  // Removed when org enforcement turns on — site creation then requires an
-  // explicit organization.
-  orgId       String   @default("default")
+  // Every insert path sets orgId explicitly (site creation, seed, backup
+  // restore), so the column carries no DEFAULT: a forgotten orgId must fail
+  // rather than silently land a site in the default org once enforcement is on.
+  orgId       String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/frontend/prisma/seed.ts
+++ b/frontend/prisma/seed.ts
@@ -26,6 +26,7 @@ async function main() {
     create: {
       name: "Default Site",
       description: "Default site for existing VyOS instance",
+      orgId: "default",
     },
   });
 


### PR DESCRIPTION
Closes #481.

## Why
`sites.orgId` carried `DEFAULT 'default'` — scaffolding from the org migration (#442) that kept inserts working before anything read orgs. Ruling #5 requires it gone before organization enforcement is enabled: with the DEFAULT in place a future insert that forgets `orgId` silently lands a site in the default org; without it the same mistake fails the `NOT NULL` constraint.

## Change
- **Migration** `20260712_drop_site_org_default`: `ALTER TABLE sites ALTER COLUMN orgId DROP DEFAULT` (column stays `NOT NULL`).
- **schema.prisma**: drop `@default("default")` on `Site.orgId`.

## Every insert path stays explicit (no regression)
- `create_site` already sets `orgId` (falls back to `default` with no org context).
- **Restore**: pre-org backups have no `orgId` on site rows → backfill to the default org in the restore loop. The default org is never in `BACKUP_TABLES`, so it survives a replace restore and the FK resolves.
- `prisma/seed.ts`: seeded site sets `orgId`.
- The org-scope fixture inserts `orgId` explicitly.

## Verified (freshly migrated DB)
- `information_schema` shows `sites.orgId` default removed, still `NOT NULL`.
- Insert without `orgId` → `null value ... violates not-null constraint` (fails closed).
- Pre-org site row (no `orgId`) restored via the real restore helpers → lands in `default`.
- `test_backup_safety` + `test_org_scope` pass (17).

## Inert
Runtime behavior unchanged (enforcement still off); only removes a silent fallback so the flip fails closed.