### PR TITLE
feat: move oauth_providers writes to the backend

### DIFF
--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -38,6 +38,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         "/api/auth/sign-out",
         "/api/auth/session",
         "/session/onboarding-status",  # Must be public to check if first-time setup is needed
+        "/oauth-config/public",  # Login page lists enabled providers before auth
         "/vyos/monitoring/ws/monitor",  # WebSocket auth handled inside handler
         "/vyos/version/check",  # Version check is public
         "/internal/sso-reconcile",  # Internal shared-secret auth (not a session)

--- a/backend/routers/oauth_config/oauth_config.py
+++ b/backend/routers/oauth_config/oauth_config.py
@@ -9,6 +9,7 @@ Postgres directly. ADMIN only.
 import json
 import secrets
 import string
+import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -16,7 +17,7 @@ import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
-from org_scope import org_conn_admin
+from org_scope import org_conn, org_conn_admin
 from fastapi_permissions import require_super_admin
 
 router = APIRouter(prefix="/oauth-config", tags=["oauth-config"])
@@ -279,4 +280,270 @@ async def delete_role_mapping(
     if not existing or existing["providerId"] != provider_id:
         raise HTTPException(status_code=404, detail="Mapping not found")
     await conn.execute("DELETE FROM oauth_role_mappings WHERE id = $1", mapping_id)
+    return {"success": True}
+
+
+# ============================================================================
+# OAuth providers
+#
+# better-auth reads oauth_providers at login (in the frontend) to configure the
+# OAuth flow; these endpoints own the writes. The frontend proxies to them and
+# drops the better-auth cache on a successful write, same as the role mappings.
+# ============================================================================
+
+
+class ProviderUpsertInput(BaseModel):
+    """Create/update body. providerId/displayName/clientId/clientSecret are
+    required on create; update patches whatever is supplied."""
+
+    providerId: Optional[str] = None
+    displayName: Optional[str] = None
+    clientId: Optional[str] = None
+    clientSecret: Optional[str] = None
+    enabled: Optional[bool] = None
+    discoveryUrl: Optional[str] = None
+    authorizationUrl: Optional[str] = None
+    tokenUrl: Optional[str] = None
+    userInfoUrl: Optional[str] = None
+    scopes: Optional[str] = None
+    pkce: Optional[bool] = None
+    roleMappingEnabled: Optional[bool] = None
+    groupsClaim: Optional[str] = None
+
+
+class ProviderEnabledInput(BaseModel):
+    enabled: bool
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if isinstance(value, datetime) else value
+
+
+def _serialize_provider(row: asyncpg.Record, include_secret: bool = False) -> Dict[str, Any]:
+    """Shape a provider row for the frontend. The client secret is only ever
+    returned on the single-item GET (for editing), never on lists or writes."""
+    data = {
+        "id": row["id"],
+        "providerId": row["providerId"],
+        "displayName": row["displayName"],
+        "enabled": row["enabled"],
+        "clientId": row["clientId"],
+        "discoveryUrl": row["discoveryUrl"],
+        "authorizationUrl": row["authorizationUrl"],
+        "tokenUrl": row["tokenUrl"],
+        "userInfoUrl": row["userInfoUrl"],
+        "scopes": row["scopes"],
+        "pkce": row["pkce"],
+        "roleMappingEnabled": row["roleMappingEnabled"],
+        "groupsClaim": row["groupsClaim"],
+        "createdAt": _iso(row["createdAt"]),
+        "updatedAt": _iso(row["updatedAt"]),
+    }
+    if include_secret:
+        data["clientSecret"] = row["clientSecret"]
+    return data
+
+
+@router.get("")
+async def list_providers(
+    request: Request, conn: asyncpg.Connection = Depends(org_conn_admin)
+):
+    """List all configured providers (never includes client secrets)."""
+    await require_super_admin(request)
+    rows = await conn.fetch('SELECT * FROM oauth_providers ORDER BY "createdAt" ASC')
+    return {"providers": [_serialize_provider(r) for r in rows]}
+
+
+@router.post("")
+async def upsert_provider(
+    body: ProviderUpsertInput,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Create a provider, or update it in place when the providerId exists."""
+    await require_super_admin(request)
+    if not (body.providerId and body.displayName and body.clientId and body.clientSecret):
+        raise HTTPException(
+            status_code=400,
+            detail="providerId, displayName, clientId, and clientSecret are required",
+        )
+    row = await conn.fetchrow(
+        """
+        INSERT INTO oauth_providers
+            (id, "providerId", "displayName", "clientId", "clientSecret", enabled,
+             "discoveryUrl", "authorizationUrl", "tokenUrl", "userInfoUrl", scopes,
+             pkce, "roleMappingEnabled", "groupsClaim", "createdAt", "updatedAt")
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+                NOW(), NOW())
+        ON CONFLICT ("providerId") DO UPDATE SET
+            "displayName" = EXCLUDED."displayName",
+            "clientId" = EXCLUDED."clientId",
+            "clientSecret" = EXCLUDED."clientSecret",
+            enabled = EXCLUDED.enabled,
+            "discoveryUrl" = EXCLUDED."discoveryUrl",
+            "authorizationUrl" = EXCLUDED."authorizationUrl",
+            "tokenUrl" = EXCLUDED."tokenUrl",
+            "userInfoUrl" = EXCLUDED."userInfoUrl",
+            scopes = EXCLUDED.scopes,
+            pkce = EXCLUDED.pkce,
+            "roleMappingEnabled" = EXCLUDED."roleMappingEnabled",
+            "groupsClaim" = EXCLUDED."groupsClaim",
+            "updatedAt" = NOW()
+        RETURNING *
+        """,
+        str(uuid.uuid4()),
+        body.providerId,
+        body.displayName,
+        body.clientId,
+        body.clientSecret,
+        bool(body.enabled) if body.enabled is not None else False,
+        body.discoveryUrl or None,
+        body.authorizationUrl or None,
+        body.tokenUrl or None,
+        body.userInfoUrl or None,
+        body.scopes or None,
+        bool(body.pkce) if body.pkce is not None else True,
+        bool(body.roleMappingEnabled) if body.roleMappingEnabled is not None else False,
+        body.groupsClaim or None,
+    )
+    return {"provider": _serialize_provider(row)}
+
+
+# Declared before /{provider_id} so "public" is not captured as a provider id.
+@router.get("/public")
+async def list_public_providers(conn: asyncpg.Connection = Depends(org_conn)):
+    """Enabled providers with no secrets, for the pre-auth login page."""
+    rows = await conn.fetch(
+        'SELECT "providerId", "displayName", enabled FROM oauth_providers'
+        ' WHERE enabled = true ORDER BY "createdAt" ASC'
+    )
+    return {
+        "providers": [
+            {
+                "providerId": r["providerId"],
+                "displayName": r["displayName"],
+                "enabled": r["enabled"],
+            }
+            for r in rows
+        ]
+    }
+
+
+@router.get("/{provider_id}")
+async def get_provider(
+    provider_id: str,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Get a single provider, including its client secret for editing."""
+    await require_super_admin(request)
+    row = await conn.fetchrow(
+        'SELECT * FROM oauth_providers WHERE "providerId" = $1', provider_id
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    return {"provider": _serialize_provider(row, include_secret=True)}
+
+
+@router.put("/{provider_id}")
+async def update_provider(
+    provider_id: str,
+    body: ProviderUpsertInput,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Full update. Unset fields keep their stored value; the client secret is
+    only rewritten when a non-empty value is supplied."""
+    await require_super_admin(request)
+    existing = await conn.fetchrow(
+        'SELECT * FROM oauth_providers WHERE "providerId" = $1', provider_id
+    )
+    if not existing:
+        raise HTTPException(status_code=404, detail="Provider not found")
+
+    def keep_nullable(new: Optional[str], key: str) -> Optional[str]:
+        return (new or None) if new is not None else existing[key]
+
+    display_name = body.displayName if body.displayName is not None else existing["displayName"]
+    client_id = body.clientId if body.clientId is not None else existing["clientId"]
+    client_secret = body.clientSecret if body.clientSecret else existing["clientSecret"]
+    enabled = body.enabled if body.enabled is not None else existing["enabled"]
+    pkce = body.pkce if body.pkce is not None else existing["pkce"]
+    role_mapping = (
+        body.roleMappingEnabled
+        if body.roleMappingEnabled is not None
+        else existing["roleMappingEnabled"]
+    )
+
+    row = await conn.fetchrow(
+        """
+        UPDATE oauth_providers SET
+            "displayName" = $2,
+            "clientId" = $3,
+            "clientSecret" = $4,
+            enabled = $5,
+            "discoveryUrl" = $6,
+            "authorizationUrl" = $7,
+            "tokenUrl" = $8,
+            "userInfoUrl" = $9,
+            scopes = $10,
+            pkce = $11,
+            "roleMappingEnabled" = $12,
+            "groupsClaim" = $13,
+            "updatedAt" = NOW()
+        WHERE "providerId" = $1
+        RETURNING *
+        """,
+        provider_id,
+        display_name,
+        client_id,
+        client_secret,
+        enabled,
+        keep_nullable(body.discoveryUrl, "discoveryUrl"),
+        keep_nullable(body.authorizationUrl, "authorizationUrl"),
+        keep_nullable(body.tokenUrl, "tokenUrl"),
+        keep_nullable(body.userInfoUrl, "userInfoUrl"),
+        keep_nullable(body.scopes, "scopes"),
+        pkce,
+        role_mapping,
+        keep_nullable(body.groupsClaim, "groupsClaim"),
+    )
+    return {"provider": _serialize_provider(row)}
+
+
+@router.patch("/{provider_id}")
+async def set_provider_enabled(
+    provider_id: str,
+    body: ProviderEnabledInput,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Toggle just the enabled flag."""
+    await require_super_admin(request)
+    if not await conn.fetchval(
+        'SELECT 1 FROM oauth_providers WHERE "providerId" = $1', provider_id
+    ):
+        raise HTTPException(status_code=404, detail="Provider not found")
+    row = await conn.fetchrow(
+        'UPDATE oauth_providers SET enabled = $2, "updatedAt" = NOW()'
+        ' WHERE "providerId" = $1 RETURNING *',
+        provider_id,
+        body.enabled,
+    )
+    return {"provider": _serialize_provider(row)}
+
+
+@router.delete("/{provider_id}")
+async def delete_provider(
+    provider_id: str,
+    request: Request,
+    conn: asyncpg.Connection = Depends(org_conn_admin),
+):
+    """Delete a provider (cascades its role mappings)."""
+    await require_super_admin(request)
+    if not await conn.fetchval(
+        'SELECT 1 FROM oauth_providers WHERE "providerId" = $1', provider_id
+    ):
+        raise HTTPException(status_code=404, detail="Provider not found")
+    await conn.execute('DELETE FROM oauth_providers WHERE "providerId" = $1', provider_id)
     return {"success": True}

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -9530,6 +9530,384 @@
         }
       }
     },
+    "/oauth-config": {
+      "get": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "List Providers",
+        "description": "List all configured providers (never includes client secrets).",
+        "operationId": "list_providers_oauth_config_get",
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Upsert Provider",
+        "description": "Create a provider, or update it in place when the providerId exists.",
+        "operationId": "upsert_provider_oauth_config_post",
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderUpsertInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth-config/public": {
+      "get": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "List Public Providers",
+        "description": "Enabled providers with no secrets, for the pre-auth login page.",
+        "operationId": "list_public_providers_oauth_config_public_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth-config/{provider_id}": {
+      "get": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Get Provider",
+        "description": "Get a single provider, including its client secret for editing.",
+        "operationId": "get_provider_oauth_config__provider_id__get",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Update Provider",
+        "description": "Full update. Unset fields keep their stored value; the client secret is\nonly rewritten when a non-empty value is supplied.",
+        "operationId": "update_provider_oauth_config__provider_id__put",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderUpsertInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Set Provider Enabled",
+        "description": "Toggle just the enabled flag.",
+        "operationId": "set_provider_enabled_oauth_config__provider_id__patch",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderEnabledInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "oauth-config"
+        ],
+        "summary": "Delete Provider",
+        "description": "Delete a provider (cascades its role mappings).",
+        "operationId": "delete_provider_oauth_config__provider_id__delete",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          },
+          {
+            "name": "org_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Organization to act in; defaults to your sole organization.",
+              "title": "Org Id"
+            },
+            "description": "Organization to act in; defaults to your sole organization."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/vyos/operations": {
       "get": {
         "tags": [
@@ -45584,6 +45962,169 @@
         },
         "type": "object",
         "title": "PrometheusNodeExporter"
+      },
+      "ProviderEnabledInput": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "title": "ProviderEnabledInput"
+      },
+      "ProviderUpsertInput": {
+        "properties": {
+          "providerId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Providerid"
+          },
+          "displayName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Displayname"
+          },
+          "clientId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clientid"
+          },
+          "clientSecret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clientsecret"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "discoveryUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Discoveryurl"
+          },
+          "authorizationUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Authorizationurl"
+          },
+          "tokenUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tokenurl"
+          },
+          "userInfoUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Userinfourl"
+          },
+          "scopes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scopes"
+          },
+          "pkce": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pkce"
+          },
+          "roleMappingEnabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rolemappingenabled"
+          },
+          "groupsClaim": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Groupsclaim"
+          }
+        },
+        "type": "object",
+        "title": "ProviderUpsertInput",
+        "description": "Create/update body. providerId/displayName/clientId/clientSecret are\nrequired on create; update patches whatever is supplied."
       },
       "ProxyConfig": {
         "properties": {

--- a/frontend/src/app/api/oauth-config/[providerId]/role-mappings/[id]/route.ts
+++ b/frontend/src/app/api/oauth-config/[providerId]/role-mappings/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { proxyRoleMapping } from "@/lib/oauth-proxy";
+import { proxyOauthConfig } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,7 +13,7 @@ export async function PUT(
   { params }: { params: Promise<{ providerId: string; id: string }> }
 ) {
   const { providerId, id } = await params;
-  return proxyRoleMapping(
+  return proxyOauthConfig(
     request,
     `/oauth-config/${encodeURIComponent(providerId)}/role-mappings/${encodeURIComponent(id)}`,
     "PUT"
@@ -26,7 +26,7 @@ export async function DELETE(
   { params }: { params: Promise<{ providerId: string; id: string }> }
 ) {
   const { providerId, id } = await params;
-  return proxyRoleMapping(
+  return proxyOauthConfig(
     request,
     `/oauth-config/${encodeURIComponent(providerId)}/role-mappings/${encodeURIComponent(id)}`,
     "DELETE"

--- a/frontend/src/app/api/oauth-config/[providerId]/role-mappings/route.ts
+++ b/frontend/src/app/api/oauth-config/[providerId]/role-mappings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { proxyRoleMapping } from "@/lib/oauth-proxy";
+import { proxyOauthConfig } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ providerId: string }> }
 ) {
   const { providerId } = await params;
-  return proxyRoleMapping(
+  return proxyOauthConfig(
     request,
     `/oauth-config/${encodeURIComponent(providerId)}/role-mappings`,
     "GET"
@@ -26,7 +26,7 @@ export async function POST(
   { params }: { params: Promise<{ providerId: string }> }
 ) {
   const { providerId } = await params;
-  return proxyRoleMapping(
+  return proxyOauthConfig(
     request,
     `/oauth-config/${encodeURIComponent(providerId)}/role-mappings`,
     "POST"

--- a/frontend/src/app/api/oauth-config/[providerId]/route.ts
+++ b/frontend/src/app/api/oauth-config/[providerId]/route.ts
@@ -1,39 +1,22 @@
-import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
-import { getAuth, invalidateAuth } from "@/lib/auth";
+import { NextRequest } from "next/server";
+import { proxyOauthConfig } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const prisma = new PrismaClient();
+// oauth_providers is owned by the backend; these handlers proxy to it and
+// invalidate better-auth's cache on a successful write (see oauth-proxy).
 
-async function getAdminUser(request: NextRequest) {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) return null;
+const backendPath = (providerId: string) =>
+  `/oauth-config/${encodeURIComponent(providerId)}`;
 
-  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (!user || user.role !== "ADMIN") return null;
-  return user;
-}
-
-// GET /api/oauth-config/[providerId] — get single provider (includes clientSecret for editing)
+// GET /api/oauth-config/[providerId] — single provider (includes clientSecret)
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId } = await params;
-  const provider = await prisma.oAuthProvider.findUnique({ where: { providerId } });
-  if (!provider) {
-    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
-  }
-
-  return NextResponse.json({ provider });
+  return proxyOauthConfig(request, backendPath(providerId), "GET");
 }
 
 // PUT /api/oauth-config/[providerId] — full update
@@ -41,41 +24,8 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId } = await params;
-  const body = await request.json();
-
-  const existing = await prisma.oAuthProvider.findUnique({ where: { providerId } });
-  if (!existing) {
-    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
-  }
-
-  const updated = await prisma.oAuthProvider.update({
-    where: { providerId },
-    data: {
-      displayName: body.displayName ?? existing.displayName,
-      clientId: body.clientId ?? existing.clientId,
-      // Only update secret if a non-empty value is provided
-      ...(body.clientSecret ? { clientSecret: body.clientSecret } : {}),
-      enabled: body.enabled ?? existing.enabled,
-      discoveryUrl: body.discoveryUrl !== undefined ? (body.discoveryUrl || null) : existing.discoveryUrl,
-      authorizationUrl: body.authorizationUrl !== undefined ? (body.authorizationUrl || null) : existing.authorizationUrl,
-      tokenUrl: body.tokenUrl !== undefined ? (body.tokenUrl || null) : existing.tokenUrl,
-      userInfoUrl: body.userInfoUrl !== undefined ? (body.userInfoUrl || null) : existing.userInfoUrl,
-      scopes: body.scopes !== undefined ? (body.scopes || null) : existing.scopes,
-      pkce: body.pkce ?? existing.pkce,
-      roleMappingEnabled: body.roleMappingEnabled ?? existing.roleMappingEnabled,
-      groupsClaim: body.groupsClaim !== undefined ? (body.groupsClaim || null) : existing.groupsClaim,
-    },
-  });
-
-  invalidateAuth();
-
-  return NextResponse.json({ provider: { ...updated, clientSecret: undefined } });
+  return proxyOauthConfig(request, backendPath(providerId), "PUT");
 }
 
 // PATCH /api/oauth-config/[providerId] — toggle enabled only
@@ -83,27 +33,8 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId } = await params;
-  const body = await request.json();
-
-  const existing = await prisma.oAuthProvider.findUnique({ where: { providerId } });
-  if (!existing) {
-    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
-  }
-
-  const updated = await prisma.oAuthProvider.update({
-    where: { providerId },
-    data: { enabled: body.enabled },
-  });
-
-  invalidateAuth();
-
-  return NextResponse.json({ provider: { ...updated, clientSecret: undefined } });
+  return proxyOauthConfig(request, backendPath(providerId), "PATCH");
 }
 
 // DELETE /api/oauth-config/[providerId] — remove provider
@@ -111,20 +42,6 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ providerId: string }> }
 ) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   const { providerId } = await params;
-
-  const existing = await prisma.oAuthProvider.findUnique({ where: { providerId } });
-  if (!existing) {
-    return NextResponse.json({ error: "Provider not found" }, { status: 404 });
-  }
-
-  await prisma.oAuthProvider.delete({ where: { providerId } });
-  invalidateAuth();
-
-  return NextResponse.json({ success: true });
+  return proxyOauthConfig(request, backendPath(providerId), "DELETE");
 }

--- a/frontend/src/app/api/oauth-config/public/route.ts
+++ b/frontend/src/app/api/oauth-config/public/route.ts
@@ -1,23 +1,11 @@
-import { NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
+import { NextRequest } from "next/server";
+import { proxyOauthConfig } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const prisma = new PrismaClient();
-
-// Public endpoint — returns only enabled providers with minimal info (no secrets)
-// Used by the login page to show OAuth buttons
-export async function GET() {
-  const providers = await prisma.oAuthProvider.findMany({
-    where: { enabled: true },
-    select: {
-      providerId: true,
-      displayName: true,
-      enabled: true,
-    },
-    orderBy: { createdAt: "asc" },
-  });
-
-  return NextResponse.json({ providers });
+// Public endpoint — enabled providers with no secrets, used by the login page.
+// Proxies to the backend, which owns oauth_providers. No auth required.
+export async function GET(request: NextRequest) {
+  return proxyOauthConfig(request, "/oauth-config/public", "GET");
 }

--- a/frontend/src/app/api/oauth-config/route.ts
+++ b/frontend/src/app/api/oauth-config/route.ts
@@ -1,124 +1,18 @@
-import { NextRequest, NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
-import { getAuth } from "@/lib/auth";
+import { NextRequest } from "next/server";
+import { proxyOauthConfig } from "@/lib/oauth-proxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const prisma = new PrismaClient();
+// oauth_providers is owned by the backend; these handlers proxy to it and
+// invalidate better-auth's cache on a successful write (see oauth-proxy).
 
-async function getAdminUser(request: NextRequest) {
-  const auth = await getAuth();
-  const session = await auth.api.getSession({ headers: request.headers });
-  if (!session?.user) return null;
-
-  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (!user || user.role !== "ADMIN") return null;
-  return user;
-}
-
-// GET /api/oauth-config — list all providers
+// GET /api/oauth-config — list all providers (no secrets)
 export async function GET(request: NextRequest) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const providers = await prisma.oAuthProvider.findMany({
-    orderBy: { createdAt: "asc" },
-    select: {
-      id: true,
-      providerId: true,
-      displayName: true,
-      enabled: true,
-      clientId: true,
-      // Never expose clientSecret in list response
-      discoveryUrl: true,
-      authorizationUrl: true,
-      tokenUrl: true,
-      userInfoUrl: true,
-      scopes: true,
-      pkce: true,
-      roleMappingEnabled: true,
-      groupsClaim: true,
-      createdAt: true,
-      updatedAt: true,
-    },
-  });
-
-  return NextResponse.json({ providers });
+  return proxyOauthConfig(request, "/oauth-config", "GET");
 }
 
 // POST /api/oauth-config — create or update a provider
 export async function POST(request: NextRequest) {
-  const user = await getAdminUser(request);
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const body = await request.json();
-  const {
-    providerId,
-    displayName,
-    clientId,
-    clientSecret,
-    enabled = false,
-    discoveryUrl,
-    authorizationUrl,
-    tokenUrl,
-    userInfoUrl,
-    scopes,
-    pkce = true,
-    roleMappingEnabled = false,
-    groupsClaim,
-  } = body;
-
-  if (!providerId || !displayName || !clientId || !clientSecret) {
-    return NextResponse.json(
-      { error: "providerId, displayName, clientId, and clientSecret are required" },
-      { status: 400 }
-    );
-  }
-
-  const provider = await prisma.oAuthProvider.upsert({
-    where: { providerId },
-    update: {
-      displayName,
-      clientId,
-      clientSecret,
-      enabled,
-      discoveryUrl: discoveryUrl || null,
-      authorizationUrl: authorizationUrl || null,
-      tokenUrl: tokenUrl || null,
-      userInfoUrl: userInfoUrl || null,
-      scopes: scopes || null,
-      pkce,
-      roleMappingEnabled,
-      groupsClaim: groupsClaim || null,
-    },
-    create: {
-      id: crypto.randomUUID(),
-      providerId,
-      displayName,
-      clientId,
-      clientSecret,
-      enabled,
-      discoveryUrl: discoveryUrl || null,
-      authorizationUrl: authorizationUrl || null,
-      tokenUrl: tokenUrl || null,
-      userInfoUrl: userInfoUrl || null,
-      scopes: scopes || null,
-      pkce,
-      roleMappingEnabled,
-      groupsClaim: groupsClaim || null,
-    },
-  });
-
-  // Invalidate auth so next request picks up new config
-  const { invalidateAuth } = await import("@/lib/auth");
-  invalidateAuth();
-
-  return NextResponse.json({
-    provider: { ...provider, clientSecret: undefined },
-  });
+  return proxyOauthConfig(request, "/oauth-config", "POST");
 }

--- a/frontend/src/lib/oauth-proxy.ts
+++ b/frontend/src/lib/oauth-proxy.ts
@@ -5,18 +5,19 @@ import { invalidateAuth } from "@/lib/auth";
 const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
 
 /**
- * Forward a role-mapping request to the backend, which owns oauth_role_mappings.
+ * Forward an oauth-config request (providers or role mappings) to the backend,
+ * which owns oauth_providers and oauth_role_mappings.
  *
  * The backend performs the auth check and the write; on a successful write we
- * drop better-auth's in-process rule cache so the next login re-reads the rules.
+ * drop better-auth's in-process cache so the next login re-reads the config.
  * That cache lives here in the frontend (better-auth runs in this process), so
  * the backend cannot invalidate it — hence this thin proxy instead of pointing
  * the client straight at the backend.
  */
-export async function proxyRoleMapping(
+export async function proxyOauthConfig(
   request: NextRequest,
   backendPath: string,
-  method: "GET" | "POST" | "PUT" | "DELETE",
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
 ): Promise<NextResponse> {
   const sessionToken = request.cookies.get("better-auth.session_token");
 
@@ -26,7 +27,7 @@ export async function proxyRoleMapping(
   }
 
   let body: string | undefined;
-  if (method === "POST" || method === "PUT") {
+  if (method === "POST" || method === "PUT" || method === "PATCH") {
     headers["Content-Type"] = "application/json";
     body = await request.text();
   }


### PR DESCRIPTION
Closes #486. Follow-up to #484.

## Why
OAuth **provider** config (`oauth_providers`) was the last place the frontend wrote application data straight to Postgres via Prisma. This moves it to the backend so the whole `/api/oauth-config` surface is Prisma-free — closing the Golden Rule for OAuth.

## Backend
Extends the `/oauth-config` router:
- `GET /oauth-config` (list, no secrets) · `POST /oauth-config` (upsert)
- `GET /oauth-config/public` — enabled providers, no secrets, **unauthenticated** (login page); added to the auth middleware allowlist
- `GET /oauth-config/{providerId}` (single, **includes** clientSecret for editing)
- `PUT /oauth-config/{providerId}` (full update; secret only rewritten when supplied)
- `PATCH /oauth-config/{providerId}` (toggle enabled) · `DELETE /oauth-config/{providerId}`

Admin endpoints are `require_super_admin`; the public one uses a plain org connection (`oauth_providers` isn't RLS-gated — SSO is deployment-global per RFC §9). The client secret is only ever returned on the single-item GET.

## Frontend
The three provider route handlers become thin proxies to the backend and drop better-auth's cache on a successful write. The shared `oauth-proxy` helper (from #484) gains `PATCH` and is renamed `proxyOauthConfig`. **No Prisma in any `/api/oauth-config` route.** `oauth.ts` and all paths unchanged; the login-time Prisma read in `auth.ts` stays (better-auth's own config load).

## Verified (real app, migrated DB)
create/upsert (id preserved) · secret never leaks on list/write/public · single GET returns it · empty `clientSecret` on update keeps stored · enabled toggle · unauthenticated public list = enabled only · non-admin → `403` · missing fields → `400` · unknown → `404`. Canary + org-scope + backup-safety + sso-reconcile suites pass (25). Frontend `tsc` clean; OpenAPI spec regenerated (Python 3.11).