### PR TITLE
fix: harden the unauthenticated onboarding surface

### DIFF
--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -37,10 +37,12 @@ router = APIRouter(prefix="/session", tags=["session"])
 
 
 class OnboardingStatusResponse(BaseModel):
-    """Response indicating if system needs onboarding."""
+    """Response indicating if system needs onboarding.
+
+    Public pre-auth endpoint: deliberately only the boolean — the exact
+    user count is unauthenticated info disclosure."""
 
     needs_onboarding: bool
-    user_count: int
 
 
 class SiteResponse(BaseModel):
@@ -195,7 +197,6 @@ async def get_onboarding_status(request: Request, conn: asyncpg.Connection = Dep
 
         return OnboardingStatusResponse(
             needs_onboarding=user_count == 0,
-            user_count=user_count
         )
     except Exception as e:
         logger.exception("Unhandled error")

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -40921,19 +40921,14 @@
           "needs_onboarding": {
             "type": "boolean",
             "title": "Needs Onboarding"
-          },
-          "user_count": {
-            "type": "integer",
-            "title": "User Count"
           }
         },
         "type": "object",
         "required": [
-          "needs_onboarding",
-          "user_count"
+          "needs_onboarding"
         ],
         "title": "OnboardingStatusResponse",
-        "description": "Response indicating if system needs onboarding."
+        "description": "Response indicating if system needs onboarding.\n\nPublic pre-auth endpoint: deliberately only the boolean \u2014 the exact\nuser count is unauthenticated info disclosure."
       },
       "OpenfabricBatchOperation": {
         "properties": {

--- a/frontend/src/app/api/auth/[...all]/route.ts
+++ b/frontend/src/app/api/auth/[...all]/route.ts
@@ -85,6 +85,17 @@ export async function POST(request: NextRequest) {
             { status: 403 }
           );
         }
+      } else if (!allowOnboardingFailOpen) {
+        // A non-2xx answer must fail closed like a network error —
+        // otherwise any backend hiccup reopens registration.
+        return NextResponse.json(
+          {
+            error: {
+              message: "Unable to verify onboarding status. Please try again later.",
+            },
+          },
+          { status: 503 }
+        );
       }
     } catch (err) {
       console.error("[Auth] Error checking onboarding status:", err);


### PR DESCRIPTION
## What
Two related audit findings (Domain 1, Low) on the pre-auth surface:

1. **Signup gate fail-open on non-2xx:** the `/sign-up` gate in `app/api/auth/[...all]/route.ts` blocked registration only when `/session/onboarding-status` returned 2xx; a 500/503/404 skipped both the block and the `catch` (network errors only) and let signup proceed. Impact was bounded (new accounts are VIEWER) but the gate now fails closed on any non-ok answer, with the existing `ALLOW_ONBOARDING_FAIL_OPEN` escape hatch preserved.
2. **User-count disclosure:** public `/session/onboarding-status` returned the exact `user_count` to anonymous callers. Every consumer (login page, onboarding wizard, signup gate) reads only `needs_onboarding`, so the field is gone. OpenAPI spec regenerated (the `.mdx` API pages were deliberately not regenerated — the generator churns all 400+ pages; the committed spec is what CI diffs).

## Testing
- Full backend suite passes; frontend typechecks clean.
- docs-openapi-check CI validates the regenerated spec on this PR.