### PR TITLE
fix: enforce RBAC on routing-policy config/batch/reorder endpoints

### DIFF
--- a/backend/routers/as_path_list/as_path_list.py
+++ b/backend/routers/as_path_list/as_path_list.py
@@ -13,6 +13,13 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import AsPathListBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors route.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -137,6 +144,9 @@ async def get_as_path_list_config(http_request: Request, refresh: bool = False):
     Returns:
         Generalized configuration data optimized for frontend consumption
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.BGP_AS_PATH)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -204,6 +214,9 @@ async def as_path_list_batch_configure(http_request: Request, body: AsPathListBa
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_AS_PATH)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -211,7 +224,11 @@ async def as_path_list_batch_configure(http_request: Request, body: AsPathListBa
 
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -245,6 +262,8 @@ async def as_path_list_batch_configure(http_request: Request, body: AsPathListBa
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -271,6 +290,9 @@ async def reorder_as_path_list_rules(http_request: Request, body: ReorderAsPathL
     Returns:
         VyOSResponse with success/failure information
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_AS_PATH)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/routers/community_list/community_list.py
+++ b/backend/routers/community_list/community_list.py
@@ -13,6 +13,13 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import CommunityListBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors route.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -137,6 +144,9 @@ async def get_community_list_config(http_request: Request, refresh: bool = False
     Returns:
         Generalized configuration data optimized for frontend consumption
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.BGP_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -204,6 +214,9 @@ async def community_list_batch_configure(http_request: Request, body: CommunityL
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -211,7 +224,11 @@ async def community_list_batch_configure(http_request: Request, body: CommunityL
 
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -245,6 +262,8 @@ async def community_list_batch_configure(http_request: Request, body: CommunityL
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -271,6 +290,9 @@ async def reorder_community_list_rules(http_request: Request, body: ReorderCommu
     Returns:
         VyOSResponse with success/failure information
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/routers/extcommunity_list/extcommunity_list.py
+++ b/backend/routers/extcommunity_list/extcommunity_list.py
@@ -13,6 +13,13 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import ExtCommunityListBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors route.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -137,6 +144,9 @@ async def get_extcommunity_list_config(http_request: Request, refresh: bool = Fa
     Returns:
         Generalized configuration data optimized for frontend consumption
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.BGP_EXTENDED_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -204,6 +214,9 @@ async def extcommunity_list_batch_configure(http_request: Request, body: ExtComm
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_EXTENDED_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -211,7 +224,11 @@ async def extcommunity_list_batch_configure(http_request: Request, body: ExtComm
 
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -245,6 +262,8 @@ async def extcommunity_list_batch_configure(http_request: Request, body: ExtComm
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -271,6 +290,9 @@ async def reorder_extcommunity_list_rules(http_request: Request, body: ReorderEx
     Returns:
         VyOSResponse with success/failure information
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_EXTENDED_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/routers/large_community_list/large_community_list.py
+++ b/backend/routers/large_community_list/large_community_list.py
@@ -13,6 +13,13 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import LargeCommunityListBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors route.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -137,6 +144,9 @@ async def get_large_community_list_config(http_request: Request, refresh: bool =
     Returns:
         Generalized configuration data optimized for frontend consumption
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.BGP_LARGE_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -204,6 +214,9 @@ async def large_community_list_batch_configure(http_request: Request, body: Larg
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_LARGE_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -211,7 +224,11 @@ async def large_community_list_batch_configure(http_request: Request, body: Larg
 
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -245,6 +262,8 @@ async def large_community_list_batch_configure(http_request: Request, body: Larg
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -271,6 +290,9 @@ async def reorder_large_community_list_rules(http_request: Request, body: Reorde
     Returns:
         VyOSResponse with success/failure information
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.BGP_LARGE_COMMUNITY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/routers/local_route/local_route.py
+++ b/backend/routers/local_route/local_route.py
@@ -13,6 +13,13 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import LocalRouteBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors route.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -107,6 +114,9 @@ async def get_local_route_capabilities(http_request: Request):
 
     Returns feature flags indicating which operations are supported.
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.LOCAL_ROUTE)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -158,6 +168,9 @@ async def get_local_route_config(http_request: Request, refresh: bool = False):
     Returns:
         Generalized configuration data for IPv4 and IPv6 rules
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.LOCAL_ROUTE)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -222,6 +235,9 @@ async def local_route_batch_configure(http_request: Request, body: LocalRouteBat
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.LOCAL_ROUTE)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -229,7 +245,11 @@ async def local_route_batch_configure(http_request: Request, body: LocalRouteBat
 
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -250,6 +270,8 @@ async def local_route_batch_configure(http_request: Request, body: LocalRouteBat
             data={"message": "Configuration updated"},
             error=response.error if response.error else None,
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -268,6 +290,9 @@ async def local_route_reorder_rules(http_request: Request, body: LocalRouteReord
     This is done by deleting all rules and recreating them with new numbers
     in a single batch operation.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.LOCAL_ROUTE)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/routers/route/route.py
+++ b/backend/routers/route/route.py
@@ -235,6 +235,9 @@ async def get_route_config(http_request: Request, refresh: bool = False):
     Returns:
         Both IPv4 (route) and IPv6 (route6) policies
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.ROUTE_POLICY)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -653,6 +656,9 @@ async def route_batch_configure(http_request: Request, body: RouteBatchRequest):
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.ROUTE_POLICY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -736,6 +742,8 @@ async def route_batch_configure(http_request: Request, body: RouteBatchRequest):
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -1115,6 +1123,9 @@ async def reorder_rules(http_request: Request, body: ReorderRequest):
 
     Deletes all rules and recreates them in the new order using batch operations.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.ROUTE_POLICY)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/routers/route_map/route_map.py
+++ b/backend/routers/route_map/route_map.py
@@ -13,6 +13,13 @@ from session_vyos_service import get_session_vyos_service
 from vyos_builders import RouteMapBatchBuilder
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
+
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors route.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
 import inspect
 import logging
 logger = logging.getLogger(__name__)
@@ -234,6 +241,9 @@ async def get_route_map_config(http_request: Request, refresh: bool = False):
     Returns:
         Generalized configuration data optimized for frontend consumption
     """
+    # Check RBAC permission
+    await require_read_permission(http_request, FeatureGroup.ROUTE_MAP)
+
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh=refresh)
@@ -473,6 +483,9 @@ async def route_map_batch_configure(http_request: Request, body: RouteMapBatchRe
 
     Allows multiple changes in a single VyOS commit for efficiency.
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.ROUTE_MAP)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()
@@ -480,7 +493,11 @@ async def route_map_batch_configure(http_request: Request, body: RouteMapBatchRe
 
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -514,6 +531,8 @@ async def route_map_batch_configure(http_request: Request, body: RouteMapBatchRe
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -548,6 +567,9 @@ async def reorder_route_map_rules(http_request: Request, body: ReorderRouteMapRe
     Returns:
         VyOSResponse with success/failure information
     """
+    # Check RBAC permission
+    await require_write_permission(http_request, FeatureGroup.ROUTE_MAP)
+
     try:
         service = get_session_vyos_service(http_request)
         version = service.get_version()

--- a/backend/tests/test_routing_policy_rbac.py
+++ b/backend/tests/test_routing_policy_rbac.py
@@ -1,0 +1,118 @@
+"""Source guards for routing-policy RBAC enforcement (audit D3-01).
+
+The routing-policy family (route, route_map, local_route, access/prefix
+lists, the BGP list routers) exposes ``/config`` (read), ``/batch`` and
+``/reorder`` (write). Each handler must call its ``require_*_permission``
+check — the read-only-token scope gate lives inside that check, so a
+missing call means a VIEWER or a read-only API token can mutate routing
+config. These tests parse the router sources so a regression fails the
+suite without needing a database or a device.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROUTERS_DIR = Path(__file__).resolve().parents[1] / "routers"
+
+# router file → {handler → required permission call}
+GATED_HANDLERS = {
+    "local_route/local_route.py": {
+        "get_local_route_capabilities": "require_read_permission",
+        "get_local_route_config": "require_read_permission",
+        "local_route_batch_configure": "require_write_permission",
+        "local_route_reorder_rules": "require_write_permission",
+    },
+    "as_path_list/as_path_list.py": {
+        "get_as_path_list_config": "require_read_permission",
+        "as_path_list_batch_configure": "require_write_permission",
+        "reorder_as_path_list_rules": "require_write_permission",
+    },
+    "community_list/community_list.py": {
+        "get_community_list_config": "require_read_permission",
+        "community_list_batch_configure": "require_write_permission",
+        "reorder_community_list_rules": "require_write_permission",
+    },
+    "extcommunity_list/extcommunity_list.py": {
+        "get_extcommunity_list_config": "require_read_permission",
+        "extcommunity_list_batch_configure": "require_write_permission",
+        "reorder_extcommunity_list_rules": "require_write_permission",
+    },
+    "large_community_list/large_community_list.py": {
+        "get_large_community_list_config": "require_read_permission",
+        "large_community_list_batch_configure": "require_write_permission",
+        "reorder_large_community_list_rules": "require_write_permission",
+    },
+    "route/route.py": {
+        "get_route_config": "require_read_permission",
+        "route_batch_configure": "require_write_permission",
+        "reorder_rules": "require_write_permission",
+    },
+    "route_map/route_map.py": {
+        "get_route_map_config": "require_read_permission",
+        "route_map_batch_configure": "require_write_permission",
+        "reorder_route_map_rules": "require_write_permission",
+    },
+    # the siblings the fix was copied from — keep them honest too
+    "access_list/access_list.py": {
+        "access_list_batch_configure": "require_write_permission",
+        "reorder_access_list_rules": "require_write_permission",
+    },
+    "prefix_list/prefix_list.py": {},
+}
+
+# router file → handlers that dispatch getattr(builder, operation.op)
+DYNAMIC_DISPATCH_FILES = [
+    "local_route/local_route.py",
+    "as_path_list/as_path_list.py",
+    "community_list/community_list.py",
+    "extcommunity_list/extcommunity_list.py",
+    "large_community_list/large_community_list.py",
+    "route/route.py",
+    "route_map/route_map.py",
+]
+
+
+def _permission_calls(func_node):
+    """Names of require_*_permission functions awaited inside a handler."""
+    calls = set()
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Call):
+            name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            if name and name.startswith("require_"):
+                calls.add(name)
+    return calls
+
+
+def _handlers(path):
+    tree = ast.parse(path.read_text())
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+    }
+
+
+@pytest.mark.parametrize("rel_path", sorted(GATED_HANDLERS))
+def test_handlers_call_their_permission_check(rel_path):
+    handlers = _handlers(ROUTERS_DIR / rel_path)
+    for handler, required_call in GATED_HANDLERS[rel_path].items():
+        assert handler in handlers, f"{rel_path}: handler {handler} not found"
+        calls = _permission_calls(handlers[handler])
+        assert required_call in calls, (
+            f"{rel_path}:{handler} must call {required_call} — "
+            "a missing check lets a VIEWER or read-only token through (D3-01)"
+        )
+
+
+@pytest.mark.parametrize("rel_path", DYNAMIC_DISPATCH_FILES)
+def test_batch_dispatch_guards_operation_names(rel_path):
+    source = (ROUTERS_DIR / rel_path).read_text()
+    assert "_INTERNAL_BUILDER_METHODS" in source, (
+        f"{rel_path}: getattr(builder, operation.op) dispatch must allowlist "
+        "operation names"
+    )
+    assert "method = getattr(builder, operation.op)\n" not in source, (
+        f"{rel_path}: unguarded getattr dispatch on a client-supplied name"
+    )


### PR DESCRIPTION
## What
The seven routing-policy routers (route, route_map, local_route, as_path_list, community_list, extcommunity_list, large_community_list) called their permission check only on /capabilities. This adds the missing `require_read_permission` / `require_write_permission` calls on /config, /batch and /reorder — the same pattern access_list already uses — plus an allowlist for the client-supplied batch operation name before `getattr` dispatch (mirroring route.py), and `except HTTPException: raise` so the new 400s aren't converted to 500s.

## Why
Without the check these endpoints accepted requests from any authenticated user with an active instance, regardless of role or token scope (audit finding D3-01).

## Testing
- New `tests/test_routing_policy_rbac.py` source-guards: every gated handler must call its permission check; unguarded `getattr(builder, operation.op)` dispatch fails the suite. 16 tests pass.
- Full backend suite: 103 passed, 27 skipped (DB-gated) — unchanged from before the fix.
- Routers import cleanly; no endpoint signatures changed.