### PR TITLE
fix: version-gating corrections in the mapper/builder layer

### DIFF
--- a/backend/routers/isis/isis.py
+++ b/backend/routers/isis/isis.py
@@ -302,6 +302,8 @@ async def isis_batch_configure(http_request: Request, body: IsisBatchRequest):
         )
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {e}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/ospf/ospf.py
+++ b/backend/routers/ospf/ospf.py
@@ -699,6 +699,8 @@ async def ospf_batch_configure(http_request: Request, body: OspfBatchRequest):
         )
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tests/test_mapper_version_gating.py
+++ b/backend/tests/test_mapper_version_gating.py
@@ -1,0 +1,54 @@
+"""Version-gating corrections from the 2026-07-09 audit (Domain 2).
+
+- IS-IS 1.4 mapper: 1.5-only options must raise, not silently no-op —
+  a direct API call setting TI-LFA on a 1.4 device used to return
+  success while applying nothing.
+- OSPF builder: redistribute nhrp is 1.5-only and must be rejected on
+  1.4 instead of emitting an invalid path.
+- ethernet/zones factories: version selection must substring-match like
+  every other factory, not silently fall back to 1.5 on "1.4.0".
+"""
+
+import pytest
+
+from vyos_builders.ospf.ospf_batch_builder import OspfBatchBuilder
+from vyos_mappers.firewall.zones_versions import get_firewall_zones_mapper
+from vyos_mappers.interfaces.ethernet_versions import get_ethernet_mapper
+from vyos_mappers.isis.isis_versions.v1_4 import IsisMapperV1_4
+
+
+def test_isis_v14_rejects_ti_lfa_instead_of_silent_noop():
+    mapper = IsisMapperV1_4()
+    with pytest.raises(ValueError, match="1.5"):
+        mapper.get_interface_ti_lfa_path("eth0")
+    with pytest.raises(ValueError, match="1.5"):
+        mapper.get_sr_srv6_locator_path("LOC1")
+    with pytest.raises(ValueError, match="1.5"):
+        mapper.get_te_export_path()
+
+
+def test_ospf_14_rejects_redistribute_nhrp():
+    builder = OspfBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_redistribute("nhrp")
+    # supported protocols still pass through
+    builder.set_redistribute("bgp")
+    assert builder.get_operations()
+
+
+def test_ospf_15_allows_redistribute_nhrp():
+    builder = OspfBatchBuilder(version="1.5")
+    builder.set_redistribute("nhrp")
+    assert builder.get_operations()[-1]["path"][-1] == "nhrp"
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.4.0", "1.4.4 sagitta"])
+def test_factories_substring_match_14(version):
+    assert type(get_ethernet_mapper(version)).__name__ == "EthernetMapper_v1_4"
+    assert type(get_firewall_zones_mapper(version)).__name__ == "FirewallZonesMapper_v1_4"
+
+
+@pytest.mark.parametrize("version", ["1.5", "1.5.0", "2025.rolling"])
+def test_factories_default_to_15(version):
+    assert type(get_ethernet_mapper(version)).__name__ == "EthernetMapper_v1_5"
+    assert type(get_firewall_zones_mapper(version)).__name__ == "FirewallZonesMapper_v1_5"

--- a/backend/vyos_builders/ospf/ospf_batch_builder.py
+++ b/backend/vyos_builders/ospf/ospf_batch_builder.py
@@ -287,16 +287,29 @@ class OspfBatchBuilder:
     # Redistribute
     # ========================================================================
 
+    # Protocols that only exist as redistribute sources from VyOS 1.5.
+    _V15_ONLY_REDISTRIBUTE = frozenset({"nhrp"})
+
+    def _check_redistribute_supported(self, protocol: str) -> None:
+        if protocol in self._V15_ONLY_REDISTRIBUTE and "1.4" in self.version:
+            raise ValueError(
+                f"redistribute {protocol} requires VyOS 1.5+. "
+                "Current device is running v1.4")
+
     def set_redistribute(self, protocol: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute(protocol))
 
     def set_redistribute_metric(self, protocol: str, value: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute_metric(protocol, value))
 
     def set_redistribute_metric_type(self, protocol: str, value: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute_metric_type(protocol, value))
 
     def set_redistribute_route_map(self, protocol: str, value: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute_route_map(protocol, value))
 
     def delete_redistribute(self, protocol: str) -> "OspfBatchBuilder":

--- a/backend/vyos_mappers/firewall/zones_versions/__init__.py
+++ b/backend/vyos_mappers/firewall/zones_versions/__init__.py
@@ -23,13 +23,11 @@ def get_firewall_zones_mapper(version: str) -> "FirewallZonesMapper":
     from .v1_4 import FirewallZonesMapper_v1_4
     from .v1_5 import FirewallZonesMapper_v1_5
 
-    version_map = {
-        "1.4": FirewallZonesMapper_v1_4,
-        "1.5": FirewallZonesMapper_v1_5,
-    }
-
-    mapper_class = version_map.get(version, FirewallZonesMapper_v1_5)
-    return mapper_class(version)
+    # Substring match like every other factory: exact-key lookup silently
+    # fell back to the 1.5 mapper for strings like "1.4.0" or "sagitta".
+    if "1.4" in version:
+        return FirewallZonesMapper_v1_4(version)
+    return FirewallZonesMapper_v1_5(version)
 
 
 __all__ = ["get_firewall_zones_mapper"]

--- a/backend/vyos_mappers/interfaces/ethernet_versions/__init__.py
+++ b/backend/vyos_mappers/interfaces/ethernet_versions/__init__.py
@@ -27,15 +27,11 @@ def get_ethernet_mapper(version: str) -> "EthernetInterfaceMapper":
     from .v1_4 import EthernetMapper_v1_4
     from .v1_5 import EthernetMapper_v1_5
 
-    version_map = {
-        "1.4": EthernetMapper_v1_4,
-        "1.5": EthernetMapper_v1_5,
-    }
-
-    # Get mapper class for version, fallback to latest (1.5) for unknown versions
-    mapper_class = version_map.get(version, EthernetMapper_v1_5)
-
-    return mapper_class(version)
+    # Substring match like every other factory: exact-key lookup silently
+    # fell back to the 1.5 mapper for strings like "1.4.0" or "sagitta".
+    if "1.4" in version:
+        return EthernetMapper_v1_4(version)
+    return EthernetMapper_v1_5(version)
 
 
 __all__ = ["get_ethernet_mapper"]

--- a/backend/vyos_mappers/isis/isis_versions/v1_4.py
+++ b/backend/vyos_mappers/isis/isis_versions/v1_4.py
@@ -7,61 +7,65 @@ VyOS 1.4 does NOT support:
   - SRv6 locator (segment-routing srv6)
   - Traffic Engineering export
 
-All v1.5-only methods return [] so builder.add_set([]) becomes a no-op.
+All v1.5-only methods raise ValueError: silently dropping the operation
+returned success while applying nothing (a false-positive the audit
+flagged); the router surfaces the error as a 400.
 """
 
 from typing import List
+
+_V15_ONLY = "This IS-IS option requires VyOS 1.5+. Current device is running v1.4"
 
 
 class IsisMapperV1_4:
     # TI-LFA — not supported
     def get_interface_ti_lfa_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level1_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level1_node_protection_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level1_link_fallback_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level2_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level2_node_protection_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level2_link_fallback_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     # Remote LFA — not supported
     def get_interface_remote_lfa_level1_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level1_max_metric_path(self, iface: str, val: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level1_tunnel_mpls_ldp_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level2_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level2_max_metric_path(self, iface: str, val: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level2_tunnel_mpls_ldp_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     # SRv6 — not supported
     def get_sr_srv6_locator_path(self, locator: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_sr_srv6_path(self) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     # TE export — not supported
     def get_te_export_path(self) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)


### PR DESCRIPTION
## What
Three Domain-2 audit findings of the same shape:

1. **IS-IS silent no-op (Medium):** the 1.4 mapper returned `[]` for TI-LFA / remote-LFA / SRv6 / TE-export paths and the builder's `if path:` guard dropped them — success returned, nothing applied. Now raises `ValueError`; the IS-IS and OSPF batch endpoints convert it to a 400 (same convention as ethernet/groups/NAT).
2. **OSPF `redistribute nhrp` on 1.4 (Low):** emitted through the generic redistribute path regardless of version; nhrp is 1.5-only. The builder now rejects it on 1.4 (`_V15_ONLY_REDISTRIBUTE`).
3. **Factory exact-key version match (Low, latent):** ethernet and firewall-zones factories used `version_map.get(version, v1_5)` unlike every other factory's substring match — `"1.4.0"` or `"1.4.4 sagitta"` would silently get the 1.5 mapper. Masked today by the `Literal["1.4","1.5"]` typing in config_loader; now substring-matched.

## Testing
- New `tests/test_mapper_version_gating.py` (9 tests): IS-IS 1.4 raises, OSPF 1.4 rejects nhrp / 1.5 allows / other protocols unaffected, factories pick v1_4 for `1.4.0`-style strings and default to v1_5 otherwise.
- Full backend suite passes.