### PR TITLE
fix: gate backend startup on completed migrations

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -115,6 +115,7 @@ from routers import version as version_router
 from routers import events as events_router
 from routers.events import start_poller, stop_poller
 import revocation_bus
+from schema_gate import wait_for_schema
 
 # Global variables
 db_pool: Optional[asyncpg.Pool] = None
@@ -210,6 +211,10 @@ async def lifespan(app: FastAPI):
         database_url = os.getenv("DATABASE_URL")
         if not database_url:
             raise ValueError("DATABASE_URL environment variable is required")
+
+        # Migrations run in the frontend container; don't serve requests
+        # against a half-migrated schema (bounded wait, see schema_gate).
+        await wait_for_schema(database_url)
 
         db_pool = await asyncpg.create_pool(
             database_url,

--- a/backend/schema_gate.py
+++ b/backend/schema_gate.py
@@ -1,0 +1,101 @@
+"""Startup gate: wait for the Prisma-managed schema before serving.
+
+Migrations run in the frontend container (``prisma migrate deploy``), so
+on a populated-database upgrade there is a window where the backend is up
+but the new tables don't exist yet — admin endpoints 500 and feature
+pages degrade to spurious "no active instance" errors until the frontend
+finishes migrating. Instead of serving through that window, the backend
+polls until the schema it depends on is present and no migration is left
+half-applied.
+
+The wait is bounded (``VYMANAGER_SCHEMA_WAIT_TIMEOUT``, seconds,
+default 120, ``0`` disables the gate): if the schema never appears the
+backend logs loudly and serves anyway, preserving the old self-healing
+behavior and avoiding a startup deadlock with compose setups where the
+migration runner waits for the backend healthcheck.
+"""
+
+import asyncio
+import os
+import time
+
+import asyncpg
+
+# Tables the backend queries unconditionally (middleware, org scoping,
+# RBAC, auditing). Extend this list when a migration adds a table the
+# backend reads at request time.
+REQUIRED_TABLES = (
+    "users",
+    "sites",
+    "instances",
+    "organizations",
+    "org_memberships",
+    "user_instance_roles",
+    "user_feature_permissions",
+    "active_sessions",
+    "audit_logs",
+)
+
+
+async def _schema_status(database_url: str):
+    """Return (missing_tables, unfinished_migrations) or raise on connect failure."""
+    conn = await asyncpg.connect(database_url, timeout=10)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT table_name FROM information_schema.tables
+            WHERE table_schema = current_schema() AND table_name = ANY($1::text[])
+            """,
+            list(REQUIRED_TABLES) + ["_prisma_migrations"],
+        )
+        present = {r["table_name"] for r in rows}
+        missing = [t for t in REQUIRED_TABLES if t not in present]
+
+        unfinished = 0
+        if "_prisma_migrations" in present:
+            unfinished = await conn.fetchval(
+                'SELECT count(*) FROM "_prisma_migrations" '
+                "WHERE finished_at IS NULL AND rolled_back_at IS NULL"
+            )
+        return missing, unfinished
+    finally:
+        await conn.close()
+
+
+async def wait_for_schema(database_url: str) -> bool:
+    """Poll until the required schema exists. True = ready, False = timed out."""
+    timeout = float(os.getenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "120"))
+    interval = float(os.getenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "2"))
+    if timeout <= 0:
+        return True
+
+    deadline = time.monotonic() + timeout
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            missing, unfinished = await _schema_status(database_url)
+            if not missing and not unfinished:
+                if attempt > 1:
+                    print("  ✓ Database schema ready")
+                return True
+            state = []
+            if missing:
+                state.append(f"missing tables: {', '.join(missing)}")
+            if unfinished:
+                state.append(f"{unfinished} unfinished migration(s)")
+            reason = "; ".join(state)
+        except Exception as e:
+            reason = f"database not reachable: {e}"
+
+        if time.monotonic() >= deadline:
+            print("  " + "!" * 58)
+            print(f"  ✗ Schema not ready after {timeout:.0f}s ({reason}).")
+            print("  ✗ Serving anyway — run 'prisma migrate deploy' (frontend")
+            print("  ✗ container) to bring the database up to date.")
+            print("  " + "!" * 58)
+            return False
+
+        if attempt == 1 or attempt % 5 == 0:
+            print(f"  ⏳ Waiting for database schema ({reason})")
+        await asyncio.sleep(interval)

--- a/backend/tests/test_schema_gate.py
+++ b/backend/tests/test_schema_gate.py
@@ -1,0 +1,65 @@
+"""Startup schema gate behavior (audit D2-03). No database needed."""
+
+import asyncio
+
+import pytest
+
+import schema_gate
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def test_gate_disabled_by_zero_timeout(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "0")
+
+    async def boom(url):  # pragma: no cover - must not be called
+        raise AssertionError("gate should not touch the database when disabled")
+
+    monkeypatch.setattr(schema_gate, "_schema_status", boom)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is True
+
+
+def test_ready_schema_passes_immediately(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "5")
+
+    async def ready(url):
+        return [], 0
+
+    monkeypatch.setattr(schema_gate, "_schema_status", ready)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is True
+
+
+def test_missing_tables_time_out_and_serve_anyway(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "0.05")
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "0.01")
+
+    async def missing(url):
+        return ["organizations"], 0
+
+    monkeypatch.setattr(schema_gate, "_schema_status", missing)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is False
+
+
+def test_unfinished_migration_blocks_until_done(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "5")
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "0.01")
+    states = iter([([], 1), ([], 1), ([], 0)])
+
+    async def sequence(url):
+        return next(states)
+
+    monkeypatch.setattr(schema_gate, "_schema_status", sequence)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is True
+
+
+def test_connection_errors_keep_polling_then_time_out(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "0.05")
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "0.01")
+
+    async def down(url):
+        raise ConnectionRefusedError("postgres still starting")
+
+    monkeypatch.setattr(schema_gate, "_schema_status", down)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is False

--- a/backend/tests/test_schema_gate.py
+++ b/backend/tests/test_schema_gate.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-import pytest
-
 import schema_gate
 
 

--- a/container/vymanager-dev/env-file-docker-compose.yml
+++ b/container/vymanager-dev/env-file-docker-compose.yml
@@ -21,6 +21,29 @@ services:
       retries: 5
       start_period: 10s
 
+  # One-shot migration runner: applies Prisma migrations before the
+  # backend serves and before the frontend starts (the backend healthcheck
+  # used to gate the frontend, which ran the migrations — so on upgrades
+  # the backend served against the old schema until the frontend came up).
+  migrate:
+    build:
+      context: ../../frontend
+      dockerfile: Dockerfile
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    volumes:
+      - ../../frontend:/app
+      - /app/node_modules
+      - /app/.next
+    env_file:
+      - ../../frontend/.env
+    restart: "no"
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     build:
       context: ../../backend
@@ -41,6 +64,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
       interval: 30s

--- a/container/vymanager-prod/env-file-docker-compose.yml
+++ b/container/vymanager-prod/env-file-docker-compose.yml
@@ -22,6 +22,23 @@ services:
       retries: 5
       start_period: 10s
 
+  # One-shot migration runner: applies Prisma migrations before the
+  # backend serves and before the frontend starts. The frontend
+  # entrypoint still runs migrate deploy itself (harmless no-op here) so
+  # non-compose deployments keep working.
+  migrate:
+    image: ghcr.io/community-vyprojects/vymanager-frontend:beta
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    env_file:
+      - ../../frontend/.env
+    restart: "no"
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     image: ghcr.io/community-vyprojects/vymanager-backend:beta
     container_name: vymanager-backend
@@ -35,6 +52,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
       interval: 30s
@@ -52,6 +71,11 @@ services:
     restart: unless-stopped
     networks:
       - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
 networks:
   vymanager-network:


### PR DESCRIPTION
## What
Audit finding D2-03: on a populated-DB upgrade there is a window where the backend serves before `prisma migrate deploy` (which lives in the frontend container) has run — org tables missing → admin endpoints 500, feature pages degrade to "no active instance" 400s. Dev compose even ordered the migration runner *after* the backend healthcheck; prod compose had no ordering at all.

## How
- New `backend/schema_gate.py`: before creating the pool, poll until every table the backend reads at request time exists and `_prisma_migrations` has no unfinished row. Bounded wait (`VYMANAGER_SCHEMA_WAIT_TIMEOUT`, default 120 s, `0` disables); on timeout it logs a loud warning and serves anyway — preserving today's self-healing and avoiding deadlock with setups where the migration runner waits on the backend healthcheck.
- Both compose files add a one-shot `migrate` service (frontend image, `npx prisma generate && npx prisma migrate deploy`), and backend + frontend depend on it via `service_completed_successfully`. The frontend entrypoint still runs `migrate deploy` (idempotent), so non-compose deployments are unchanged.

## Testing
- `tests/test_schema_gate.py`: gate disabled by 0-timeout, immediate pass, timeout-serves-anyway, waits-across-unfinished-migration, keeps-polling-through-connection-errors (5 tests, no DB needed).
- Full backend suite: 113 passed, 27 skipped (DB-gated).
- Compose files parse as valid YAML; not brought up here (no docker on this host) — worth one `docker compose up` smoke test on the staging box.