### PR TITLE
fix: users.role is backend-owned — drop the frontend UPDATE path

### DIFF
--- a/backend/scripts/prove_runtime_role.py
+++ b/backend/scripts/prove_runtime_role.py
@@ -61,6 +61,15 @@ async def main() -> int:
                     break
                 if allowed:
                     failures.append(f"role has {privilege} on {table}")
+
+        # The D1-01 vector: UPDATE on users.role lets a compromised
+        # frontend self-promote to site ADMIN.
+        role_update = await conn.fetchval(
+            "SELECT has_column_privilege(current_user, 'users', 'role',"
+            " 'UPDATE')")
+        if role_update:
+            failures.append(
+                "role can UPDATE users.role — frontend self-promotion open")
     finally:
         await conn.close()
 

--- a/backend/tests/adversarial/test_golden_rule.py
+++ b/backend/tests/adversarial/test_golden_rule.py
@@ -64,6 +64,22 @@ def test_frontend_role_cannot_write_authz_tables():
             await owner.execute(f"GRANT USAGE ON SCHEMA public TO {FRONTEND}")
             # Frontend gets write access to the Better Auth core tables only.
             for table in CORE_TABLES:
+                if table == "users":
+                    # UPDATE is column-scoped to exclude role: the site-admin
+                    # bit is backend-owned (sso-reconcile applies it), so a
+                    # compromised frontend must not be able to self-promote.
+                    # INSERT stays table-wide — role is legitimately set at
+                    # creation (first-user promotion, SSO mapping).
+                    cols = [r["column_name"] for r in await owner.fetch(
+                        "SELECT column_name FROM information_schema.columns"
+                        " WHERE table_schema = current_schema()"
+                        " AND table_name = 'users' AND column_name <> 'role'")]
+                    quoted = ", ".join(f'"{c}"' for c in cols)
+                    await owner.execute(
+                        f'GRANT SELECT, INSERT, DELETE ON "users" TO {FRONTEND}')
+                    await owner.execute(
+                        f'GRANT UPDATE ({quoted}) ON "users" TO {FRONTEND}')
+                    continue
                 await owner.execute(
                     f'GRANT SELECT, INSERT, UPDATE, DELETE ON "{table}" '
                     f"TO {FRONTEND}")
@@ -81,7 +97,8 @@ def test_frontend_role_cannot_write_authz_tables():
                 finally:
                     await conn.close()
 
-            # Sanity: the frontend role CAN write a core table (users).
+            # Sanity: the frontend role CAN write a core table (users) —
+            # and specifically CANNOT set users.role (the D1-01 vector).
             conn = await asyncpg.connect(os.environ["DATABASE_URL"])
             try:
                 await conn.execute(f"SET ROLE {FRONTEND}")
@@ -92,6 +109,13 @@ def test_frontend_role_cannot_write_authz_tables():
                         "INSERT INTO users (id) VALUES ('u_probe')")
                 assert not isinstance(
                     exc.value, asyncpg.InsufficientPrivilegeError)
+                # Self-promotion must be a privilege error, not a data error.
+                with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                    await conn.execute(
+                        "UPDATE users SET role = 'ADMIN'")
+                # A non-role column update is within the grant (0 rows,
+                # but a privilege failure would raise).
+                await conn.execute("UPDATE users SET name = name WHERE false")
             finally:
                 await conn.close()
         finally:

--- a/docs-site/docs/architecture/organizations.md
+++ b/docs-site/docs/architecture/organizations.md
@@ -74,15 +74,24 @@ enforcement), grant it narrowly:
 
 ```sql
 GRANT USAGE ON SCHEMA public TO vym_frontend;
-GRANT SELECT, INSERT, UPDATE, DELETE ON users, sessions, accounts, verifications
+GRANT SELECT, INSERT, DELETE ON users TO vym_frontend;
+-- UPDATE on users is column-scoped: everything EXCEPT role. The site-admin
+-- bit is backend-owned (/internal/sso-reconcile applies it), so a
+-- compromised frontend cannot self-promote. role is still set at INSERT
+-- (first-user promotion, SSO mapping at creation) — creation-time only.
+GRANT UPDATE (name, email, "emailVerified", image, "createdAt", "updatedAt")
+    ON users TO vym_frontend;
+GRANT SELECT, INSERT, UPDATE, DELETE ON sessions, accounts, verifications
     TO vym_frontend;
 -- No grant on org_memberships / user_instance_roles /
--- user_feature_permissions / organizations: the frontend never writes them.
+-- user_feature_permissions / organizations / oauth_role_mappings / sites /
+-- instances: the frontend never writes them (oauth config and role
+-- mappings write via backend endpoints since #484/#487).
 ```
 
-`oauth_role_mappings` is not yet in the ban — the frontend still writes it via
-the OAuth-config UI; relocating that write to the backend (as the SSO reconcile
-relocation did for grants) is the remaining step before it joins the list.
+Verify the live role after the switch with
+`DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role`,
+which also asserts `users.role` is not updatable.
 
 ## Row-level security (foundation in place, inert)
 

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -154,12 +154,11 @@ async function buildAuth() {
       : null;
 
     if (existing) {
-      if (resolved.siteRole) {
-        await prisma.user.update({
-          where: { id: existing.id },
-          data: { role: resolved.siteRole },
-        });
-      }
+      // users.role is backend-owned: /internal/sso-reconcile re-derives the
+      // claims from the stored account token and applies the site role
+      // itself. Writing it here too would keep the frontend DB role needing
+      // UPDATE on users.role — the exact privilege the Golden Rule wants
+      // revoked (a compromised frontend could self-promote to ADMIN).
       await reconcileGrants(existing.id);
     } else if (
       email &&


### PR DESCRIPTION
**Stacked on #515** (extends the same Golden Rule proof file and runtime script) — merge #515 first, then retarget/merge this.

## What
Audit D1-01 (High): site-ADMIN is defined solely as `users.role == 'ADMIN'`, and `auth.ts` still wrote that column directly via Prisma on every SSO login of an existing user. `/internal/sso-reconcile` has applied the site role server-side (re-derived from the stored account token) since #468 — the frontend write was redundant, and it is the one legitimate use that forced the frontend DB role to keep `UPDATE` on `users.role`, i.e. the self-promotion privilege.

## How
- `auth.ts`: existing-user SSO path no longer writes `users.role`; it only calls `reconcileGrants`, and the backend applies the role.
- Golden Rule structural proof: synthetic frontend role now has column-scoped UPDATE on `users` (everything except `role`); new assertions — `UPDATE users SET role='ADMIN'` is a privilege error, non-role UPDATE and INSERT still pass.
- `scripts/prove_runtime_role.py`: also checks `has_column_privilege(current_user, 'users', 'role', 'UPDATE')` on the real deployment role.
- Organizations arch doc: `vym_frontend` grant block updated to the column-scoped form (and the stale `oauth_role_mappings` paragraph corrected — relocated in #484).

**Deliberately kept in the frontend:** creation-time role (first-user ADMIN promotion in `user.create.before`, SSO-mapped role on the initial INSERT). Both are INSERT-time and survive the `UPDATE(role)` revoke; moving INSERT-time assignment behind the backend needs the Better-Auth hook-timing work flagged in #468 and is not required to close the self-promotion vector.

## Testing
- Full backend suite green locally; the extended Golden Rule proof runs in CI with DB + CREATEROLE.
- Frontend typechecks clean.
- **Owner verify on live IdP:** an existing SSO user whose IdP group changes should still get the new site role on next login (now applied only by the backend reconcile — same path #468 verified, but please re-confirm since the frontend fallback write is gone).