### PR TITLE
docs: clarify backup is platform-admin-only and whole-system

### DIFF
--- a/docs-site/docs/operations/backups.md
+++ b/docs-site/docs/operations/backups.md
@@ -16,6 +16,12 @@ One exception: SSH private keys inside the backup are stored as the database hol
 
 Restore supports **Merge** (upsert, nothing deleted) and **Replace** (wipe and restore exactly; signs everyone out). Restore is also available before onboarding, so a fresh install can be seeded from a backup.
 
+### Who can back up, and organization scope
+
+Backup and restore are platform-administrator operations: only a user with the platform **ADMIN** role can create or restore a `.vymgr` file. An organization admin (the `ADMIN` role *within* an organization) cannot — the backup is a whole-system disaster-recovery tool, not a per-organization export.
+
+This still holds once [organization enforcement](../architecture/organizations) is enabled. The export runs with the system administrator's row-level-security bypass, so it captures every organization's sites, instances and grants in one file; there is no org-scoped partial export, and restore likewise rewrites the whole system.
+
 ## PostgreSQL
 
 The `.vymgr` backup covers the same data, but a database-level backup protects against botched upgrades and gives point-in-time recovery. Either dump:


### PR DESCRIPTION
## What
Documents the backup/restore access model and its behaviour under organization enforcement, so operators enabling the flip understand it:

- Backup/restore is a **platform-ADMIN** operation. Organization admins (an `ADMIN` role within an org) cannot create or restore a `.vymgr` file.
- Under organization enforcement, the export runs with the system administrator's row-level-security bypass, so it still captures **every** organization's data in one file. There is no org-scoped partial export; restore rewrites the whole system.

## Why
Reflects the existing behaviour — `_require_backup_admin` gates on the platform `ADMIN` role, and `org_conn_admin` sets the system-admin RLS bypass so a full-DB backup stays complete under FORCE RLS. This was the open "backup export scoping" question; the decision is to keep backup whole-system and platform-admin-only, and this documents it.

Docs-only; no code change.