### PR TITLE
fix: org ADMIN/OWNER sees their org's sites under enforcement

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -6,6 +6,7 @@ Handles connect/disconnect operations and instance selection.
 """
 
 from fastapi import Depends, APIRouter, HTTPException, Request, UploadFile, File, Form
+import org_scope
 from org_scope import assert_row_in_acting_org, org_conn_admin, org_conn_self
 from starlette.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
@@ -577,8 +578,9 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
                 user_id,
             )
 
-            return [
-                SiteResponse(
+            by_id: dict = {}
+            for site in sites:
+                by_id[site["id"]] = SiteResponse(
                     id=site["id"],
                     name=site["name"],
                     description=site["description"],
@@ -588,8 +590,41 @@ async def list_user_sites(request: Request, conn: asyncpg.Connection = Depends(o
                     created_at=site["createdAt"],
                     updated_at=site["updatedAt"],
                 )
-                for site in sites
-            ]
+
+            # Under org enforcement, an org ADMIN/OWNER also sees every site in
+            # their organization(s), with ADMIN role (org admin superset
+            # instance admin) — mirroring the permission layer, which grants
+            # org ADMIN/OWNER full access on their org's instances. Inert while
+            # ORG_ENFORCEMENT is off, so single-team deployments are unchanged.
+            if org_scope.ORG_ENFORCEMENT:
+                org_admin_sites = await conn.fetch(
+                    """
+                    SELECT s.id, s.name, s.description, s."orgId",
+                           o.name AS org_name, s."createdAt", s."updatedAt"
+                    FROM sites s
+                    JOIN org_memberships m
+                        ON m."orgId" = s."orgId" AND m."userId" = $1
+                        AND m."orgRole" IN ('ADMIN', 'OWNER')
+                    LEFT JOIN organizations o ON o.id = s."orgId"
+                    """,
+                    user_id,
+                )
+                for site in org_admin_sites:
+                    by_id[site["id"]] = SiteResponse(
+                        id=site["id"],
+                        name=site["name"],
+                        description=site["description"],
+                        role="ADMIN",
+                        org_id=site["orgId"],
+                        org_name=site["org_name"],
+                        created_at=site["createdAt"],
+                        updated_at=site["updatedAt"],
+                    )
+
+            return sorted(
+                by_id.values(),
+                key=lambda s: ((s.org_name or ""), s.name),
+            )
 
     except Exception as e:
         logger.exception("Unhandled error")

--- a/backend/tests/test_org_admin.py
+++ b/backend/tests/test_org_admin.py
@@ -79,3 +79,67 @@ def test_org_admin_full_access_gated_by_flag(monkeypatch):
         assert on[FeatureGroup.USER_MANAGEMENT] == PermissionLevel.WRITE
     finally:
         asyncio.run(cleanup())
+
+
+@requires_db
+def test_org_admin_sees_org_sites_under_enforcement(monkeypatch):
+    """list_user_sites must show an org ADMIN/OWNER their org's sites when
+    enforcement is on (mirrors the permission layer), and never another org's.
+    Inert when off."""
+    import asyncpg
+    from types import SimpleNamespace
+
+    from routers.session.session import list_user_sites
+
+    db = os.environ["DATABASE_URL"]
+    ids = ("u_ov", "o_ov", "s_ov", "o_ov2", "s_ov2")
+
+    async def seed():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_ov'")
+        await conn.execute("DELETE FROM sites WHERE id IN ('s_ov','s_ov2')")
+        await conn.execute("DELETE FROM organizations WHERE id IN ('o_ov','o_ov2')")
+        await conn.execute(
+            'INSERT INTO organizations (id,name,"createdAt","updatedAt") VALUES'
+            " ('o_ov','OV',NOW(),NOW()),('o_ov2','OV2',NOW(),NOW())")
+        await conn.execute(
+            'INSERT INTO users (id,email,name,role,"emailVerified","createdAt",'
+            '"updatedAt") VALUES (\'u_ov\',\'ov@t.test\',\'OV\',\'VIEWER\',true,NOW(),NOW())')
+        # org ADMIN of o_ov only; not a member of o_ov2.
+        await conn.execute(
+            'INSERT INTO org_memberships (id,"userId","orgId","orgRole","createdAt",'
+            '"updatedAt") VALUES (\'om_ov\',\'u_ov\',\'o_ov\',\'ADMIN\',NOW(),NOW())')
+        await conn.execute(
+            'INSERT INTO sites (id,name,"orgId","createdAt","updatedAt") VALUES'
+            " ('s_ov','SOV','o_ov',NOW(),NOW()),('s_ov2','SOV2','o_ov2',NOW(),NOW())")
+        await conn.close()
+
+    async def cleanup():
+        conn = await asyncpg.connect(db)
+        await conn.execute("DELETE FROM users WHERE id = 'u_ov'")
+        await conn.execute("DELETE FROM sites WHERE id IN ('s_ov','s_ov2')")
+        await conn.execute("DELETE FROM organizations WHERE id IN ('o_ov','o_ov2')")
+        await conn.close()
+
+    async def list_sites():
+        conn = await asyncpg.connect(db)
+        try:
+            req = SimpleNamespace(state=SimpleNamespace(user={"id": "u_ov"}))
+            result = await list_user_sites(req, conn)
+            return {s.id for s in result}
+        finally:
+            await conn.close()
+
+    asyncio.run(seed())
+    try:
+        # OFF: org ADMIN with no instance grant sees no sites.
+        monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", False)
+        assert asyncio.run(list_sites()) == set()
+
+        # ON: sees their org's site, never the other org's.
+        monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+        seen = asyncio.run(list_sites())
+        assert "s_ov" in seen, seen
+        assert "s_ov2" not in seen, seen
+    finally:
+        asyncio.run(cleanup())


### PR DESCRIPTION
Closes #497. Found while validating org management under FORCE RLS for 1.0.

## Symptom
With `ORG_ENFORCEMENT` on, an **org ADMIN/OWNER** (not a platform ADMIN, no explicit per-instance grant) gets an **empty** `GET /session/sites` — can't reach their own org in the UI, despite the permission layer granting them full access to that org's instances (#471).

## Cause
`list_user_sites`' regular branch joins only `user_instance_roles`; it never consults org role, diverging from `rbac_permissions`.

## Fix
Under enforcement, the regular branch also includes every site in an org where the caller is `ADMIN`/`OWNER` (shown as site role `ADMIN`), merged with instance-grant sites. Gated on `ORG_ENFORCEMENT` → enforcement-off path returns the identical set as before (single-team unchanged).

## Verified
Live on a FORCE-RLS + fenced `vym_runtime` stack: org-ADMIN member sees `[('s_acme','ADMIN')]`, stays fenced from `default` (403), sysadmin still global. New regression test (both flag states + no-leak). `test_org_admin`, `test_org_scope`, adversarial, backup, sso suites pass (35+2).