### PR TITLE
fix: savepoint replace-mode restore rows like merge mode

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -1656,12 +1656,12 @@ async def restore_backup(
                 sql = _build_insert(table, columns, types, merge=(mode == "merge"))
 
                 try:
-                    if mode == "merge":
-                        # Row-level savepoint so a natural-key collision skips
-                        # just this row instead of aborting the whole restore.
-                        async with conn.transaction():
-                            was_inserted = await conn.fetchval(sql, *values)
-                    else:
+                    # Row-level savepoint so a natural-key collision skips
+                    # just this row instead of poisoning the outer
+                    # transaction (without it, replace mode turned one
+                    # duplicate into InFailedSQLTransaction 500s for every
+                    # following row).
+                    async with conn.transaction():
                         was_inserted = await conn.fetchval(sql, *values)
                 except asyncpg.UniqueViolationError:
                     skipped += 1


### PR DESCRIPTION
## What
Audit finding (Domain 2, Low): replace-mode restore inserts were not wrapped in a per-row savepoint (merge mode's were). A backup containing duplicate natural keys aborted the whole transaction on the first `UniqueViolationError`, and following rows raised `InFailedSQLTransactionError` — uncaught → 500 + full rollback, instead of the intended per-row skip.

## How
Both modes now run each row inside `conn.transaction()` (a savepoint under the outer restore transaction) with the same `UniqueViolationError → skipped` accounting. No behavior change for clean backups.

## Testing
Full backend suite passes; restore roundtrip covered by `test_backup_safety` in CI. Triggering the exact failure needs a corrupted backup with duplicate natural keys — the code path is now identical to the already-proven merge branch.