### PR TITLE
fix: org ADMIN sees org instances under enforcement; adversarial xfails now strict

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -676,23 +676,50 @@ async def list_site_instances(request: Request, site_id: str, conn: asyncpg.Conn
                 site_id,
             )
         else:
-            # Regular users see only instances they have explicit access to
-            instances = await conn.fetch(
+            # Under org enforcement, an org ADMIN/OWNER of the site's
+            # organization sees all of its instances (mirrors the permission
+            # layer and the site listing). Inert while enforcement is off.
+            org_admin = org_scope.ORG_ENFORCEMENT and await conn.fetchval(
                 """
-                SELECT DISTINCT i.id, i."siteId", i.name, i.description, i.host, i.port, i.protocol, i."verifySsl", i."isActive",
-                       i."vyosVersion", i."sshPort", i."sshUsername", i."sshKeyConfigured",
-                       i."commitConfirmEnabled", i."commitConfirmMinutes", i.timeout,
-                       i."createdAt", i."updatedAt"
-                FROM instances i
-                JOIN user_instance_roles uir
-                    ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
-                    AND uir."userId" = $2
-                WHERE i."siteId" = $1
-                ORDER BY i.name
+                SELECT 1 FROM sites s
+                JOIN org_memberships m ON m."orgId" = s."orgId"
+                WHERE s.id = $1 AND m."userId" = $2
+                      AND m."orgRole" IN ('ADMIN', 'OWNER')
                 """,
                 site_id,
                 user_id,
             )
+            if org_admin:
+                instances = await conn.fetch(
+                    """
+                    SELECT id, "siteId", name, description, host, port, protocol, "verifySsl", "isActive",
+                           "vyosVersion", "sshPort", "sshUsername", "sshKeyConfigured",
+                           "commitConfirmEnabled", "commitConfirmMinutes", timeout,
+                           "createdAt", "updatedAt"
+                    FROM instances
+                    WHERE "siteId" = $1
+                    ORDER BY name
+                    """,
+                    site_id,
+                )
+            else:
+                # Regular users see only instances they have explicit access to
+                instances = await conn.fetch(
+                    """
+                    SELECT DISTINCT i.id, i."siteId", i.name, i.description, i.host, i.port, i.protocol, i."verifySsl", i."isActive",
+                           i."vyosVersion", i."sshPort", i."sshUsername", i."sshKeyConfigured",
+                           i."commitConfirmEnabled", i."commitConfirmMinutes", i.timeout,
+                           i."createdAt", i."updatedAt"
+                    FROM instances i
+                    JOIN user_instance_roles uir
+                        ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
+                        AND uir."userId" = $2
+                    WHERE i."siteId" = $1
+                    ORDER BY i.name
+                    """,
+                    site_id,
+                    user_id,
+                )
 
         # If no instances found, return empty list (don't throw 404)
         # This allows the frontend to show "No instances available"

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -1,18 +1,13 @@
-"""Cross-organization negatives and target-state expectations.
+"""Cross-organization negatives and org-role semantics.
 
-Two kinds of tests, deliberately mixed in one file so the boundary reads
-as one story:
+- Plain assertions: invariants that hold with enforcement off (today's
+  default) and must keep holding through every step of the organization
+  work. A regression here is a broken build, full stop.
 
-- Plain assertions: invariants that hold TODAY and must keep holding
-  through every step of the organization work. A regression here is a
-  broken build, full stop.
-
-- xfail assertions: the TARGET semantics of org roles, which arrive with
-  org enforcement. They execute the real request today and document
-  current behavior; the enforcement-flip PR converts them to strict
-  assertions. An early XPASS is a SIGNAL, not noise - it means an
-  endpoint started enforcing (or otherwise changed) ahead of the flip,
-  and must be reported and explained, whether it is good news or bad.
+- Enforcement-on assertions: the org-role semantics that activate under
+  ORG_ENFORCEMENT. Each turns the flag on for the request and asserts the
+  enforced behavior directly (no longer xfail placeholders — the
+  enforcement path has landed and is proven by the FORCE-RLS rehearsal).
 """
 
 import pytest
@@ -20,11 +15,6 @@ import pytest
 from conftest import IDS, as_user
 
 pytestmark = pytest.mark.usefixtures("adversarial_world")
-
-ENFORCEMENT_OFF = pytest.mark.xfail(
-    reason="target org-role semantics; enforced at the org-enforcement flip",
-    strict=False,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -85,39 +75,29 @@ def test_system_administrator_sees_all_orgs(adversarial_world):
 
 
 # ---------------------------------------------------------------------------
-# Target-state expectations (xfail until the enforcement flip)
+# Org-role semantics under enforcement (proven workable by the FORCE-RLS
+# rehearsal; asserted here with the flag on). These were xfail placeholders
+# until the enforcement path landed and is verified; they are strict now.
 # ---------------------------------------------------------------------------
 
-@ENFORCEMENT_OFF
-def test_org_admin_sees_all_sites_of_their_org(adversarial_world):
+def test_org_admin_sees_all_sites_of_their_org(adversarial_world, monkeypatch):
     # Composition rule: org ADMIN is at least instance-ADMIN on every
     # instance in the org - the site listing must include all org-A sites
     # without per-site grants.
+    import org_scope
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
     response = as_user(adversarial_world, "a_admin").get("/session/sites")
     assert response.status_code == 200
     assert IDS["site_a"] in [s["id"] for s in response.json()]
 
 
-@ENFORCEMENT_OFF
-def test_org_admin_sees_instances_of_their_org_site(adversarial_world):
+def test_org_admin_sees_instances_of_their_org_site(adversarial_world, monkeypatch):
+    import org_scope
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
     response = as_user(adversarial_world, "a_admin").get(
         f"/session/sites/{IDS['site_a']}/instances")
     assert response.status_code == 200
     assert IDS["instance_a"] in [i["id"] for i in response.json()]
-
-
-@ENFORCEMENT_OFF
-def test_token_creation_rejects_foreign_org_instance_ids(adversarial_world):
-    # Target semantics with enforcement OFF: a cross-org allowed-id is inert
-    # (FK passes, request-time grant intersection is the backstop). This
-    # xfails today and flips strict at the enforcement flip; the enforced
-    # behavior is proven in the ON test below.
-    response = as_user(adversarial_world, "a_member").post(
-        "/tokens",
-        json={"name": "adv-cross-org-probe", "scopes": ["read"],
-              "allowed_instance_ids": [IDS["instance_b"]],
-              "allowed_site_ids": []})
-    assert response.status_code in (400, 403, 422)
 
 
 def test_token_creation_org_confined_under_enforcement(


### PR DESCRIPTION
Closes #500. Part of the 1.0 push (found while converting the adversarial xfails to strict).

## Fix
`GET /session/sites/{id}/instances` had the same org-admin gap as the site listing (#497): under `ORG_ENFORCEMENT`, an org ADMIN/OWNER (not a platform ADMIN) now sees every instance in a site of an org they administer. Inert while off.

## Tests
- The two `test_cross_org` target-state placeholders (org ADMIN sees org **sites** / **instances**) convert from `xfail` to strict enforcement-on assertions — the enforcement path has landed and is proven by the FORCE-RLS rehearsal.
- The redundant OFF-state token xfail is dropped (its enforced version already asserts confinement); `ENFORCEMENT_OFF` removed.

## Verified
Live on a FORCE-RLS + fenced `vym_runtime` stack: org-ADMIN member sees their org's instance. Adversarial **13 passed / 0 xfailed**; org/backup/sso **38 passed**.