### PR TITLE
fix: verify stored SSO id_tokens against the provider JWKS

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,4 +13,5 @@ passlib==1.7.4
 email-validator==2.3.0
 asyncssh==2.23.0
 cryptography==48.0.1
+PyJWT==2.10.1
 tzdata==2026.2

--- a/backend/routers/internal/sso_reconcile.py
+++ b/backend/routers/internal/sso_reconcile.py
@@ -13,12 +13,22 @@ auth.ts reconcileGrants, with claim extraction moved server-side.
 
 import base64
 import json
+import logging
 import os
 from typing import Any, Dict, List, Optional
 
 import asyncpg
 from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel
+
+from sso_jwt_verify import (
+    TokenInvalid,
+    VerificationUnavailable,
+    require_verification,
+    verified_claims,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
@@ -247,14 +257,43 @@ async def sso_reconcile(
             for acc in accounts:
                 provider = await conn.fetchrow(
                     'SELECT "providerId", enabled, "roleMappingEnabled",'
-                    ' "groupsClaim" FROM oauth_providers'
+                    ' "groupsClaim", "discoveryUrl", "clientId"'
+                    ' FROM oauth_providers'
                     ' WHERE "providerId" = $1 AND enabled = true',
                     acc["providerId"])
                 if not provider or not provider["roleMappingEnabled"]:
                     continue
 
                 claim_name = provider["groupsClaim"] or DEFAULT_GROUPS_CLAIM
-                claims = _decode_jwt_claims(acc["idToken"] or "")
+                # Verify the stored id_token against the provider's JWKS
+                # before trusting its groups: accounts is frontend-writable,
+                # so an unverified decode would let a planted token mint
+                # grants (audit D1-03).
+                try:
+                    claims = await verified_claims(
+                        acc["idToken"] or "",
+                        provider["discoveryUrl"],
+                        provider["clientId"])
+                except TokenInvalid as e:
+                    # A token that FAILS verification is never trusted —
+                    # skip this provider entirely (no grant changes).
+                    logger.warning(
+                        "sso-reconcile: id_token for provider %s failed "
+                        "verification (%s); skipping", acc["providerId"], e)
+                    continue
+                except VerificationUnavailable as e:
+                    if require_verification():
+                        logger.warning(
+                            "sso-reconcile: verification unavailable for "
+                            "provider %s (%s) and "
+                            "VYMANAGER_SSO_REQUIRE_JWT_VERIFY=1; skipping",
+                            acc["providerId"], e)
+                        continue
+                    logger.info(
+                        "sso-reconcile: verification unavailable for "
+                        "provider %s (%s); using unverified claims",
+                        acc["providerId"], e)
+                    claims = _decode_jwt_claims(acc["idToken"] or "")
                 claim_values = extract_claim_values(claims, claim_name)
 
                 rules = [dict(r) for r in await conn.fetch(

--- a/backend/sso_jwt_verify.py
+++ b/backend/sso_jwt_verify.py
@@ -1,0 +1,137 @@
+"""JWKS verification for stored SSO id_tokens (audit D1-03).
+
+The sso-reconcile endpoint derives group claims from the id_token stored
+in the Better-Auth ``accounts`` table. That table is frontend-writable,
+so a compromised frontend holding the internal secret could plant a
+forged token and mint grants. When the provider has a ``discoveryUrl``,
+we verify the token's signature against the provider's JWKS plus its
+``iss``/``aud``/``exp`` claims before trusting it.
+
+Failure semantics (deliberate asymmetry):
+
+- The token is INVALID (bad signature, wrong issuer/audience, expired)
+  → ``TokenInvalid``: the caller must skip reconciliation for this
+  provider — falling back to the unverified decode would defeat the
+  check.
+- Verification is UNAVAILABLE (no discoveryUrl, discovery/JWKS fetch
+  failed) → ``VerificationUnavailable``: the caller may fall back to the
+  legacy unverified decode (and log), unless
+  ``VYMANAGER_SSO_REQUIRE_JWT_VERIFY=1`` makes that fail closed too.
+"""
+
+import os
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+import jwt
+
+# Asymmetric algorithms only: the JWKS flow hands us public keys, and
+# accepting an HMAC alg here would let a forged token be "signed" with a
+# public value.
+ALLOWED_ALGORITHMS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512",
+                      "PS256", "PS384", "PS512"]
+
+_CACHE_TTL_SECONDS = 3600.0
+
+# discovery_url -> (fetched_at, discovery_doc)
+_discovery_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+# jwks_uri -> (fetched_at, jwks)
+_jwks_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
+
+class TokenInvalid(Exception):
+    """The id_token failed verification — do not trust it."""
+
+
+class VerificationUnavailable(Exception):
+    """Verification could not be attempted (no discovery/JWKS reachable)."""
+
+
+def require_verification() -> bool:
+    return os.getenv("VYMANAGER_SSO_REQUIRE_JWT_VERIFY") == "1"
+
+
+async def _fetch_json(url: str) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+async def _cached_fetch(cache: Dict[str, Tuple[float, Dict[str, Any]]],
+                        url: str) -> Dict[str, Any]:
+    now = time.monotonic()
+    hit = cache.get(url)
+    if hit and now - hit[0] < _CACHE_TTL_SECONDS:
+        return hit[1]
+    try:
+        doc = await _fetch_json(url)
+    except Exception as e:
+        if hit:  # serve stale rather than failing on a transient blip
+            return hit[1]
+        raise VerificationUnavailable(f"fetch failed for {url}: {e}") from e
+    cache[url] = (now, doc)
+    return doc
+
+
+def _key_for(jwks: Dict[str, Any], kid: Optional[str]):
+    keys = jwks.get("keys") or []
+    for key in keys:
+        if kid is None or key.get("kid") == kid:
+            return jwt.PyJWK(key).key
+    return None
+
+
+async def verified_claims(
+    id_token: str,
+    discovery_url: Optional[str],
+    client_id: Optional[str],
+) -> Dict[str, Any]:
+    """Verify the id_token against the provider's JWKS and return claims.
+
+    Raises TokenInvalid when the token fails verification and
+    VerificationUnavailable when verification cannot be attempted.
+    """
+    if not id_token:
+        raise TokenInvalid("empty id_token")
+    if not discovery_url:
+        raise VerificationUnavailable("provider has no discoveryUrl")
+
+    discovery = await _cached_fetch(_discovery_cache, discovery_url)
+    jwks_uri = discovery.get("jwks_uri")
+    issuer = discovery.get("issuer")
+    if not jwks_uri:
+        raise VerificationUnavailable("discovery document has no jwks_uri")
+
+    try:
+        header = jwt.get_unverified_header(id_token)
+    except jwt.InvalidTokenError as e:
+        raise TokenInvalid(f"malformed token: {e}") from e
+
+    jwks = await _cached_fetch(_jwks_cache, jwks_uri)
+    key = _key_for(jwks, header.get("kid"))
+    if key is None:
+        # An unknown kid usually means key rotation: refetch once.
+        _jwks_cache.pop(jwks_uri, None)
+        jwks = await _cached_fetch(_jwks_cache, jwks_uri)
+        key = _key_for(jwks, header.get("kid"))
+    if key is None:
+        raise TokenInvalid(f"no JWKS key matches kid {header.get('kid')!r}")
+
+    try:
+        return jwt.decode(
+            id_token,
+            key=key,
+            algorithms=ALLOWED_ALGORITHMS,
+            audience=client_id if client_id else None,
+            issuer=issuer if issuer else None,
+            options={
+                "require": ["exp"],
+                "verify_aud": bool(client_id),
+                "verify_iss": bool(issuer),
+            },
+            leeway=60,
+        )
+    except jwt.InvalidTokenError as e:
+        raise TokenInvalid(str(e)) from e

--- a/backend/tests/test_sso_jwt_verify.py
+++ b/backend/tests/test_sso_jwt_verify.py
@@ -1,0 +1,135 @@
+"""JWKS verification of stored SSO id_tokens (audit D1-03). No DB needed.
+
+Generates a real RSA keypair, serves discovery/JWKS from monkeypatched
+fetches, and proves: a properly signed token passes; a tampered or
+expired token, a wrong audience, and an HMAC downgrade are rejected as
+TokenInvalid (never falling back); missing discovery is
+VerificationUnavailable (legacy fallback allowed unless the strict env
+flag is set).
+"""
+
+import asyncio
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import sso_jwt_verify
+from sso_jwt_verify import (
+    TokenInvalid,
+    VerificationUnavailable,
+    verified_claims,
+)
+
+ISSUER = "https://idp.test"
+CLIENT_ID = "vymanager-client"
+DISCOVERY_URL = "https://idp.test/.well-known/openid-configuration"
+JWKS_URI = "https://idp.test/jwks"
+
+
+@pytest.fixture()
+def idp(monkeypatch):
+    """A fake IdP: RSA key, discovery doc and JWKS served from memory."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = jwt.algorithms.RSAAlgorithm.to_jwk(
+        private_key.public_key(), as_dict=True)
+    public_jwk["kid"] = "test-key"
+    public_jwk["alg"] = "RS256"
+
+    documents = {
+        DISCOVERY_URL: {"issuer": ISSUER, "jwks_uri": JWKS_URI},
+        JWKS_URI: {"keys": [public_jwk]},
+    }
+
+    async def fake_fetch(url):
+        if url not in documents:
+            raise VerificationUnavailable(f"fetch failed for {url}")
+        return documents[url]
+
+    monkeypatch.setattr(sso_jwt_verify, "_fetch_json", fake_fetch)
+    sso_jwt_verify._discovery_cache.clear()
+    sso_jwt_verify._jwks_cache.clear()
+
+    def make_token(**overrides):
+        claims = {
+            "iss": ISSUER,
+            "aud": CLIENT_ID,
+            "exp": int(time.time()) + 300,
+            "sub": "user-1",
+            "groups": ["netops"],
+        }
+        claims.update(overrides)
+        return jwt.encode(
+            claims, private_key, algorithm="RS256",
+            headers={"kid": "test-key"})
+
+    return make_token
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def test_valid_token_yields_claims(idp):
+    claims = _run(verified_claims(idp(), DISCOVERY_URL, CLIENT_ID))
+    assert claims["groups"] == ["netops"]
+
+
+def test_tampered_token_is_invalid(idp):
+    token = idp()
+    header, payload, signature = token.split(".")
+    forged = f"{header}.{payload[:-2]}AA.{signature}"
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(forged, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_expired_token_is_invalid(idp):
+    token = idp(exp=int(time.time()) - 3600)
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(token, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_wrong_audience_is_invalid(idp):
+    token = idp(aud="someone-else")
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(token, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_wrong_issuer_is_invalid(idp):
+    token = idp(iss="https://evil.test")
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(token, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_hmac_downgrade_is_invalid(idp):
+    # A token HMAC-"signed" with public material must not verify: only
+    # asymmetric algorithms are accepted.
+    forged = jwt.encode(
+        {"iss": ISSUER, "aud": CLIENT_ID, "exp": int(time.time()) + 300},
+        "not-a-real-key", algorithm="HS256", headers={"kid": "test-key"})
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(forged, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_missing_discovery_is_unavailable_not_invalid(idp):
+    with pytest.raises(VerificationUnavailable):
+        _run(verified_claims(idp(), None, CLIENT_ID))
+
+
+def test_unreachable_jwks_is_unavailable(idp, monkeypatch):
+    async def down(url):
+        raise VerificationUnavailable(f"fetch failed for {url}")
+
+    monkeypatch.setattr(sso_jwt_verify, "_fetch_json", down)
+    sso_jwt_verify._discovery_cache.clear()
+    sso_jwt_verify._jwks_cache.clear()
+    with pytest.raises(VerificationUnavailable):
+        _run(verified_claims(idp(), DISCOVERY_URL, CLIENT_ID))
+
+
+def test_strict_mode_flag(monkeypatch):
+    monkeypatch.delenv("VYMANAGER_SSO_REQUIRE_JWT_VERIFY", raising=False)
+    assert sso_jwt_verify.require_verification() is False
+    monkeypatch.setenv("VYMANAGER_SSO_REQUIRE_JWT_VERIFY", "1")
+    assert sso_jwt_verify.require_verification() is True


### PR DESCRIPTION
## What
Audit D1-03 (Medium): `/internal/sso-reconcile` derived group claims from `accounts.idToken` with a plain base64 decode — no signature/exp/iss/aud verification. `accounts` is frontend-writable, so a compromised frontend (which holds the internal secret) could plant a forged id_token and mint instance grants.

## How
New `backend/sso_jwt_verify.py`:
- Resolves the provider's `discoveryUrl` → discovery doc → `jwks_uri` (1 h in-memory cache; serves stale on transient fetch failure; refetches once on unknown `kid` to handle key rotation).
- `jwt.decode` with signature + `iss` (discovery issuer) + `aud` (provider `clientId`) + `exp` (60 s leeway). **Asymmetric algorithms only** — an HS256 downgrade token "signed" with public material is rejected.
- Two failure classes with different handling in the reconcile loop:
  - `TokenInvalid` (bad signature / iss / aud / exp) → **skip the provider, no grant changes, never fall back**.
  - `VerificationUnavailable` (no `discoveryUrl`, JWKS unreachable with cold cache) → legacy unverified decode + log, so manual-URL providers keep working; `VYMANAGER_SSO_REQUIRE_JWT_VERIFY=1` makes this fail closed too.

Adds `PyJWT==2.10.1` (pure-Python; `cryptography` was already a dependency).

## Testing
- New `tests/test_sso_jwt_verify.py` (9 tests, no DB): real RSA keypair + fake IdP — valid passes; tampered/expired/wrong-aud/wrong-iss/HMAC-downgrade all `TokenInvalid`; missing discovery and unreachable JWKS are `VerificationUnavailable`; strict-flag behavior.
- Existing `test_sso_reconcile.py` (forged-body claims, auth) unchanged and green in CI — providers there have no `discoveryUrl`, exercising the compat fallback.
- **Not verified against a live IdP here** — worth one live login on staging (Authentik/Keycloak both publish discovery + JWKS).