### PR TITLE
fix: let a multi-org system admin act globally without org_id

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -173,11 +173,15 @@ async def _handler_conn(
                     orgs = row["orgs"]
                     if len(orgs) == 1:
                         org_id = orgs[0]
-                    elif len(orgs) > 1:
+                    elif len(orgs) > 1 and not is_admin:
                         raise HTTPException(
                             status_code=400,
                             detail="You belong to multiple organizations;"
                                    " pass org_id")
+                    # A system admin is cross-org by design: with no explicit
+                    # org_id they act globally (org_id stays empty and the
+                    # is_system_admin bypass applies), rather than being forced
+                    # to pick one org. Non-admin multi-org members must choose.
 
             if is_admin is None:
                 is_admin = False

--- a/backend/tests/test_org_scope.py
+++ b/backend/tests/test_org_scope.py
@@ -341,3 +341,71 @@ def test_middleware_derives_org_from_active_instance():
     finally:
         session_cookie._secret = original_secret
         asyncio.run(cleanup())
+
+
+# ---------------------------------------------------------------------------
+# Multi-org context resolution: a system admin acts globally with no org_id;
+# a non-admin member must still choose an org.
+# ---------------------------------------------------------------------------
+
+def _fake_request(pool, user_id):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(db_pool=pool)),
+        state=SimpleNamespace(user={"id": user_id}),
+    )
+
+
+@requires_db
+def test_multi_org_admin_acts_globally_without_org_id():
+    import asyncpg
+
+    async def body():
+        pool = await asyncpg.create_pool(os.environ["DATABASE_URL"])
+        try:
+            async with pool.acquire() as c:
+                await c.execute(
+                    'INSERT INTO organizations (id,name,"createdAt","updatedAt")'
+                    " VALUES ('org_g2','Org G2',NOW(),NOW())"
+                    " ON CONFLICT (id) DO NOTHING")
+                await c.execute(
+                    'INSERT INTO users (id,email,name,role,"emailVerified",'
+                    '"createdAt","updatedAt") VALUES'
+                    " ('u_admin_g','admin_g@t.test','AG','ADMIN',true,NOW(),NOW()),"
+                    " ('u_member_g','member_g@t.test','MG','VIEWER',true,NOW(),NOW())")
+                for uid in ("u_admin_g", "u_member_g"):
+                    await c.execute(
+                        'INSERT INTO org_memberships (id,"userId","orgId","orgRole",'
+                        '"createdAt","updatedAt") VALUES'
+                        " ($1,$2,'default','MEMBER',NOW(),NOW()),"
+                        " ($3,$2,'org_g2','MEMBER',NOW(),NOW())",
+                        f"omg_{uid}_1", uid, f"omg_{uid}_2")
+
+            # System admin, two orgs, no org_id -> global (bypass, empty org).
+            req = _fake_request(pool, "u_admin_g")
+            async with org_scope._handler_conn(req, None) as conn:
+                sysadmin = await conn.fetchval(
+                    "SELECT current_setting('app.is_system_admin', true)")
+                org = await conn.fetchval(
+                    "SELECT current_setting('app.org_id', true)")
+            assert sysadmin == "true"
+            assert org == ""
+            assert req.state.is_system_admin is True
+            assert req.state.acting_org_id is None
+
+            # Non-admin, two orgs, no org_id -> must choose (400).
+            req2 = _fake_request(pool, "u_member_g")
+            raised = None
+            try:
+                async with org_scope._handler_conn(req2, None):
+                    pass
+            except HTTPException as exc:
+                raised = exc
+            assert raised is not None and raised.status_code == 400
+        finally:
+            async with pool.acquire() as c:
+                await c.execute(
+                    "DELETE FROM users WHERE id IN ('u_admin_g','u_member_g')")
+                await c.execute("DELETE FROM organizations WHERE id='org_g2'")
+            await pool.close()
+
+    asyncio.run(body())


### PR DESCRIPTION
Closes #488. Found live while deploying the org UI for review.

## Symptom
A platform **ADMIN** in more than one organization got `400 You belong to multiple organizations; pass org_id` on admin surfaces that don't pass an `org_id` — **User Management** and the **OAuth config** endpoints (`/oauth-config`) both broke. Screenshots showed "Error Loading Users" / "Request failed: 400".

## Cause
`org_scope._handler_conn` resolves an acting org for every admin request and raised 400 on multiple memberships with no `org_id` — **even for a system administrator**, who is cross-org by design (`assert_row_in_acting_org`: *role ADMIN → System Administrator → bypass even on a cross-org id*).

## Fix
Only raise the 400 for **non-admins**. A system admin with no explicit `org_id` acts globally — `org_id` stays empty and the existing `is_system_admin` bypass applies. A multi-org non-admin member still must choose an org. Single-org users are unaffected.

One-line change in `_handler_conn` (`elif len(orgs) > 1 and not is_admin`), plus a comment.

## Verified
- New unit regression (`test_multi_org_admin_acts_globally_without_org_id`): multi-org admin → `is_system_admin=true`, `org_id=''`; multi-org member → 400.
- Live: a two-org admin's User Management and OAuth config pages load (200).
- `test_org_admin`, `test_org_scope`, adversarial, backup-safety, sso-reconcile suites pass (35 passed, 1 skipped, 3 xfailed).