### PR TITLE
feat: move oauth_role_mappings writes to the backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -61,6 +61,7 @@ from routers import dashboard as dashboard_router
 from routers import user_management as user_management_router
 from routers.tokens import tokens as tokens_router
 from routers.internal import sso_reconcile as sso_reconcile_router
+from routers.oauth_config import oauth_config as oauth_config_router
 from routers.operations import operations as operations_router
 from routers.monitoring import monitoring as monitoring_router
 from routers.high_availability import high_availability as high_availability_router
@@ -403,6 +404,7 @@ app.include_router(dashboard_router.router)
 app.include_router(user_management_router.router)
 app.include_router(tokens_router.router)
 app.include_router(sso_reconcile_router.router)
+app.include_router(oauth_config_router.router)
 app.include_router(operations_router.router)
 app.include_router(monitoring_router.router)
 app.include_router(high_availability_router.router)

--- a/backend/routers/oauth_config/oauth_config.py
+++ b/backend/routers/oauth_config/oauth_config.py
@@ -1,0 +1,282 @@
+"""
+OAuth Role Mapping Router
+
+Backend-owned writes for the SSO role-mapping rules (oauth_role_mappings). The
+Next.js route handlers proxy here and drop better-auth's in-process rule cache
+after a successful write, so the frontend no longer writes these rows to
+Postgres directly. ADMIN only.
+"""
+import json
+import secrets
+import string
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from org_scope import org_conn_admin
+from fastapi_permissions import require_super_admin
+
+router = APIRouter(prefix="/oauth-config", tags=["oauth-config"])
+
+# Mirror the Prisma Role / InstanceRole enums.
+_SITE_ROLES = {"ADMIN", "VIEWER"}
+_INSTANCE_ROLES = {"ADMIN", "EDITOR", "OPERATOR", "VIEWER"}
+
+_ID_ALPHABET = string.ascii_lowercase + string.digits
+
+
+def _new_id() -> str:
+    # The Prisma default cuid() is generated client-side, so there is no DB
+    # default to fall back on; mint a collision-resistant opaque id here.
+    return "orm_" + "".join(secrets.choice(_ID_ALPHABET) for _ in range(24))
+
+
+class RoleMappingInput(BaseModel):
+    """Create/update body. Every field is optional so PUT can patch a subset;
+    create enforces the required shape through _validate_grant."""
+
+    claimValue: Optional[str] = None
+    siteRole: Optional[str] = None
+    instanceId: Optional[str] = None
+    siteId: Optional[str] = None
+    instanceRole: Optional[str] = None
+    featurePermissions: Optional[Any] = None
+    priority: Optional[int] = None
+
+
+def _serialize(row: asyncpg.Record) -> Dict[str, Any]:
+    """Shape a row to the RoleMapping the frontend expects (camelCase keys,
+    parsed featurePermissions, ISO timestamps)."""
+    fp = row["featurePermissions"]
+    if isinstance(fp, str):
+        try:
+            fp = json.loads(fp)
+        except (ValueError, TypeError):
+            fp = None
+    created = row["createdAt"]
+    updated = row["updatedAt"]
+    return {
+        "id": row["id"],
+        "providerId": row["providerId"],
+        "claimValue": row["claimValue"],
+        "siteRole": row["siteRole"],
+        "instanceId": row["instanceId"],
+        "siteId": row["siteId"],
+        "instanceRole": row["instanceRole"],
+        "featurePermissions": fp,
+        "priority": row["priority"],
+        "createdAt": created.isoformat() if isinstance(created, datetime) else created,
+        "updatedAt": updated.isoformat() if isinstance(updated, datetime) else updated,
+    }
+
+
+def _fp_bind(value: Any) -> Optional[str]:
+    """Bind featurePermissions as JSON text for a jsonb column (NULL when absent)."""
+    if value is None:
+        return None
+    return value if isinstance(value, str) else json.dumps(value)
+
+
+async def _require_provider(conn: asyncpg.Connection, provider_id: str) -> None:
+    if not await conn.fetchval(
+        'SELECT 1 FROM oauth_providers WHERE "providerId" = $1', provider_id
+    ):
+        raise HTTPException(status_code=404, detail="Provider not found")
+
+
+async def _validate_grant(
+    conn: asyncpg.Connection,
+    claim_value: Any,
+    site_role: Optional[str],
+    instance_id: Optional[str],
+    site_id: Optional[str],
+    instance_role: Optional[str],
+) -> Optional[str]:
+    """Return an error string if the grant shape is invalid, otherwise None."""
+    if not claim_value or not isinstance(claim_value, str):
+        return "claimValue is required"
+    if site_role and site_role not in _SITE_ROLES:
+        return f"Invalid siteRole: {site_role}"
+    if instance_role and instance_role not in _INSTANCE_ROLES:
+        return f"Invalid instanceRole: {instance_role}"
+    if instance_id and site_id:
+        return "A grant targets an instance or a site, not both"
+    if (instance_id or site_id) and not instance_role:
+        return "instanceRole is required for an instance/site grant"
+    if not site_role and not instance_id and not site_id:
+        return "A rule must grant a site role and/or an instance/site role"
+    if site_id and not await conn.fetchval("SELECT 1 FROM sites WHERE id = $1", site_id):
+        return "Site not found"
+    if instance_id and not await conn.fetchval(
+        "SELECT 1 FROM instances WHERE id = $1", instance_id
+    ):
+        return "Instance not found"
+    return None
+
+
+@router.get("/{provider_id}/role-mappings")
+async def list_role_mappings(
+    provider_id: str,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """List the role-mapping rules for a provider."""
+    await require_super_admin(request)
+    rows = await conn.fetch(
+        """
+        SELECT * FROM oauth_role_mappings
+        WHERE "providerId" = $1
+        ORDER BY "claimValue" ASC, priority DESC, "createdAt" ASC
+        """,
+        provider_id,
+    )
+    return {"mappings": [_serialize(r) for r in rows]}
+
+
+@router.post("/{provider_id}/role-mappings")
+async def create_role_mapping(
+    provider_id: str,
+    body: RoleMappingInput,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Create a role-mapping rule for a provider."""
+    await require_super_admin(request)
+    await _require_provider(conn, provider_id)
+
+    site_role = body.siteRole or None
+    instance_id = body.instanceId or None
+    site_id = body.siteId or None
+    instance_role = body.instanceRole or None
+    priority = body.priority if isinstance(body.priority, int) else 0
+
+    error = await _validate_grant(
+        conn, body.claimValue, site_role, instance_id, site_id, instance_role
+    )
+    if error:
+        raise HTTPException(status_code=400, detail=error)
+
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO oauth_role_mappings
+                (id, "providerId", "claimValue", "siteRole", "instanceId",
+                 "siteId", "instanceRole", "featurePermissions", priority,
+                 "createdAt", "updatedAt")
+            VALUES ($1, $2, $3, $4::"Role", $5, $6, $7::"InstanceRole",
+                    $8::jsonb, $9, NOW(), NOW())
+            RETURNING *
+            """,
+            _new_id(),
+            provider_id,
+            body.claimValue,
+            site_role,
+            instance_id,
+            site_id,
+            instance_role,
+            _fp_bind(body.featurePermissions),
+            priority,
+        )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="A rule for this claim value and target already exists",
+        )
+    return {"mapping": _serialize(row)}
+
+
+@router.put("/{provider_id}/role-mappings/{mapping_id}")
+async def update_role_mapping(
+    provider_id: str,
+    mapping_id: str,
+    body: RoleMappingInput,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Update a role-mapping rule. Fields left unset keep their stored value."""
+    await require_super_admin(request)
+
+    existing = await conn.fetchrow(
+        "SELECT * FROM oauth_role_mappings WHERE id = $1", mapping_id
+    )
+    if not existing or existing["providerId"] != provider_id:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+
+    if body.siteRole and body.siteRole not in _SITE_ROLES:
+        raise HTTPException(status_code=400, detail=f"Invalid siteRole: {body.siteRole}")
+    if body.instanceRole and body.instanceRole not in _INSTANCE_ROLES:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid instanceRole: {body.instanceRole}"
+        )
+
+    claim_value = body.claimValue if body.claimValue is not None else existing["claimValue"]
+    site_role = (body.siteRole or None) if body.siteRole is not None else existing["siteRole"]
+    instance_id = (
+        (body.instanceId or None) if body.instanceId is not None else existing["instanceId"]
+    )
+    site_id = (body.siteId or None) if body.siteId is not None else existing["siteId"]
+    instance_role = (
+        (body.instanceRole or None)
+        if body.instanceRole is not None
+        else existing["instanceRole"]
+    )
+    priority = body.priority if isinstance(body.priority, int) else existing["priority"]
+    # Only rewrite the JSON column when the caller supplies it; otherwise keep
+    # the stored jsonb text as-is.
+    feature_permissions = (
+        _fp_bind(body.featurePermissions)
+        if body.featurePermissions is not None
+        else existing["featurePermissions"]
+    )
+
+    try:
+        row = await conn.fetchrow(
+            """
+            UPDATE oauth_role_mappings
+            SET "claimValue" = $2,
+                "siteRole" = $3::"Role",
+                "instanceId" = $4,
+                "siteId" = $5,
+                "instanceRole" = $6::"InstanceRole",
+                "featurePermissions" = $7::jsonb,
+                priority = $8,
+                "updatedAt" = NOW()
+            WHERE id = $1
+            RETURNING *
+            """,
+            mapping_id,
+            claim_value,
+            site_role,
+            instance_id,
+            site_id,
+            instance_role,
+            feature_permissions,
+            priority,
+        )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail="A rule for this claim value and instance already exists",
+        )
+    return {"mapping": _serialize(row)}
+
+
+@router.delete("/{provider_id}/role-mappings/{mapping_id}")
+async def delete_role_mapping(
+    provider_id: str,
+    mapping_id: str,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Delete a role-mapping rule."""
+    await require_super_admin(request)
+    existing = await conn.fetchrow(
+        'SELECT id, "providerId" FROM oauth_role_mappings WHERE id = $1', mapping_id
+    )
+    if not existing or existing["providerId"] != provider_id:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+    await conn.execute("DELETE FROM oauth_role_mappings WHERE id = $1", mapping_id)
+    return {"success": True}

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -9260,6 +9260,276 @@
         }
       }
     },
+    "/oauth-config/{provider_id}/role-mappings": {
+      "get": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "List Role Mappings",
+        "description": "List the role-mapping rules for a provider.",
+        "operationId": "list_role_mappings_oauth_config__provider_id__role_mappings_get",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Create Role Mapping",
+        "description": "Create a role-mapping rule for a provider.",
+        "operationId": "create_role_mapping_oauth_config__provider_id__role_mappings_post",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoleMappingInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth-config/{provider_id}/role-mappings/{mapping_id}": {
+      "put": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Update Role Mapping",
+        "description": "Update a role-mapping rule. Fields left unset keep their stored value.",
+        "operationId": "update_role_mapping_oauth_config__provider_id__role_mappings__mapping_id__put",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "mapping_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Mapping Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoleMappingInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Delete Role Mapping",
+        "description": "Delete a role-mapping rule.",
+        "operationId": "delete_role_mapping_oauth_config__provider_id__role_mappings__mapping_id__delete",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "mapping_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Mapping Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/vyos/operations": {
       "get": {
         "tags": [
@@ -47942,6 +48212,88 @@
         },
         "type": "object",
         "title": "RipTimers"
+      },
+      "RoleMappingInput": {
+        "properties": {
+          "claimValue": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Claimvalue"
+          },
+          "siteRole": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Siterole"
+          },
+          "instanceId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instanceid"
+          },
+          "siteId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Siteid"
+          },
+          "instanceRole": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instancerole"
+          },
+          "featurePermissions": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Featurepermissions"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          }
+        },
+        "type": "object",
+        "title": "RoleMappingInput",
+        "description": "Create/update body. Every field is optional so PUT can patch a subset;\ncreate enforces the required shape through _validate_grant."
       },
       "RouteBatchOperation": {
         "properties": {

--- a/frontend/src/app/api/oauth-config/[providerId]/role-mappings/[id]/route.ts
+++ b/frontend/src/app/api/oauth-config/[providerId]/role-mappings/[id]/route.ts
@@ -1,79 +1,23 @@
-import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient, Prisma, Role, InstanceRole } from "@prisma/client";
-import { getAuth, invalidateAuth } from "@/lib/auth";
+import { NextRequest } from "next/server";
+import { proxyRoleMapping } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const prisma = new PrismaClient();
-
-async function getAdminUser(request: NextRequest) {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) return null;
-
-  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (!user || user.role !== "ADMIN") return null;
-  return user;
-}
-
-const SITE_ROLES = Object.values(Role) as string[];
-const INSTANCE_ROLES = Object.values(InstanceRole) as string[];
+// oauth_role_mappings is owned by the backend; these handlers proxy to it and
+// invalidate better-auth's rule cache on a successful write (see oauth-proxy).
 
 // PUT /api/oauth-config/[providerId]/role-mappings/[id] — update a rule
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string; id: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId, id } = await params;
-  const existing = await prisma.oAuthRoleMapping.findUnique({ where: { id } });
-  if (!existing || existing.providerId !== providerId) {
-    return NextResponse.json({ error: "Mapping not found" }, { status: 404 });
-  }
-
-  const body = await request.json();
-
-  if (body.siteRole && !SITE_ROLES.includes(body.siteRole)) {
-    return NextResponse.json({ error: `Invalid siteRole: ${body.siteRole}` }, { status: 400 });
-  }
-  if (body.instanceRole && !INSTANCE_ROLES.includes(body.instanceRole)) {
-    return NextResponse.json({ error: `Invalid instanceRole: ${body.instanceRole}` }, { status: 400 });
-  }
-
-  try {
-    const mapping = await prisma.oAuthRoleMapping.update({
-      where: { id },
-      data: {
-        claimValue: body.claimValue ?? existing.claimValue,
-        siteRole: body.siteRole !== undefined ? (body.siteRole || null) : existing.siteRole,
-        instanceId: body.instanceId !== undefined ? (body.instanceId || null) : existing.instanceId,
-        siteId: body.siteId !== undefined ? (body.siteId || null) : existing.siteId,
-        instanceRole:
-          body.instanceRole !== undefined ? (body.instanceRole || null) : existing.instanceRole,
-        // Only rewrite the JSON column when the caller supplies it.
-        ...(body.featurePermissions !== undefined
-          ? { featurePermissions: body.featurePermissions ?? Prisma.JsonNull }
-          : {}),
-        priority: typeof body.priority === "number" ? body.priority : existing.priority,
-      },
-    });
-
-    invalidateAuth();
-    return NextResponse.json({ mapping });
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-      return NextResponse.json(
-        { error: "A rule for this claim value and instance already exists" },
-        { status: 409 }
-      );
-    }
-    throw err;
-  }
+  return proxyRoleMapping(
+    request,
+    `/oauth-config/${encodeURIComponent(providerId)}/role-mappings/${encodeURIComponent(id)}`,
+    "PUT"
+  );
 }
 
 // DELETE /api/oauth-config/[providerId]/role-mappings/[id] — remove a rule
@@ -81,19 +25,10 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string; id: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId, id } = await params;
-  const existing = await prisma.oAuthRoleMapping.findUnique({ where: { id } });
-  if (!existing || existing.providerId !== providerId) {
-    return NextResponse.json({ error: "Mapping not found" }, { status: 404 });
-  }
-
-  await prisma.oAuthRoleMapping.delete({ where: { id } });
-  invalidateAuth();
-
-  return NextResponse.json({ success: true });
+  return proxyRoleMapping(
+    request,
+    `/oauth-config/${encodeURIComponent(providerId)}/role-mappings/${encodeURIComponent(id)}`,
+    "DELETE"
+  );
 }

--- a/frontend/src/app/api/oauth-config/[providerId]/role-mappings/route.ts
+++ b/frontend/src/app/api/oauth-config/[providerId]/role-mappings/route.ts
@@ -1,42 +1,23 @@
-import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient, Prisma, Role, InstanceRole } from "@prisma/client";
-import { getAuth, invalidateAuth } from "@/lib/auth";
+import { NextRequest } from "next/server";
+import { proxyRoleMapping } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const prisma = new PrismaClient();
-
-async function getAdminUser(request: NextRequest) {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) return null;
-
-  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (!user || user.role !== "ADMIN") return null;
-  return user;
-}
-
-const SITE_ROLES = Object.values(Role) as string[];
-const INSTANCE_ROLES = Object.values(InstanceRole) as string[];
+// oauth_role_mappings is owned by the backend; these handlers proxy to it and
+// invalidate better-auth's rule cache on a successful write (see oauth-proxy).
 
 // GET /api/oauth-config/[providerId]/role-mappings — list rules for a provider
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId } = await params;
-  const mappings = await prisma.oAuthRoleMapping.findMany({
-    where: { providerId },
-    orderBy: [{ claimValue: "asc" }, { priority: "desc" }, { createdAt: "asc" }],
-  });
-
-  return NextResponse.json({ mappings });
+  return proxyRoleMapping(
+    request,
+    `/oauth-config/${encodeURIComponent(providerId)}/role-mappings`,
+    "GET"
+  );
 }
 
 // POST /api/oauth-config/[providerId]/role-mappings — create a rule
@@ -44,94 +25,10 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId } = await params;
-
-  const provider = await prisma.oAuthProvider.findUnique({ where: { providerId } });
-  if (!provider) {
-    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
-  }
-
-  const body = await request.json();
-  const {
-    claimValue,
-    siteRole = null,
-    instanceId = null,
-    siteId = null,
-    instanceRole = null,
-    featurePermissions = null,
-    priority = 0,
-  } = body;
-
-  const validation = await validateGrant({
-    claimValue,
-    siteRole,
-    instanceId,
-    siteId,
-    instanceRole,
-  });
-  if (validation) {
-    return NextResponse.json({ error: validation }, { status: 400 });
-  }
-
-  try {
-    const mapping = await prisma.oAuthRoleMapping.create({
-      data: {
-        providerId,
-        claimValue,
-        siteRole: siteRole || null,
-        instanceId: instanceId || null,
-        siteId: siteId || null,
-        instanceRole: instanceRole || null,
-        featurePermissions: featurePermissions ?? Prisma.JsonNull,
-        priority: typeof priority === "number" ? priority : 0,
-      },
-    });
-
-    invalidateAuth();
-    return NextResponse.json({ mapping });
-  } catch (err) {
-    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
-      return NextResponse.json(
-        { error: "A rule for this claim value and target already exists" },
-        { status: 409 }
-      );
-    }
-    throw err;
-  }
-}
-
-// Returns an error string if the grant shape is invalid, otherwise null.
-async function validateGrant(g: {
-  claimValue: unknown;
-  siteRole: string | null;
-  instanceId: string | null;
-  siteId: string | null;
-  instanceRole: string | null;
-}): Promise<string | null> {
-  if (!g.claimValue || typeof g.claimValue !== "string") return "claimValue is required";
-  if (g.siteRole && !SITE_ROLES.includes(g.siteRole)) return `Invalid siteRole: ${g.siteRole}`;
-  if (g.instanceRole && !INSTANCE_ROLES.includes(g.instanceRole))
-    return `Invalid instanceRole: ${g.instanceRole}`;
-  if (g.instanceId && g.siteId) return "A grant targets an instance or a site, not both";
-  if ((g.instanceId || g.siteId) && !g.instanceRole)
-    return "instanceRole is required for an instance/site grant";
-  if (!g.siteRole && !g.instanceId && !g.siteId)
-    return "A rule must grant a site role and/or an instance/site role";
-  if (g.siteId) {
-    const site = await prisma.site.findUnique({ where: { id: g.siteId }, select: { id: true } });
-    if (!site) return "Site not found";
-  }
-  if (g.instanceId) {
-    const inst = await prisma.instance.findUnique({
-      where: { id: g.instanceId },
-      select: { id: true },
-    });
-    if (!inst) return "Instance not found";
-  }
-  return null;
+  return proxyRoleMapping(
+    request,
+    `/oauth-config/${encodeURIComponent(providerId)}/role-mappings`,
+    "POST"
+  );
 }

--- a/frontend/src/lib/oauth-proxy.ts
+++ b/frontend/src/lib/oauth-proxy.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { invalidateAuth } from "@/lib/auth";
+
+// Runtime env, not NEXT_PUBLIC_, so the backend URL is configurable without a rebuild.
+const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+
+/**
+ * Forward a role-mapping request to the backend, which owns oauth_role_mappings.
+ *
+ * The backend performs the auth check and the write; on a successful write we
+ * drop better-auth's in-process rule cache so the next login re-reads the rules.
+ * That cache lives here in the frontend (better-auth runs in this process), so
+ * the backend cannot invalidate it — hence this thin proxy instead of pointing
+ * the client straight at the backend.
+ */
+export async function proxyRoleMapping(
+  request: NextRequest,
+  backendPath: string,
+  method: "GET" | "POST" | "PUT" | "DELETE",
+): Promise<NextResponse> {
+  const sessionToken = request.cookies.get("better-auth.session_token");
+
+  const headers: Record<string, string> = {};
+  if (sessionToken) {
+    headers["Cookie"] = `better-auth.session_token=${sessionToken.value}`;
+  }
+
+  let body: string | undefined;
+  if (method === "POST" || method === "PUT") {
+    headers["Content-Type"] = "application/json";
+    body = await request.text();
+  }
+
+  const res = await fetch(`${getBackendUrl()}${backendPath}`, { method, headers, body });
+  const text = await res.text();
+
+  // A successful write can change how logins resolve roles; refresh the cache.
+  if (method !== "GET" && res.ok) {
+    invalidateAuth();
+  }
+
+  return new NextResponse(text || null, {
+    status: res.status,
+    headers: {
+      "Content-Type": res.headers.get("Content-Type") || "application/json",
+    },
+  });
+}


### PR DESCRIPTION
Closes #483.

## Why
The SSO role-mapping rules (`oauth_role_mappings`) were written directly from the Next.js route handlers via Prisma — the last place the frontend wrote application data straight to Postgres. This moves ownership to the backend so all persistence goes through it (Golden Rule).

## Backend
New `/oauth-config/{providerId}/role-mappings` router — `GET`/`POST` and `/{id}` `PUT`/`DELETE`, `require_super_admin` gated. Ports the grant validation (site-role/instance-role enums, instance-XOR-site, target existence) and the unique-conflict → `409` behaviour.

## Frontend
The two `role-mappings` route handlers become thin proxies to the backend and drop better-auth's in-process rule cache (`invalidateAuth()`) on a **successful write**. better-auth runs in the frontend and caches the rules at login, so the backend can't clear that cache — hence the proxy instead of pointing the client straight at the backend. The handlers no longer import Prisma; `oauth.ts` and all `/api/oauth-config/...` paths are unchanged.

## Out of scope
- Provider config writes (`/api/oauth-config`, `[providerId]`) stay frontend-side for now — separate follow-up.
- The login-time Prisma **read** in `auth.ts` stays; it's better-auth's own config load, not application data.

## Verified (real app, migrated DB)
create (site-role + site-target) · duplicate target → `409` · list · invalid grant + bad enum → `400` · non-admin → `403` · partial update keeps unset fields · delete · unknown → `404`. Frontend `tsc --noEmit` clean; OpenAPI spec regenerated (Python 3.11).