### PR TITLE
fix: grant FIREWALL_BRIDGE and FIREWALL_FLOWTABLES on the live paths

### DIFF
--- a/backend/rbac_permissions.py
+++ b/backend/rbac_permissions.py
@@ -543,6 +543,8 @@ _INSTANCE_ADMIN_FEATURES = [
     FeatureGroup.FIREWALL_POLICIES,
     FeatureGroup.FIREWALL_ZONES,
     FeatureGroup.FIREWALL_GLOBAL_OPTIONS,
+    FeatureGroup.FIREWALL_BRIDGE,
+    FeatureGroup.FIREWALL_FLOWTABLES,
     FeatureGroup.NETWORK,
     FeatureGroup.NAT,
     FeatureGroup.NAT64,
@@ -736,6 +738,8 @@ async def get_user_permissions(
                 FeatureGroup.FIREWALL_POLICIES,
                 FeatureGroup.FIREWALL_ZONES,
                 FeatureGroup.FIREWALL_GLOBAL_OPTIONS,
+                FeatureGroup.FIREWALL_BRIDGE,
+                FeatureGroup.FIREWALL_FLOWTABLES,
                 FeatureGroup.NETWORK,
                 FeatureGroup.NAT,
                 FeatureGroup.NAT64,
@@ -1021,7 +1025,8 @@ def _apply_parent_child_permissions(permissions: Dict[FeatureGroup, PermissionLe
     permission to all child features.
 
     Parent-Child relationships:
-    - FIREWALL → FIREWALL_GROUPS, FIREWALL_POLICIES, FIREWALL_ZONES
+    - FIREWALL → FIREWALL_GROUPS, FIREWALL_POLICIES, FIREWALL_ZONES,
+                 FIREWALL_GLOBAL_OPTIONS, FIREWALL_BRIDGE, FIREWALL_FLOWTABLES
     - NETWORK → INTERFACES, DHCP, VRF, LOAD_BALANCING, NAT
     - VPN → IPSEC, WIREGUARD
     - ROUTING → UNICAST_PROTOCOLS
@@ -1037,7 +1042,7 @@ def _apply_parent_child_permissions(permissions: Dict[FeatureGroup, PermissionLe
     firewall_perm = permissions.get(FeatureGroup.FIREWALL, PermissionLevel.NONE)
     if firewall_perm != PermissionLevel.NONE:
         # Grant parent permission to children if they don't have a higher permission
-        for child in [FeatureGroup.FIREWALL_GROUPS, FeatureGroup.FIREWALL_POLICIES, FeatureGroup.FIREWALL_ZONES, FeatureGroup.FIREWALL_GLOBAL_OPTIONS]:
+        for child in [FeatureGroup.FIREWALL_GROUPS, FeatureGroup.FIREWALL_POLICIES, FeatureGroup.FIREWALL_ZONES, FeatureGroup.FIREWALL_GLOBAL_OPTIONS, FeatureGroup.FIREWALL_BRIDGE, FeatureGroup.FIREWALL_FLOWTABLES]:
             current = permissions.get(child, PermissionLevel.NONE)
             # Only upgrade permission, never downgrade
             if firewall_perm == PermissionLevel.WRITE:

--- a/backend/tests/test_rbac_firewall_children.py
+++ b/backend/tests/test_rbac_firewall_children.py
@@ -1,0 +1,42 @@
+"""FIREWALL_BRIDGE / FIREWALL_FLOWTABLES must sit on the live grant paths.
+
+Both groups gate their routers, but they only appeared in the dead
+BUILT_IN_PERMISSIONS dicts — so any non-site-ADMIN (instance-ADMIN
+grant, org ADMIN/OWNER under enforcement, FIREWALL=WRITE operator)
+resolved them to NONE and got a hard 403 on the whole bridge-firewall
+and flowtables pages (audit finding, Domain 2 Medium).
+"""
+
+from rbac_permissions import (
+    FeatureGroup,
+    PermissionLevel,
+    _INSTANCE_ADMIN_FEATURES,
+    _apply_parent_child_permissions,
+)
+
+CHILDREN = [FeatureGroup.FIREWALL_BRIDGE, FeatureGroup.FIREWALL_FLOWTABLES]
+
+
+def all_none():
+    return {feature: PermissionLevel.NONE for feature in FeatureGroup}
+
+
+def test_firewall_write_propagates_to_bridge_and_flowtables():
+    permissions = all_none()
+    permissions[FeatureGroup.FIREWALL] = PermissionLevel.WRITE
+    _apply_parent_child_permissions(permissions)
+    for child in CHILDREN:
+        assert permissions[child] == PermissionLevel.WRITE, child
+
+
+def test_firewall_read_propagates_to_bridge_and_flowtables():
+    permissions = all_none()
+    permissions[FeatureGroup.FIREWALL] = PermissionLevel.READ
+    _apply_parent_child_permissions(permissions)
+    for child in CHILDREN:
+        assert permissions[child] == PermissionLevel.READ, child
+
+
+def test_instance_admin_gets_bridge_and_flowtables():
+    for child in CHILDREN:
+        assert child in _INSTANCE_ADMIN_FEATURES, child


### PR DESCRIPTION
## What
`FIREWALL_BRIDGE` and `FIREWALL_FLOWTABLES` gate their routers but were missing from every live grant path — `_INSTANCE_ADMIN_FEATURES`, the org-admin full-access list, and the `FIREWALL` parent→child propagation (they only existed in the dead `BUILT_IN_PERMISSIONS` dicts). Result: any non-site-ADMIN resolved both groups to NONE → hard 403 on the whole bridge firewall and flowtables pages. Fail-closed under-grant, same defect class as the #428 interface-group fix.

## Testing
- New `tests/test_rbac_firewall_children.py`: FIREWALL WRITE/READ propagates to both children; both are in the instance-ADMIN feature list (3 tests).
- Existing `test_rbac_interface_groups.py` still green (propagation logic shared).
- Full backend suite passes.