### PR TITLE
test: close the canary and Golden Rule guardrail blind spots

### DIFF
--- a/backend/scripts/prove_runtime_role.py
+++ b/backend/scripts/prove_runtime_role.py
@@ -61,6 +61,15 @@ async def main() -> int:
                     break
                 if allowed:
                     failures.append(f"role has {privilege} on {table}")
+
+        # The D1-01 vector: UPDATE on users.role lets a compromised
+        # frontend self-promote to site ADMIN.
+        role_update = await conn.fetchval(
+            "SELECT has_column_privilege(current_user, 'users', 'role',"
+            " 'UPDATE')")
+        if role_update:
+            failures.append(
+                "role can UPDATE users.role — frontend self-promotion open")
     finally:
         await conn.close()
 

--- a/backend/scripts/prove_runtime_role.py
+++ b/backend/scripts/prove_runtime_role.py
@@ -1,0 +1,77 @@
+"""Prove the Golden Rule on the REAL runtime role (flip-runbook step).
+
+The structural test (tests/adversarial/test_golden_rule.py) shows the
+intended grant set blocks the authorization tables — but production
+could still run the frontend as the table owner or a superuser with the
+ban unenforced. This script asks Postgres about the actual principal of
+the DATABASE_URL it is given. Run it after switching the frontend to its
+fenced role:
+
+    DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role
+
+Exit code 0 = the role cannot write any authorization table and is not
+a superuser. Non-zero = the Golden Rule is not structurally enforced on
+this deployment; the output names each offending grant.
+"""
+
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+BANNED_TABLES = [
+    "org_memberships",
+    "user_instance_roles",
+    "user_feature_permissions",
+    "organizations",
+    "oauth_role_mappings",
+    "sites",
+    "instances",
+]
+
+PRIVILEGES = ("INSERT", "UPDATE", "DELETE")
+
+
+async def main() -> int:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is required (the frontend's connection string)")
+        return 2
+
+    conn = await asyncpg.connect(url)
+    failures = []
+    try:
+        role = await conn.fetchval("SELECT current_user")
+        superuser = await conn.fetchval(
+            "SELECT usesuper FROM pg_user WHERE usename = current_user")
+        print(f"runtime role: {role} (superuser: {bool(superuser)})")
+        if superuser:
+            failures.append(
+                "role is a superuser — every table ban is bypassed")
+
+        for table in BANNED_TABLES:
+            for privilege in PRIVILEGES:
+                try:
+                    allowed = await conn.fetchval(
+                        "SELECT has_table_privilege(current_user, $1, $2)",
+                        f'"{table}"', privilege)
+                except asyncpg.UndefinedTableError:
+                    print(f"  {table}: missing (skipped)")
+                    break
+                if allowed:
+                    failures.append(f"role has {privilege} on {table}")
+    finally:
+        await conn.close()
+
+    if failures:
+        print("\nGOLDEN RULE NOT ENFORCED:")
+        for failure in failures:
+            print(f"  ✗ {failure}")
+        return 1
+    print("✓ runtime role cannot write any authorization table")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -33,6 +33,19 @@ PERMANENT_GLOBAL = {
         "iterates every instance with active subscribers, a "
         "deployment-wide system service. The request-path streams in "
         "the same file use org-scoped connections per tick.",
+    "revocation_bus.py":
+        "Holds one dedicated LISTEN connection for the deployment-wide "
+        "revocation channel; no request, no org context by nature.",
+    "rbac_permissions.py":
+        "_acquire accepts a Pool on the short-lived /vyos permission "
+        "path (the sanctioned request_scoped_conn design); flagged by "
+        "the broadened .acquire( marker, reviewed as correct.",
+    "routers/console/console.py":
+        "getattr(state, 'db_pool') presence check only - every actual "
+        "acquisition in the WS handler goes through ws_conn/ws_org_conn.",
+    "routers/monitoring/monitoring.py":
+        "getattr(state, 'db_pool') presence check only - acquisitions "
+        "go through ws_conn/ws_org_conn.",
 }
 
 # Files not yet migrated to org-scoped connections. The conversion waves

--- a/backend/tests/adversarial/test_canary.py
+++ b/backend/tests/adversarial/test_canary.py
@@ -12,10 +12,13 @@ from canary_allowlist import MIGRATION_PENDING, PERMANENT_GLOBAL
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
-# Direct pool access markers. org-scoped code never mentions db_pool:
-# handlers take a connection from the org_conn dependencies, and the
-# permission path goes through request_scoped_conn.
-MARKERS = ("db_pool.acquire(", "state.db_pool")
+# Direct pool access markers. org-scoped code never mentions db_pool or
+# acquires connections itself: handlers take a connection from the
+# org_conn dependencies, and the permission path goes through
+# request_scoped_conn. The generic ".acquire(" marker also catches
+# aliased acquisitions (a Pool passed under another name) that the old
+# literal markers were blind to.
+MARKERS = (".acquire(", '"db_pool"', "'db_pool'", "state.db_pool")
 
 EXCLUDED_DIRS = {"tests", "__pycache__", "venv", ".venv", "node_modules"}
 

--- a/backend/tests/adversarial/test_golden_rule.py
+++ b/backend/tests/adversarial/test_golden_rule.py
@@ -10,9 +10,12 @@ The proof creates a restricted role mirroring the intended frontend grants —
 write access to the Better Auth core tables only — and asserts that INSERT and
 UPDATE on each authz table fail. Needs CREATE ROLE; skips otherwise.
 
-Note: oauth_role_mappings is not covered here — the frontend still writes it
-via the OAuth-config UI. Relocating that write to the backend (like the SSO
-reconcile relocation) is the remaining step before it joins this ban.
+oauth_role_mappings joined the ban once its writes relocated to the backend
+(PR #484); sites and instances are backend-owned and join it too. A second proof
+checks the REAL runtime role instead of a synthetic one — run it on a
+deployment after the enforcement flip (flip-runbook step, not CI):
+
+    DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role
 """
 
 import asyncio
@@ -35,6 +38,11 @@ BANNED_TABLES = [
     "user_instance_roles",
     "user_feature_permissions",
     "organizations",
+    # writes relocated to the backend; the frontend only proxies
+    "oauth_role_mappings",
+    # backend-owned resources — the frontend never writes them directly
+    "sites",
+    "instances",
 ]
 
 
@@ -99,3 +107,4 @@ def test_frontend_role_cannot_write_authz_tables():
 
     if asyncio.run(main()) == "skip":
         pytest.skip("no privilege to CREATE ROLE for the Golden Rule proof")
+

--- a/backend/tests/adversarial/test_golden_rule.py
+++ b/backend/tests/adversarial/test_golden_rule.py
@@ -64,6 +64,22 @@ def test_frontend_role_cannot_write_authz_tables():
             await owner.execute(f"GRANT USAGE ON SCHEMA public TO {FRONTEND}")
             # Frontend gets write access to the Better Auth core tables only.
             for table in CORE_TABLES:
+                if table == "users":
+                    # UPDATE is column-scoped to exclude role: the site-admin
+                    # bit is backend-owned (sso-reconcile applies it), so a
+                    # compromised frontend must not be able to self-promote.
+                    # INSERT stays table-wide — role is legitimately set at
+                    # creation (first-user promotion, SSO mapping).
+                    cols = [r["column_name"] for r in await owner.fetch(
+                        "SELECT column_name FROM information_schema.columns"
+                        " WHERE table_schema = current_schema()"
+                        " AND table_name = 'users' AND column_name <> 'role'")]
+                    quoted = ", ".join(f'"{c}"' for c in cols)
+                    await owner.execute(
+                        f'GRANT SELECT, INSERT, DELETE ON "users" TO {FRONTEND}')
+                    await owner.execute(
+                        f'GRANT UPDATE ({quoted}) ON "users" TO {FRONTEND}')
+                    continue
                 await owner.execute(
                     f'GRANT SELECT, INSERT, UPDATE, DELETE ON "{table}" '
                     f"TO {FRONTEND}")
@@ -81,7 +97,8 @@ def test_frontend_role_cannot_write_authz_tables():
                 finally:
                     await conn.close()
 
-            # Sanity: the frontend role CAN write a core table (users).
+            # Sanity: the frontend role CAN write a core table (users) —
+            # and specifically CANNOT set users.role (the D1-01 vector).
             conn = await asyncpg.connect(os.environ["DATABASE_URL"])
             try:
                 await conn.execute(f"SET ROLE {FRONTEND}")
@@ -92,6 +109,13 @@ def test_frontend_role_cannot_write_authz_tables():
                         "INSERT INTO users (id) VALUES ('u_probe')")
                 assert not isinstance(
                     exc.value, asyncpg.InsufficientPrivilegeError)
+                # Self-promotion must be a privilege error, not a data error.
+                with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                    await conn.execute(
+                        "UPDATE users SET role = 'ADMIN'")
+                # A non-role column update is within the grant (0 rows,
+                # but a privilege failure would raise).
+                await conn.execute("UPDATE users SET name = name WHERE false")
             finally:
                 await conn.close()
         finally:

--- a/docs-site/docs/architecture/organizations.md
+++ b/docs-site/docs/architecture/organizations.md
@@ -74,15 +74,24 @@ enforcement), grant it narrowly:
 
 ```sql
 GRANT USAGE ON SCHEMA public TO vym_frontend;
-GRANT SELECT, INSERT, UPDATE, DELETE ON users, sessions, accounts, verifications
+GRANT SELECT, INSERT, DELETE ON users TO vym_frontend;
+-- UPDATE on users is column-scoped: everything EXCEPT role. The site-admin
+-- bit is backend-owned (/internal/sso-reconcile applies it), so a
+-- compromised frontend cannot self-promote. role is still set at INSERT
+-- (first-user promotion, SSO mapping at creation) — creation-time only.
+GRANT UPDATE (name, email, "emailVerified", image, "createdAt", "updatedAt")
+    ON users TO vym_frontend;
+GRANT SELECT, INSERT, UPDATE, DELETE ON sessions, accounts, verifications
     TO vym_frontend;
 -- No grant on org_memberships / user_instance_roles /
--- user_feature_permissions / organizations: the frontend never writes them.
+-- user_feature_permissions / organizations / oauth_role_mappings / sites /
+-- instances: the frontend never writes them (oauth config and role
+-- mappings write via backend endpoints since #484/#487).
 ```
 
-`oauth_role_mappings` is not yet in the ban — the frontend still writes it via
-the OAuth-config UI; relocating that write to the backend (as the SSO reconcile
-relocation did for grants) is the remaining step before it joins the list.
+Verify the live role after the switch with
+`DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role`,
+which also asserts `users.role` is not updatable.
 
 ## Row-level security (foundation in place, inert)
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -154,12 +154,11 @@ async function buildAuth() {
       : null;
 
     if (existing) {
-      if (resolved.siteRole) {
-        await prisma.user.update({
-          where: { id: existing.id },
-          data: { role: resolved.siteRole },
-        });
-      }
+      // users.role is backend-owned: /internal/sso-reconcile re-derives the
+      // claims from the stored account token and applies the site role
+      // itself. Writing it here too would keep the frontend DB role needing
+      // UPDATE on users.role — the exact privilege the Golden Rule wants
+      // revoked (a compromised frontend could self-promote to ADMIN).
       await reconcileGrants(existing.id);
     } else if (
       email &&


### PR DESCRIPTION
## What
Audit findings D1-04 and D1-05 — the two guardrails Domain 1 leans on had holes that would let a regression through unnoticed.

**Canary (D1-04):** markers were the literals `db_pool.acquire(` and `state.db_pool`, blind to `db.acquire()` on a passed-in Pool (`rbac_permissions._acquire` — a live code path), `pool.acquire()` in `revocation_bus.py`, and the `getattr(x.state, \"db_pool\")` form in the console/monitoring WS handlers. Markers are now any `.acquire(` plus quoted `db_pool` lookups; the four newly-visible files join PERMANENT_GLOBAL with justifications (each reviewed as correct — the guardrail just couldn't see them).

**Golden Rule (D1-05):** `BANNED_TABLES` gains `oauth_role_mappings` (writes relocated to the backend in #484; the docstring still claimed the relocation was pending), `sites` and `instances`. The synthetic-role limitation gets a real answer: `scripts/prove_runtime_role.py` interrogates the actual DATABASE_URL principal via `has_table_privilege` and exits non-zero on any write grant to an authz table or a superuser connection — a flip-runbook step (CI connects as the owner, so this is deliberately a script, not a skipping test, keeping the CI zero-skip gate meaningful).

## Testing
- Canary suite passes locally with the broadened markers (3 tests) — i.e. no unreviewed unscoped acquisition exists today.
- Golden Rule structural test runs in CI (#513) where DATABASE_URL + CREATEROLE exist; the three new banned tables get the same INSERT/UPDATE denial assertions.
- `prove_runtime_role.py` syntax-checked; needs a fenced-role deployment to exercise for real (flip runbook).