### PR TITLE
fix: friendly error when SSO role mapping denies access

### DIFF
--- a/frontend/src/app/api/auth/[...all]/route.ts
+++ b/frontend/src/app/api/auth/[...all]/route.ts
@@ -36,7 +36,17 @@ function checkLoginRateLimit(ip: string): boolean {
 export async function GET(request: NextRequest) {
   const auth = await getAuth();
   const handlers = toNextJsHandler(auth);
-  return handlers.GET(request);
+  const response = await handlers.GET(request);
+  // A denied SSO login (the role mapping throws when the account is in no
+  // permitted group) surfaces as a 5xx from the OAuth callback. Turn that into
+  // a friendly redirect to the login page instead of a raw error page.
+  if (
+    request.nextUrl.pathname.includes("/oauth2/callback/") &&
+    response.status >= 500
+  ) {
+    return NextResponse.redirect(new URL("/login?error=oauth", request.url));
+  }
+  return response;
 }
 
 export async function POST(request: NextRequest) {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -64,6 +64,13 @@ export default function LoginPage() {
       if (f && f !== "/login" && f !== "/onboarding") {
         setFrom(f);
       }
+      // A failed OAuth callback redirects back here with ?error=oauth.
+      if (params.get("error")) {
+        setError(
+          "Single sign-on was denied. Your account may not be a member of a " +
+            "group permitted to access VyManager. Contact your administrator."
+        );
+      }
     } catch {
       // ignore
     }
@@ -159,6 +166,10 @@ export default function LoginPage() {
       await authClient.signIn.oauth2({
         providerId,
         callbackURL: from,
+        // On a failed callback (e.g. role mapping denies access because the
+        // account is in no permitted group) return to the login page with a
+        // friendly message instead of a raw 500.
+        errorCallbackURL: "/login?error=oauth",
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : "OAuth sign-in failed");


### PR DESCRIPTION
Found while verifying SSO role mapping against a local OIDC provider (part of the 1.0 push).

## Symptom
With provider role mapping enabled, a user whose account is in **no permitted group** is correctly rejected — but it surfaced as a raw **5xx page** from the OAuth callback.

## Fix
- The auth `GET` route turns a 5xx on `/oauth2/callback/*` into a redirect to `/login?error=oauth`.
- The login page shows a friendly *"single sign-on was denied…"* message on `?error`, and passes `errorCallbackURL` so provider-side OAuth protocol errors land there too.

Security unchanged: denied account still rejected, no user row created.

## Verified (live OIDC provider)
- User in a permitted group (`vyos-admins`) → signs in, gets the mapped role (ADMIN).
- User in no permitted group (`marketing`) → denied, returned to `/login` with the message, **no user created**.