### PR TITLE
fix: close the org-existence oracle and small revocation/WS gaps

### DIFF
--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -119,9 +119,9 @@ async def _resolve_admin_org(
             ' WHERE "userId" = $1 AND "orgId" = $2',
             user["id"], requested_org_id)
         if not member:
-            raise HTTPException(
-                status_code=403,
-                detail="You are not a member of this organization")
+            # Same 404 as a nonexistent org: a 403 here was an existence
+            # oracle (non-members could enumerate valid org ids).
+            raise HTTPException(status_code=404, detail="Organization not found")
     return requested_org_id
 
 
@@ -144,8 +144,10 @@ async def _handler_conn(
             # org-scoped tables (org_memberships) to find WHO/WHERE before org
             # context exists. Under FORCE RLS as the fenced role those reads
             # would be denied, so run them with a temporary operator bypass.
-            # The real context is set below; the derivation queries are
-            # userId-scoped, so the bypass cannot leak another user's rows.
+            # The real context is set below. The derivation queries are
+            # userId-scoped except the org-existence check, whose only
+            # signal (404 for nonexistent AND non-member orgs alike) does
+            # not distinguish existence — no oracle.
             await conn.execute(
                 "SELECT set_config('app.is_system_admin', 'true', true)")
 
@@ -267,6 +269,13 @@ async def ws_org_conn(
     org context, and yields. A WS holds a long-lived SSH stream, so — like the
     /vyos permission path — it must take short scoped connections per unit of
     work, never hold one across the stream.
+
+    CONTRACT: instance_id must be SERVER-derived (the caller's
+    active_sessions row), never a client-supplied value — the org context
+    is derived from it under the bootstrap bypass with no membership
+    check, so a client-chosen id would set app.org_id to a foreign org.
+    Both current callers (monitoring/console WS) satisfy this; a future
+    caller passing a client value must add a grant check first.
     """
     pool = _ws_pool(websocket)
     async with pool.acquire() as conn:

--- a/backend/routers/tokens/tokens.py
+++ b/backend/routers/tokens/tokens.py
@@ -189,8 +189,9 @@ async def revoke_token(request: Request, token_id: str, conn: asyncpg.Connection
     if int(result.split()[-1]) == 0:
         raise HTTPException(status_code=404, detail="Token not found or already revoked")
 
-    # Same transaction as the revoke: close the owner's live streams at once.
-    await revocation_bus.emit(conn, "token", token_id)
+    # Same transaction as the revoke: close the owner's live streams at
+    # once. A single user-scoped emit suffices — payload_matches has no
+    # token branch, so a token-scoped emit matched nothing (dead).
     await revocation_bus.emit(conn, "user", user["id"])
 
     logger.info("API token revoked for user %s (id=%s)", user["id"], token_id)

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -36,9 +36,11 @@ def test_member_cannot_connect_to_foreign_org_instance(adversarial_world):
 
 
 def test_explicit_org_param_rejects_non_members(adversarial_world):
+    # Uniform 404 (same as a nonexistent org) so org ids cannot be
+    # enumerated by non-members.
     response = as_user(adversarial_world, "a_member").get(
         "/session/sites", params={"org_id": IDS["org_b"]})
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_explicit_org_param_rejects_unknown_org(adversarial_world):


### PR DESCRIPTION
## What
Three Domain-1 Low findings:

1. **Org-existence oracle:** `GET /session/sites?org_id=X` answered 403 for a real org you're not in vs 404 for a fake one — enumerable. Non-members now receive the identical 404. The adversarial test asserting the old 403 is updated to pin the uniform 404 (`test_explicit_org_param_rejects_non_members`).
2. **Dead token revocation payload:** `DELETE /tokens/{id}` emitted `token:<id>`, which `payload_matches` has no branch for — matched nothing. The `user:<id>` emit in the same transaction is what actually closes the owner's streams; the dead emit is dropped rather than growing a new branch (streams don't track token ids, and owner-wide closure is the intended semantics).
3. **ws_org_conn contract:** its org derivation runs under the bootstrap bypass with no membership check — safe only while `instance_id` is server-derived (both WS callers pass the `active_sessions` value). The docstring now states that contract explicitly, and the `_handler_conn` bootstrap comment no longer overclaims that every derivation query is userId-scoped.

## Testing
- Adversarial suite updated for the uniform 404; runs in CI with DB.
- Full backend suite passes.