### PR TITLE
fix: bridge firewall base chains need the filter keyword on VyOS 1.4 too

### DIFF
--- a/backend/routers/firewall/bridge.py
+++ b/backend/routers/firewall/bridge.py
@@ -359,8 +359,8 @@ async def get_bridge_config(request: Request, refresh: bool = False):
         for chain_name in base_chain_names:
             if chain_name in bridge_config:
                 raw_chain_data = bridge_config[chain_name]
-                # VyOS 1.5 uses filter table structure
-                if is_v15 and isinstance(raw_chain_data, dict) and "filter" in raw_chain_data:
+                # Base chains nest under the filter table on both 1.4 and 1.5
+                if isinstance(raw_chain_data, dict) and "filter" in raw_chain_data:
                     chain_data = raw_chain_data["filter"]
                 else:
                     chain_data = raw_chain_data

--- a/backend/tests/test_firewall_bridge_mapper.py
+++ b/backend/tests/test_firewall_bridge_mapper.py
@@ -1,0 +1,39 @@
+"""Bridge firewall mapper paths (audit D2-01).
+
+Both VyOS 1.4 (sagitta) and 1.5 require the ``filter`` keyword for base
+chains: ``set firewall bridge forward filter rule ...``. The mapper used
+to emit the keyword only for 1.5, so every base-chain rule sent to a 1.4
+device was an invalid path and the commit was rejected.
+"""
+
+import pytest
+
+from vyos_mappers.firewall.bridge import BridgeFirewallMapper
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_base_chain_paths_include_filter(version):
+    mapper = BridgeFirewallMapper(version)
+    assert mapper.get_chain_path("forward") == ["firewall", "bridge", "forward", "filter"]
+    assert mapper.get_rule_path("forward", 10) == [
+        "firewall", "bridge", "forward", "filter", "rule", "10",
+    ]
+    assert mapper.get_chain_default_action("forward", "drop") == [
+        "firewall", "bridge", "forward", "filter", "default-action", "drop",
+    ]
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_custom_chain_paths_have_no_filter(version):
+    mapper = BridgeFirewallMapper(version)
+    assert mapper.get_chain_path("MY-CHAIN") == ["firewall", "bridge", "name", "MY-CHAIN"]
+    assert mapper.get_rule_path("MY-CHAIN", 5) == [
+        "firewall", "bridge", "name", "MY-CHAIN", "rule", "5",
+    ]
+
+
+def test_supported_chains_still_version_gated():
+    assert BridgeFirewallMapper("1.4").get_supported_chains() == ["forward"]
+    assert set(BridgeFirewallMapper("1.5").get_supported_chains()) == {
+        "forward", "input", "output", "prerouting",
+    }

--- a/backend/vyos_mappers/firewall/bridge.py
+++ b/backend/vyos_mappers/firewall/bridge.py
@@ -39,16 +39,15 @@ class BridgeFirewallMapper(BaseFeatureMapper):
         return chain in base_chains
 
     def _get_chain_base(self, chain: str, is_custom: bool = False) -> List[str]:
-        """Get base path for a chain. VyOS 1.5 uses 'filter' table for base chains."""
+        """Get base path for a chain. Base chains sit under the 'filter' table."""
         # Check if it's a custom chain (either explicitly flagged or not a base chain name)
         if is_custom or not self._is_base_chain(chain):
             # Custom chains use: firewall bridge name <chain-name>
             return ["firewall", "bridge", "name", chain]
 
-        # Base chains use: firewall bridge <chain> [filter] (filter only for VyOS 1.5)
-        if self._is_v15:
-            return ["firewall", "bridge", chain, "filter"]
-        return ["firewall", "bridge", chain]
+        # Base chains use: firewall bridge <chain> filter — on both 1.4 and
+        # 1.5; sagitta rejects the path without the filter keyword.
+        return ["firewall", "bridge", chain, "filter"]
 
     def get_chain_path(self, chain: str) -> List[str]:
         """Get command path for a chain."""


### PR DESCRIPTION
## What
`BridgeFirewallMapper._get_chain_base` treated the `filter` table keyword as 1.5-only; VyOS 1.4 (sagitta) also requires `set firewall bridge forward filter rule ...`. Every base-chain write emitted for a 1.4 device was an invalid path, so the commit was rejected. The config read path in `routers/firewall/bridge.py` had the same inverted branch and failed to unwrap the `filter` node when parsing 1.4 config.

## Why
Audit finding D2-01 (confirmed against sagitta docs; the ipv4/ipv6 mappers already emit `filter` for both versions).

## Testing
- New `tests/test_firewall_bridge_mapper.py`: base-chain paths include `filter` on 1.4 and 1.5, custom chains don't, supported-chain gating unchanged (5 tests).
- Full backend suite passes with no regressions.
- Not verified against a live 1.4 device in this PR; path shape matches the sagitta CLI reference and the sibling ipv4 mapper.