### PR TITLE
fix: reject CGNAT configuration on VyOS 1.4

### DIFF
--- a/backend/tests/test_nat_cgnat_version_gate.py
+++ b/backend/tests/test_nat_cgnat_version_gate.py
@@ -1,0 +1,46 @@
+"""CGNAT version gating (audit D2-02).
+
+CGNAT (``nat cgnat ...``) only exists from VyOS 1.5. The 1.4 mapper must
+refuse every CGNAT path instead of emitting a command the device rejects
+at commit — the same convention the firewall groups v1_4 mapper uses for
+domain/remote groups.
+"""
+
+import inspect
+
+import pytest
+
+from vyos_mappers.nat.nat import NATMapper
+from vyos_mappers.nat.nat_versions import get_nat_mapper
+
+
+def _dummy_args(method):
+    """1 for int-ish params, 'x' otherwise — enough to reach the body."""
+    params = list(inspect.signature(method).parameters.values())
+    return ["1" if "number" in p.name or p.name == "seq" else "x" for p in params]
+
+
+CGNAT_METHODS = [
+    name for name, _ in inspect.getmembers(NATMapper, predicate=inspect.isfunction)
+    if name.startswith("get_cgnat")
+]
+
+
+def test_base_mapper_defines_cgnat_methods():
+    assert len(CGNAT_METHODS) >= 17
+
+
+@pytest.mark.parametrize("name", CGNAT_METHODS)
+def test_v14_rejects_every_cgnat_path(name):
+    mapper = get_nat_mapper("1.4")
+    method = getattr(mapper, name)
+    with pytest.raises(ValueError, match="1.5"):
+        method(*_dummy_args(method))
+
+
+@pytest.mark.parametrize("name", CGNAT_METHODS)
+def test_v15_still_emits_cgnat_paths(name):
+    mapper = get_nat_mapper("1.5")
+    method = getattr(mapper, name)
+    path = method(*_dummy_args(method))
+    assert path[:2] == ["nat", "cgnat"]

--- a/backend/vyos_mappers/nat/nat_versions/v1_4.py
+++ b/backend/vyos_mappers/nat/nat_versions/v1_4.py
@@ -1,11 +1,67 @@
 """NAT mapper for VyOS 1.4."""
+from typing import List
+
 from ..nat import NATMapper
+
+_CGNAT_UNSUPPORTED = "CGNAT requires VyOS 1.5+. Current device is running v1.4"
 
 
 class NATMapper_v1_4(NATMapper):
     """NAT mapper for VyOS 1.4.
 
-    NAT is a core feature available in VyOS 1.4.
-    All commands are supported in this version.
+    Source, destination and static NAT are fully supported. CGNAT
+    (``nat cgnat ...``) only exists from VyOS 1.5, so every CGNAT path
+    raises here — mirroring the firewall groups v1_4 mapper — instead of
+    emitting a path the device would reject at commit.
     """
-    pass
+
+    def get_cgnat_log_allocation(self) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_port_range(self, pool_name: str, port_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_port_range_path(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_per_user_limit_port(self, pool_name: str, port: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_per_user_limit_port_path(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_range(self, pool_name: str, ip_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_range_seq(self, pool_name: str, ip_range: str, seq: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_range_seq_path(self, pool_name: str, ip_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_internal(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_internal_range(self, pool_name: str, ip_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_internal_range_path(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule(self, rule_number: int) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_source_pool(self, rule_number: int, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_source_pool_path(self, rule_number: int) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_translation_pool(self, rule_number: int, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_translation_pool_path(self, rule_number: int) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)


### PR DESCRIPTION
## What
The v1_4 NAT mapper inherited all `get_cgnat_*` paths from the base mapper, so `set nat cgnat ...` was emitted for 1.4 devices even though CGNAT is 1.5-only — the commit failed device-side with an opaque error. This overrides every CGNAT path in `NATMapper_v1_4` to raise `ValueError` (the NAT router already converts that to a 400 with the message), following the same convention as the firewall groups v1_4 mapper for domain/remote groups.

## Why
Audit finding D2-02. `/nat/capabilities` already reported `cgnat: supported = 1.5 only`; the write path just never enforced it.

## Testing
- New `tests/test_nat_cgnat_version_gate.py`: enumerates `get_cgnat_*` from the base mapper via introspection — 1.4 raises on all of them, 1.5 still emits `['nat', 'cgnat', ...]` paths, and a newly added CGNAT method automatically joins the parametrization (35 tests).
- Full backend suite passes.