### PR TITLE
fix: middleware polling-endpoint typo and silent session-resolution failure

### DIFF
--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -56,7 +56,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
     # These are background polling endpoints - not real user activity
     POLLING_ENDPOINTS = {
         "/vyos/config/diff",
-        "/vyos/config/snapshots",
+        "/vyos/config/snapshot",
         "/session/current",
         "/vyos/power/status",  # Polls for scheduled reboot/poweroff status
         "/vyos/events/banners",  # SSE stream - long-lived connection

--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -6,12 +6,17 @@ This middleware runs after AuthenticationMiddleware and makes the active
 instance available to all route handlers.
 """
 
+import logging
+
 from fastapi import Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 import asyncpg
 from typing import Optional
 from session_cookie import verify_session_cookie
+
+
+logger = logging.getLogger(__name__)
 
 
 class _SecureStr:
@@ -311,8 +316,12 @@ class SessionMiddleware(BaseHTTPMiddleware):
                     request.state.site = None
                     request.state.org = None
 
-        except Exception as e:
-            # Error resolving active session - set to None and continue
+        except Exception:
+            # Session resolution failed (e.g. transient DB error). Continue
+            # with no active instance, but never silently: downstream this
+            # surfaces as a spurious "no active instance" 400, and without
+            # the log line the real cause is invisible.
+            logger.exception("Active-session resolution failed; continuing without an instance")
             request.state.instance = None
             request.state.site = None
             request.state.org = None


### PR DESCRIPTION
## What
Two Domain-2 audit findings in the middleware layer:

1. **Inactivity timeout defeated by a typo:** `POLLING_ENDPOINTS` in `middleware/auth.py` listed `/vyos/config/snapshots` (plural); the real route is `/vyos/config/snapshot` (`config.py:160`). Background snapshot polling therefore bumped `lastActivityAt`, and the idle-logout janitor keyed on that column — a tab left open kept the auth session alive indefinitely. #451 fixed this string in `session.py` but missed `auth.py`.
2. **Silent session-resolution failure:** `SessionMiddleware` caught every exception during active-session resolution, bound the unused variable, and continued with instance/site/org = None — no log line. A transient DB error looked identical to "user has no active instance". Now logged via `logger.exception`; behavior stays fail-closed.

## Testing
Full backend suite passes. The polling fix is a one-string change matching the verified route; the logging change is observability-only.