### PR TITLE
fix: don't hold a DB transaction across the connect reachability test

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -238,6 +238,20 @@ async def org_conn_admin(
         yield conn
 
 
+@asynccontextmanager
+async def org_unit_of_work(
+    request: Request,
+    requested_org_id: Optional[str] = None,
+) -> AsyncIterator[asyncpg.Connection]:
+    """Explicit org-scoped unit of work for handlers that cannot hold one
+    transaction across their whole body — e.g. /session/connect, whose
+    reachability test is a blocking network call that must not pin a
+    pooled connection idle-in-transaction. Same context derivation as
+    org_conn_admin; open one per unit of work instead of per handler."""
+    async with _handler_conn(request, requested_org_id) as conn:
+        yield conn
+
+
 def _ws_pool(websocket) -> asyncpg.Pool:
     pool = getattr(websocket.app.state, "db_pool", None)
     if pool is None:

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -385,7 +385,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
         # Unit of work 2: record the active session (short transaction,
         # opened only after the device answered).
         async with org_unit_of_work(request) as conn:
-            result = await conn.execute(
+            await conn.execute(
                 """
                 INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
                 VALUES ($1, $2, $3, $4, NOW())

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -7,7 +7,7 @@ Handles connect/disconnect operations and instance selection.
 
 from fastapi import Depends, APIRouter, HTTPException, Request, UploadFile, File, Form
 import org_scope
-from org_scope import assert_row_in_acting_org, org_conn_admin, org_conn_self
+from org_scope import assert_row_in_acting_org, org_conn_admin, org_conn_self, org_unit_of_work
 from starlette.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -267,7 +267,7 @@ async def get_current_session(request: Request, conn: asyncpg.Connection = Depen
 
 
 @router.post("/connect", response_model=ApiResponse)
-async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
+async def connect_to_instance(request: Request, body: ConnectRequest):
     """
     Connect to a specific VyOS instance.
 
@@ -283,52 +283,57 @@ async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyn
     instance_id = body.instance_id
 
     try:
-        # Check if user is site-level ADMIN
-        user_site_role = await conn.fetchval(
-            """
-            SELECT role FROM users WHERE id = $1
-            """,
-            user_id
-        )
+        # Unit of work 1: permission check + instance read. Deliberately
+        # NOT one handler-wide transaction: the reachability test below
+        # is a blocking network call and must not pin a pooled
+        # connection idle-in-transaction.
+        async with org_unit_of_work(request) as conn:
+            # Check if user is site-level ADMIN
+            user_site_role = await conn.fetchval(
+                """
+                SELECT role FROM users WHERE id = $1
+                """,
+                user_id
+            )
 
-        # Site ADMIN users can access any instance
-        # Other users need explicit instance-level permissions
-        if user_site_role == "ADMIN":
-            # ADMIN can access any instance - no instance role check needed
-            instance = await conn.fetchrow(
-                """
-                SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                       i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
-                       s.name as site_name,
-                       'ADMIN' as role
-                FROM instances i
-                JOIN sites s ON i."siteId" = s.id
-                WHERE i.id = $1
-                """,
-                instance_id,
-            )
-        else:
-            # VIEWER users need explicit instance-level role assignment
-            instance = await conn.fetchrow(
-                """
-                SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                       i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
-                       s.name as site_name,
-                       uir.role as role
-                FROM instances i
-                JOIN sites s ON i."siteId" = s.id
-                JOIN user_instance_roles uir
-                    ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
-                    AND uir."userId" = $1
-                WHERE i.id = $2
-                ORDER BY CASE uir.role
-                    WHEN 'ADMIN' THEN 3 WHEN 'OPERATOR' THEN 2 WHEN 'VIEWER' THEN 1 ELSE 0
-                END DESC
-                LIMIT 1
-                """,
-                user_id,
-                instance_id,
-            )
+            # Site ADMIN users can access any instance
+            # Other users need explicit instance-level permissions
+            if user_site_role == "ADMIN":
+                # ADMIN can access any instance - no instance role check needed
+                instance = await conn.fetchrow(
+                    """
+                    SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
+                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
+                           s.name as site_name,
+                           'ADMIN' as role
+                    FROM instances i
+                    JOIN sites s ON i."siteId" = s.id
+                    WHERE i.id = $1
+                    """,
+                    instance_id,
+                )
+            else:
+                # VIEWER users need explicit instance-level role assignment
+                instance = await conn.fetchrow(
+                    """
+                    SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
+                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
+                           s.name as site_name,
+                           uir.role as role
+                    FROM instances i
+                    JOIN sites s ON i."siteId" = s.id
+                    JOIN user_instance_roles uir
+                        ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
+                        AND uir."userId" = $1
+                    WHERE i.id = $2
+                    ORDER BY CASE uir.role
+                        WHEN 'ADMIN' THEN 3 WHEN 'OPERATOR' THEN 2 WHEN 'VIEWER' THEN 1 ELSE 0
+                    END DESC
+                    LIMIT 1
+                    """,
+                    user_id,
+                    instance_id,
+                )
 
         if not instance:
             raise HTTPException(
@@ -377,18 +382,21 @@ async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyn
         alphabet = string.ascii_letters + string.digits
         session_id = ''.join(secrets.choice(alphabet) for _ in range(32))
 
-        result = await conn.execute(
-            """
-            INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
-            VALUES ($1, $2, $3, $4, NOW())
-            ON CONFLICT ("userId")
-            DO UPDATE SET "instanceId" = $3, "sessionToken" = $4, "connectedAt" = NOW()
-            """,
-            session_id,
-            user_id,
-            instance_id,
-            current_session_token,
-        )
+        # Unit of work 2: record the active session (short transaction,
+        # opened only after the device answered).
+        async with org_unit_of_work(request) as conn:
+            result = await conn.execute(
+                """
+                INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
+                VALUES ($1, $2, $3, $4, NOW())
+                ON CONFLICT ("userId")
+                DO UPDATE SET "instanceId" = $3, "sessionToken" = $4, "connectedAt" = NOW()
+                """,
+                session_id,
+                user_id,
+                instance_id,
+                current_session_token,
+            )
 
         return ApiResponse(
             success=True,


### PR DESCRIPTION
## What
Audit finding (Domain 2, Medium): `/session/connect` performed the blocking `get_full_config` reachability test inside the `org_conn_admin` whole-handler transaction, holding a pooled connection idle-in-transaction for up to the device timeout — pool-exhaustion risk under load / unreachable devices, and a regression against the org_scope design rule ("one unit of work, one conn; nothing held across VyOS calls").

## How
New public `org_scope.org_unit_of_work(request)` context manager (thin wrapper over the same `_handler_conn` core the `org_conn`/`org_conn_admin` dependencies use, so context derivation is identical). The handler now runs:
1. Unit of work 1 — role check + instance/grant read.
2. Reachability test — **no DB connection held**.
3. Unit of work 2 — short transaction for the `active_sessions` upsert, only after the device answered.

Same queries, same status codes, same response body.

## Testing
- Full backend suite passes (108 + DB-gated in CI).
- The org-context algebra is unchanged — both units derive context exactly as `org_conn_admin` did.
- Worth a live connect/disconnect smoke test against a real instance on staging.