### PR TITLE
Integrate audit fixes #511–#528 (conflicts resolved, DB suite verified)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,103 @@
+name: Backend Tests
+
+# Runs the backend pytest suite against a real Postgres with the Prisma
+# schema applied, so the DB-gated security tests (adversarial suite, RLS,
+# Golden Rule, revocation bus, audit coverage, ...) actually execute
+# instead of skipping silently. A second pass fails the build if any
+# security test was collected but skipped — a vacuously green suite is
+# treated as a failure.
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'frontend/prisma/**'
+      - '.github/workflows/backend-tests.yml'
+  push:
+    branches:
+      - beta
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: vymanager_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # The CI role is the postgres superuser, so the CREATEROLE-gated
+      # tests (RLS proof, Golden Rule) run too.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/vymanager_test
+      BETTER_AUTH_SECRET: ci-only-test-secret
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Matches the backend production image (python:3.11-slim)
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Set up Node (Prisma CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Apply Prisma migrations
+        run: npx --yes prisma@6 migrate deploy --schema frontend/prisma/schema.prisma
+
+      - name: Run backend test suite
+        working-directory: backend
+        run: python -m pytest tests -q
+
+      - name: Security tests must have run (no silent skips)
+        working-directory: backend
+        run: |
+          python -m pytest \
+            tests/adversarial \
+            tests/test_rls.py \
+            tests/test_org_admin.py \
+            tests/test_org_scope.py \
+            tests/test_revocation_bus.py \
+            tests/test_audit_coverage.py \
+            tests/test_sso_reconcile.py \
+            tests/test_backup_safety.py \
+            tests/test_organizations_endpoint.py \
+            -q -rs --junit-xml=security-report.xml
+          python - <<'EOF'
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("security-report.xml").getroot()
+          suite = root if root.tag == "testsuite" else root.find("testsuite")
+          tests = int(suite.get("tests", 0))
+          skipped = int(suite.get("skipped", 0))
+          print(f"security tests: {tests} collected, {skipped} skipped")
+          if tests == 0:
+              raise SystemExit("no security tests were collected")
+          if skipped:
+              raise SystemExit(
+                  "security tests were skipped — the suite passed vacuously. "
+                  "Check DATABASE_URL/migrations in this workflow."
+              )
+          EOF

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -67,6 +67,15 @@ jobs:
       - name: Apply Prisma migrations
         run: npx --yes prisma@6 migrate deploy --schema frontend/prisma/schema.prisma
 
+      - name: Capture permission golden file
+        # The golden harness is capture-then-compare; a fresh CI database
+        # has no pre-upgrade snapshot, so capture one first — the suite's
+        # compare pass then proves the harness itself works.
+        working-directory: backend
+        env:
+          GOLDEN_PERMISSIONS_MODE: capture
+        run: python -m pytest tests/test_permission_golden.py -q
+
       - name: Run backend test suite
         working-directory: backend
         run: python -m pytest tests -q

--- a/backend/app.py
+++ b/backend/app.py
@@ -115,6 +115,7 @@ from routers import version as version_router
 from routers import events as events_router
 from routers.events import start_poller, stop_poller
 import revocation_bus
+from schema_gate import wait_for_schema
 
 # Global variables
 db_pool: Optional[asyncpg.Pool] = None
@@ -210,6 +211,10 @@ async def lifespan(app: FastAPI):
         database_url = os.getenv("DATABASE_URL")
         if not database_url:
             raise ValueError("DATABASE_URL environment variable is required")
+
+        # Migrations run in the frontend container; don't serve requests
+        # against a half-migrated schema (bounded wait, see schema_gate).
+        await wait_for_schema(database_url)
 
         db_pool = await asyncpg.create_pool(
             database_url,

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -56,7 +56,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
     # These are background polling endpoints - not real user activity
     POLLING_ENDPOINTS = {
         "/vyos/config/diff",
-        "/vyos/config/snapshots",
+        "/vyos/config/snapshot",
         "/session/current",
         "/vyos/power/status",  # Polls for scheduled reboot/poweroff status
         "/vyos/events/banners",  # SSE stream - long-lived connection

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -13,7 +13,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 from datetime import datetime
 import asyncpg
-from session_cookie import verify_session_cookie
+from session_cookie import get_session_cookie, verify_session_cookie
 from api_token_crypto import hash_api_token, looks_like_api_token
 
 logger = logging.getLogger(__name__)
@@ -183,10 +183,9 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             # A non-vym Bearer credential falls through to cookie handling below.
 
         # Extract session token from cookie
-        session_token = request.cookies.get("better-auth.session_token")
-        session_token2 = request.cookies.get("__Secure-better-auth.session_token")
+        session_token = get_session_cookie(request)
 
-        if not session_token and not session_token2:
+        if not session_token:
             if optional_auth:
                 return await call_next(request)
             return JSONResponse(
@@ -197,7 +196,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": "Bearer"},
             )
 
-        token_to_use = session_token if session_token else session_token2
+        token_to_use = session_token
 
         try:
             # Better-auth uses signed session cookies: {session_id}.{base64(HMAC-SHA256)}

--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -6,12 +6,17 @@ This middleware runs after AuthenticationMiddleware and makes the active
 instance available to all route handlers.
 """
 
+import logging
+
 from fastapi import Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 import asyncpg
 from typing import Optional
 from session_cookie import get_session_cookie, verify_session_cookie
+
+
+logger = logging.getLogger(__name__)
 
 
 class _SecureStr:
@@ -311,8 +316,12 @@ class SessionMiddleware(BaseHTTPMiddleware):
                     request.state.site = None
                     request.state.org = None
 
-        except Exception as e:
-            # Error resolving active session - set to None and continue
+        except Exception:
+            # Session resolution failed (e.g. transient DB error). Continue
+            # with no active instance, but never silently: downstream this
+            # surfaces as a spurious "no active instance" 400, and without
+            # the log line the real cause is invisible.
+            logger.exception("Active-session resolution failed; continuing without an instance")
             request.state.instance = None
             request.state.site = None
             request.state.org = None

--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -11,7 +11,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 import asyncpg
 from typing import Optional
-from session_cookie import verify_session_cookie
+from session_cookie import get_session_cookie, verify_session_cookie
 
 
 class _SecureStr:
@@ -84,7 +84,7 @@ class SessionMiddleware(BaseHTTPMiddleware):
 
     async def _resolve_cookie_instance(self, conn, request: Request, path: str, user_id: str, user_site_role):
         """Resolve the user's single active instance from active_sessions (browser cookie flow)."""
-        cookie_token = request.cookies.get("better-auth.session_token")
+        cookie_token = get_session_cookie(request)
         current_session_token = verify_session_cookie(cookie_token) if cookie_token else None
 
         # Site ADMINs don't need user_instance_roles entries - they get ADMIN role automatically

--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -119,9 +119,9 @@ async def _resolve_admin_org(
             ' WHERE "userId" = $1 AND "orgId" = $2',
             user["id"], requested_org_id)
         if not member:
-            raise HTTPException(
-                status_code=403,
-                detail="You are not a member of this organization")
+            # Same 404 as a nonexistent org: a 403 here was an existence
+            # oracle (non-members could enumerate valid org ids).
+            raise HTTPException(status_code=404, detail="Organization not found")
     return requested_org_id
 
 
@@ -144,8 +144,10 @@ async def _handler_conn(
             # org-scoped tables (org_memberships) to find WHO/WHERE before org
             # context exists. Under FORCE RLS as the fenced role those reads
             # would be denied, so run them with a temporary operator bypass.
-            # The real context is set below; the derivation queries are
-            # userId-scoped, so the bypass cannot leak another user's rows.
+            # The real context is set below. The derivation queries are
+            # userId-scoped except the org-existence check, whose only
+            # signal (404 for nonexistent AND non-member orgs alike) does
+            # not distinguish existence — no oracle.
             await conn.execute(
                 "SELECT set_config('app.is_system_admin', 'true', true)")
 
@@ -281,6 +283,13 @@ async def ws_org_conn(
     org context, and yields. A WS holds a long-lived SSH stream, so — like the
     /vyos permission path — it must take short scoped connections per unit of
     work, never hold one across the stream.
+
+    CONTRACT: instance_id must be SERVER-derived (the caller's
+    active_sessions row), never a client-supplied value — the org context
+    is derived from it under the bootstrap bypass with no membership
+    check, so a client-chosen id would set app.org_id to a foreign org.
+    Both current callers (monitoring/console WS) satisfy this; a future
+    caller passing a client value must add a grant check first.
     """
     pool = _ws_pool(websocket)
     async with pool.acquire() as conn:

--- a/backend/org_scope.py
+++ b/backend/org_scope.py
@@ -238,6 +238,20 @@ async def org_conn_admin(
         yield conn
 
 
+@asynccontextmanager
+async def org_unit_of_work(
+    request: Request,
+    requested_org_id: Optional[str] = None,
+) -> AsyncIterator[asyncpg.Connection]:
+    """Explicit org-scoped unit of work for handlers that cannot hold one
+    transaction across their whole body — e.g. /session/connect, whose
+    reachability test is a blocking network call that must not pin a
+    pooled connection idle-in-transaction. Same context derivation as
+    org_conn_admin; open one per unit of work instead of per handler."""
+    async with _handler_conn(request, requested_org_id) as conn:
+        yield conn
+
+
 def _ws_pool(websocket) -> asyncpg.Pool:
     pool = getattr(websocket.app.state, "db_pool", None)
     if pool is None:

--- a/backend/rbac_permissions.py
+++ b/backend/rbac_permissions.py
@@ -543,6 +543,8 @@ _INSTANCE_ADMIN_FEATURES = [
     FeatureGroup.FIREWALL_POLICIES,
     FeatureGroup.FIREWALL_ZONES,
     FeatureGroup.FIREWALL_GLOBAL_OPTIONS,
+    FeatureGroup.FIREWALL_BRIDGE,
+    FeatureGroup.FIREWALL_FLOWTABLES,
     FeatureGroup.NETWORK,
     FeatureGroup.NAT,
     FeatureGroup.NAT64,
@@ -736,6 +738,8 @@ async def get_user_permissions(
                 FeatureGroup.FIREWALL_POLICIES,
                 FeatureGroup.FIREWALL_ZONES,
                 FeatureGroup.FIREWALL_GLOBAL_OPTIONS,
+                FeatureGroup.FIREWALL_BRIDGE,
+                FeatureGroup.FIREWALL_FLOWTABLES,
                 FeatureGroup.NETWORK,
                 FeatureGroup.NAT,
                 FeatureGroup.NAT64,
@@ -1021,7 +1025,8 @@ def _apply_parent_child_permissions(permissions: Dict[FeatureGroup, PermissionLe
     permission to all child features.
 
     Parent-Child relationships:
-    - FIREWALL → FIREWALL_GROUPS, FIREWALL_POLICIES, FIREWALL_ZONES
+    - FIREWALL → FIREWALL_GROUPS, FIREWALL_POLICIES, FIREWALL_ZONES,
+                 FIREWALL_GLOBAL_OPTIONS, FIREWALL_BRIDGE, FIREWALL_FLOWTABLES
     - NETWORK → INTERFACES, DHCP, VRF, LOAD_BALANCING, NAT
     - VPN → IPSEC, WIREGUARD
     - ROUTING → UNICAST_PROTOCOLS
@@ -1037,7 +1042,7 @@ def _apply_parent_child_permissions(permissions: Dict[FeatureGroup, PermissionLe
     firewall_perm = permissions.get(FeatureGroup.FIREWALL, PermissionLevel.NONE)
     if firewall_perm != PermissionLevel.NONE:
         # Grant parent permission to children if they don't have a higher permission
-        for child in [FeatureGroup.FIREWALL_GROUPS, FeatureGroup.FIREWALL_POLICIES, FeatureGroup.FIREWALL_ZONES, FeatureGroup.FIREWALL_GLOBAL_OPTIONS]:
+        for child in [FeatureGroup.FIREWALL_GROUPS, FeatureGroup.FIREWALL_POLICIES, FeatureGroup.FIREWALL_ZONES, FeatureGroup.FIREWALL_GLOBAL_OPTIONS, FeatureGroup.FIREWALL_BRIDGE, FeatureGroup.FIREWALL_FLOWTABLES]:
             current = permissions.get(child, PermissionLevel.NONE)
             # Only upgrade permission, never downgrade
             if firewall_perm == PermissionLevel.WRITE:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,4 +13,5 @@ passlib==1.7.4
 email-validator==2.3.0
 asyncssh==2.23.0
 cryptography==48.0.1
+PyJWT==2.10.1
 tzdata==2026.2

--- a/backend/routers/internal/sso_reconcile.py
+++ b/backend/routers/internal/sso_reconcile.py
@@ -13,12 +13,22 @@ auth.ts reconcileGrants, with claim extraction moved server-side.
 
 import base64
 import json
+import logging
 import os
 from typing import Any, Dict, List, Optional
 
 import asyncpg
 from fastapi import APIRouter, Header, HTTPException, Request
 from pydantic import BaseModel
+
+from sso_jwt_verify import (
+    TokenInvalid,
+    VerificationUnavailable,
+    require_verification,
+    verified_claims,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
@@ -247,14 +257,43 @@ async def sso_reconcile(
             for acc in accounts:
                 provider = await conn.fetchrow(
                     'SELECT "providerId", enabled, "roleMappingEnabled",'
-                    ' "groupsClaim" FROM oauth_providers'
+                    ' "groupsClaim", "discoveryUrl", "clientId"'
+                    ' FROM oauth_providers'
                     ' WHERE "providerId" = $1 AND enabled = true',
                     acc["providerId"])
                 if not provider or not provider["roleMappingEnabled"]:
                     continue
 
                 claim_name = provider["groupsClaim"] or DEFAULT_GROUPS_CLAIM
-                claims = _decode_jwt_claims(acc["idToken"] or "")
+                # Verify the stored id_token against the provider's JWKS
+                # before trusting its groups: accounts is frontend-writable,
+                # so an unverified decode would let a planted token mint
+                # grants (audit D1-03).
+                try:
+                    claims = await verified_claims(
+                        acc["idToken"] or "",
+                        provider["discoveryUrl"],
+                        provider["clientId"])
+                except TokenInvalid as e:
+                    # A token that FAILS verification is never trusted —
+                    # skip this provider entirely (no grant changes).
+                    logger.warning(
+                        "sso-reconcile: id_token for provider %s failed "
+                        "verification (%s); skipping", acc["providerId"], e)
+                    continue
+                except VerificationUnavailable as e:
+                    if require_verification():
+                        logger.warning(
+                            "sso-reconcile: verification unavailable for "
+                            "provider %s (%s) and "
+                            "VYMANAGER_SSO_REQUIRE_JWT_VERIFY=1; skipping",
+                            acc["providerId"], e)
+                        continue
+                    logger.info(
+                        "sso-reconcile: verification unavailable for "
+                        "provider %s (%s); using unverified claims",
+                        acc["providerId"], e)
+                    claims = _decode_jwt_claims(acc["idToken"] or "")
                 claim_values = extract_claim_values(claims, claim_name)
 
                 rules = [dict(r) for r in await conn.fetch(

--- a/backend/routers/isis/isis.py
+++ b/backend/routers/isis/isis.py
@@ -302,6 +302,8 @@ async def isis_batch_configure(http_request: Request, body: IsisBatchRequest):
         )
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {e}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/organizations/organizations.py
+++ b/backend/routers/organizations/organizations.py
@@ -263,10 +263,19 @@ async def add_member(
 
 
 async def _would_orphan_owner(
-    conn: asyncpg.Connection, organization_id: str, user_id: str
+    conn: asyncpg.Connection,
+    organization_id: str,
+    user_id: str,
+    removing: bool = False,
 ) -> bool:
-    """True if the user is the only OWNER while other members remain — the org
-    would be left with members but no owner."""
+    """True if the operation would leave members with no OWNER.
+
+    Invariant: any remaining member implies at least one owner. Demoting
+    the sole OWNER always violates it (they remain as an owner-less
+    member — the old member_count > 1 boundary let a solo owner demote
+    themselves into exactly that state). Removing the sole OWNER only
+    violates it while other members remain; removing the last member
+    empties the org, which is valid."""
     is_owner = await conn.fetchval(
         'SELECT 1 FROM org_memberships WHERE "orgId" = $1 AND "userId" = $2'
         ' AND "orgRole" = \'OWNER\'',
@@ -280,10 +289,15 @@ async def _would_orphan_owner(
         " WHERE \"orgId\" = $1 AND \"orgRole\" = 'OWNER'",
         organization_id,
     )
-    member_count = await conn.fetchval(
-        'SELECT COUNT(*) FROM org_memberships WHERE "orgId" = $1', organization_id
-    )
-    return owner_count == 1 and member_count > 1
+    if owner_count > 1:
+        return False
+    if removing:
+        member_count = await conn.fetchval(
+            'SELECT COUNT(*) FROM org_memberships WHERE "orgId" = $1',
+            organization_id,
+        )
+        return member_count > 1
+    return True
 
 
 @router.patch("/{organization_id}/members/{user_id}")
@@ -335,7 +349,7 @@ async def remove_member(
         user_id,
     ):
         raise HTTPException(status_code=404, detail="Membership not found")
-    if await _would_orphan_owner(conn, organization_id, user_id):
+    if await _would_orphan_owner(conn, organization_id, user_id, removing=True):
         raise HTTPException(
             status_code=409,
             detail="Organization must keep at least one owner",

--- a/backend/routers/ospf/ospf.py
+++ b/backend/routers/ospf/ospf.py
@@ -699,6 +699,8 @@ async def ospf_batch_configure(http_request: Request, body: OspfBatchRequest):
         )
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/segment_routing/segment_routing.py
+++ b/backend/routers/segment_routing/segment_routing.py
@@ -186,6 +186,10 @@ async def segment_routing_batch_configure(http_request: Request, body: SegmentRo
         builder = SegmentRoutingBatchBuilder(version=service.get_version())
 
         for operation in body.operations:
+            if operation.op.startswith("_"):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid operation: {operation.op}")
             method = getattr(builder, operation.op)
             sig = inspect.signature(method)
             params = [p for p in sig.parameters.keys() if p != "self"]
@@ -193,14 +197,22 @@ async def segment_routing_batch_configure(http_request: Request, body: SegmentRo
             if len(params) == 0:
                 method()
             elif len(params) == 1:
-                if operation.value is not None:
-                    method(operation.value)
-            elif len(params) == 2 and operation.value is not None:
-                values = operation.value.split(",", 1)
-                if len(values) == 2:
-                    method(values[0], values[1])
-                else:
-                    method(operation.value, "")
+                if operation.value is None:
+                    # Silently skipping used to make the batch report
+                    # success while applying fewer ops than requested.
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Operation {operation.op} requires a value")
+                method(operation.value)
+            elif len(params) == 2:
+                values = (operation.value or "").split(",", 1)
+                if len(values) != 2 or not values[0] or not values[1]:
+                    # Padding with "" built broken paths like `hmac ""`.
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Operation {operation.op} requires two "
+                               'comma-separated values')
+                method(values[0], values[1])
 
         response = service.execute_batch(builder)
 
@@ -209,6 +221,8 @@ async def segment_routing_batch_configure(http_request: Request, body: SegmentRo
             data={"message": "Segment Routing configuration updated"},
             error=response.error if response.error else None,
         )
+    except HTTPException:
+        raise
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
     except Exception:

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -385,7 +385,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest):
         # Unit of work 2: record the active session (short transaction,
         # opened only after the device answered).
         async with org_unit_of_work(request) as conn:
-            result = await conn.execute(
+            await conn.execute(
                 """
                 INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
                 VALUES ($1, $2, $3, $4, NOW())

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -37,10 +37,12 @@ router = APIRouter(prefix="/session", tags=["session"])
 
 
 class OnboardingStatusResponse(BaseModel):
-    """Response indicating if system needs onboarding."""
+    """Response indicating if system needs onboarding.
+
+    Public pre-auth endpoint: deliberately only the boolean — the exact
+    user count is unauthenticated info disclosure."""
 
     needs_onboarding: bool
-    user_count: int
 
 
 class SiteResponse(BaseModel):
@@ -195,7 +197,6 @@ async def get_onboarding_status(request: Request, conn: asyncpg.Connection = Dep
 
         return OnboardingStatusResponse(
             needs_onboarding=user_count == 0,
-            user_count=user_count
         )
     except Exception as e:
         logger.exception("Unhandled error")

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -7,7 +7,7 @@ Handles connect/disconnect operations and instance selection.
 
 from fastapi import Depends, APIRouter, HTTPException, Request, UploadFile, File, Form
 import org_scope
-from org_scope import assert_row_in_acting_org, org_conn_admin, org_conn_self
+from org_scope import assert_row_in_acting_org, org_conn_admin, org_conn_self, org_unit_of_work
 from starlette.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -267,7 +267,7 @@ async def get_current_session(request: Request, conn: asyncpg.Connection = Depen
 
 
 @router.post("/connect", response_model=ApiResponse)
-async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyncpg.Connection = Depends(org_conn_admin)):
+async def connect_to_instance(request: Request, body: ConnectRequest):
     """
     Connect to a specific VyOS instance.
 
@@ -283,52 +283,57 @@ async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyn
     instance_id = body.instance_id
 
     try:
-        # Check if user is site-level ADMIN
-        user_site_role = await conn.fetchval(
-            """
-            SELECT role FROM users WHERE id = $1
-            """,
-            user_id
-        )
+        # Unit of work 1: permission check + instance read. Deliberately
+        # NOT one handler-wide transaction: the reachability test below
+        # is a blocking network call and must not pin a pooled
+        # connection idle-in-transaction.
+        async with org_unit_of_work(request) as conn:
+            # Check if user is site-level ADMIN
+            user_site_role = await conn.fetchval(
+                """
+                SELECT role FROM users WHERE id = $1
+                """,
+                user_id
+            )
 
-        # Site ADMIN users can access any instance
-        # Other users need explicit instance-level permissions
-        if user_site_role == "ADMIN":
-            # ADMIN can access any instance - no instance role check needed
-            instance = await conn.fetchrow(
-                """
-                SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                       i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
-                       s.name as site_name,
-                       'ADMIN' as role
-                FROM instances i
-                JOIN sites s ON i."siteId" = s.id
-                WHERE i.id = $1
-                """,
-                instance_id,
-            )
-        else:
-            # VIEWER users need explicit instance-level role assignment
-            instance = await conn.fetchrow(
-                """
-                SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
-                       i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
-                       s.name as site_name,
-                       uir.role as role
-                FROM instances i
-                JOIN sites s ON i."siteId" = s.id
-                JOIN user_instance_roles uir
-                    ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
-                    AND uir."userId" = $1
-                WHERE i.id = $2
-                ORDER BY CASE uir.role
-                    WHEN 'ADMIN' THEN 3 WHEN 'OPERATOR' THEN 2 WHEN 'VIEWER' THEN 1 ELSE 0
-                END DESC
-                LIMIT 1
-                """,
-                user_id,
-                instance_id,
-            )
+            # Site ADMIN users can access any instance
+            # Other users need explicit instance-level permissions
+            if user_site_role == "ADMIN":
+                # ADMIN can access any instance - no instance role check needed
+                instance = await conn.fetchrow(
+                    """
+                    SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
+                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
+                           s.name as site_name,
+                           'ADMIN' as role
+                    FROM instances i
+                    JOIN sites s ON i."siteId" = s.id
+                    WHERE i.id = $1
+                    """,
+                    instance_id,
+                )
+            else:
+                # VIEWER users need explicit instance-level role assignment
+                instance = await conn.fetchrow(
+                    """
+                    SELECT i.id, i.name, i.host, i.port, i."siteId", i."isActive",
+                           i."apiKey", i.protocol, i."verifySsl", i."vyosVersion", i.timeout,
+                           s.name as site_name,
+                           uir.role as role
+                    FROM instances i
+                    JOIN sites s ON i."siteId" = s.id
+                    JOIN user_instance_roles uir
+                        ON (uir."instanceId" = i.id OR uir."siteId" = i."siteId")
+                        AND uir."userId" = $1
+                    WHERE i.id = $2
+                    ORDER BY CASE uir.role
+                        WHEN 'ADMIN' THEN 3 WHEN 'OPERATOR' THEN 2 WHEN 'VIEWER' THEN 1 ELSE 0
+                    END DESC
+                    LIMIT 1
+                    """,
+                    user_id,
+                    instance_id,
+                )
 
         if not instance:
             raise HTTPException(
@@ -377,18 +382,21 @@ async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyn
         alphabet = string.ascii_letters + string.digits
         session_id = ''.join(secrets.choice(alphabet) for _ in range(32))
 
-        result = await conn.execute(
-            """
-            INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
-            VALUES ($1, $2, $3, $4, NOW())
-            ON CONFLICT ("userId")
-            DO UPDATE SET "instanceId" = $3, "sessionToken" = $4, "connectedAt" = NOW()
-            """,
-            session_id,
-            user_id,
-            instance_id,
-            current_session_token,
-        )
+        # Unit of work 2: record the active session (short transaction,
+        # opened only after the device answered).
+        async with org_unit_of_work(request) as conn:
+            result = await conn.execute(
+                """
+                INSERT INTO active_sessions (id, "userId", "instanceId", "sessionToken", "connectedAt")
+                VALUES ($1, $2, $3, $4, NOW())
+                ON CONFLICT ("userId")
+                DO UPDATE SET "instanceId" = $3, "sessionToken" = $4, "connectedAt" = NOW()
+                """,
+                session_id,
+                user_id,
+                instance_id,
+                current_session_token,
+            )
 
         return ApiResponse(
             success=True,

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -1664,12 +1664,12 @@ async def restore_backup(
                 sql = _build_insert(table, columns, types, merge=(mode == "merge"))
 
                 try:
-                    if mode == "merge":
-                        # Row-level savepoint so a natural-key collision skips
-                        # just this row instead of aborting the whole restore.
-                        async with conn.transaction():
-                            was_inserted = await conn.fetchval(sql, *values)
-                    else:
+                    # Row-level savepoint so a natural-key collision skips
+                    # just this row instead of poisoning the outer
+                    # transaction (without it, replace mode turned one
+                    # duplicate into InFailedSQLTransaction 500s for every
+                    # following row).
+                    async with conn.transaction():
                         was_inserted = await conn.fetchval(sql, *values)
                 except asyncpg.UniqueViolationError:
                     skipped += 1

--- a/backend/routers/session/session.py
+++ b/backend/routers/session/session.py
@@ -18,7 +18,7 @@ import json
 import os
 from vyos_service import VyOSService, VyOSDeviceConfig
 from session_vyos_service import clear_session_cache
-from session_cookie import verify_session_cookie
+from session_cookie import get_session_cookie, verify_session_cookie
 from backup_crypto import (
     encrypt_backup,
     decrypt_backup,
@@ -367,7 +367,7 @@ async def connect_to_instance(request: Request, body: ConnectRequest, conn: asyn
 
         # Get current auth session token from cookie and verify its signature
         # This allows us to track which auth session created this VyOS connection
-        cookie_token = request.cookies.get("better-auth.session_token")
+        cookie_token = get_session_cookie(request)
         current_session_token = verify_session_cookie(cookie_token) if cookie_token else None
 
         # Create or update active session (upsert)
@@ -1750,7 +1750,7 @@ async def get_active_auth_sessions(request: Request, conn: asyncpg.Connection = 
     user_id = user["id"]
 
     # Get current session token from cookie
-    cookie_token = request.cookies.get("better-auth.session_token")
+    cookie_token = get_session_cookie(request)
 
     # Better-auth stores compound tokens in the format: {session_id}.{base64(HMAC-SHA256)}
     # Verify the signature and extract the session ID
@@ -1809,7 +1809,7 @@ async def revoke_auth_session(request: Request, body: RevokeSessionRequest, conn
     user_id = user["id"]
 
     # Get current session token to prevent self-logout; verify its signature
-    cookie_token = request.cookies.get("better-auth.session_token")
+    cookie_token = get_session_cookie(request)
     current_token = verify_session_cookie(cookie_token) if cookie_token else None
 
     if body.session_token == current_token:

--- a/backend/routers/tokens/tokens.py
+++ b/backend/routers/tokens/tokens.py
@@ -189,8 +189,9 @@ async def revoke_token(request: Request, token_id: str, conn: asyncpg.Connection
     if int(result.split()[-1]) == 0:
         raise HTTPException(status_code=404, detail="Token not found or already revoked")
 
-    # Same transaction as the revoke: close the owner's live streams at once.
-    await revocation_bus.emit(conn, "token", token_id)
+    # Same transaction as the revoke: close the owner's live streams at
+    # once. A single user-scoped emit suffices — payload_matches has no
+    # token branch, so a token-scoped emit matched nothing (dead).
     await revocation_bus.emit(conn, "user", user["id"])
 
     logger.info("API token revoked for user %s (id=%s)", user["id"], token_id)

--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -517,15 +517,25 @@ async def assign_user_to_instances(request: Request, body: AssignUserRequest, co
     if not user_exists:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # Verify instances exist
+    # Verify instances exist AND sit in the caller's acting org (mirrors
+    # remove_assignment) — existence alone would let an org admin mint
+    # grants on another org's instances once this surface opens beyond
+    # super admins.
     for instance_id in body.instance_ids:
-        if not await conn.fetchval("SELECT id FROM instances WHERE id = $1", instance_id):
+        instance_org = await conn.fetchval(
+            'SELECT s."orgId" FROM instances i JOIN sites s ON i."siteId" = s.id WHERE i.id = $1',
+            instance_id,
+        )
+        if instance_org is None:
             raise HTTPException(status_code=404, detail=f"Instance {instance_id} not found")
+        await assert_row_in_acting_org(request, conn, instance_org)
 
-    # Verify sites exist
+    # Same for whole-site grants
     for site_id in body.site_ids:
-        if not await conn.fetchval("SELECT id FROM sites WHERE id = $1", site_id):
+        site_org = await conn.fetchval('SELECT "orgId" FROM sites WHERE id = $1', site_id)
+        if site_org is None:
             raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
+        await assert_row_in_acting_org(request, conn, site_org)
 
     async def insert_feature_perms(assignment_id: str):
         # Feature permissions only apply to OPERATOR/VIEWER.

--- a/backend/schema_gate.py
+++ b/backend/schema_gate.py
@@ -1,0 +1,101 @@
+"""Startup gate: wait for the Prisma-managed schema before serving.
+
+Migrations run in the frontend container (``prisma migrate deploy``), so
+on a populated-database upgrade there is a window where the backend is up
+but the new tables don't exist yet — admin endpoints 500 and feature
+pages degrade to spurious "no active instance" errors until the frontend
+finishes migrating. Instead of serving through that window, the backend
+polls until the schema it depends on is present and no migration is left
+half-applied.
+
+The wait is bounded (``VYMANAGER_SCHEMA_WAIT_TIMEOUT``, seconds,
+default 120, ``0`` disables the gate): if the schema never appears the
+backend logs loudly and serves anyway, preserving the old self-healing
+behavior and avoiding a startup deadlock with compose setups where the
+migration runner waits for the backend healthcheck.
+"""
+
+import asyncio
+import os
+import time
+
+import asyncpg
+
+# Tables the backend queries unconditionally (middleware, org scoping,
+# RBAC, auditing). Extend this list when a migration adds a table the
+# backend reads at request time.
+REQUIRED_TABLES = (
+    "users",
+    "sites",
+    "instances",
+    "organizations",
+    "org_memberships",
+    "user_instance_roles",
+    "user_feature_permissions",
+    "active_sessions",
+    "audit_logs",
+)
+
+
+async def _schema_status(database_url: str):
+    """Return (missing_tables, unfinished_migrations) or raise on connect failure."""
+    conn = await asyncpg.connect(database_url, timeout=10)
+    try:
+        rows = await conn.fetch(
+            """
+            SELECT table_name FROM information_schema.tables
+            WHERE table_schema = current_schema() AND table_name = ANY($1::text[])
+            """,
+            list(REQUIRED_TABLES) + ["_prisma_migrations"],
+        )
+        present = {r["table_name"] for r in rows}
+        missing = [t for t in REQUIRED_TABLES if t not in present]
+
+        unfinished = 0
+        if "_prisma_migrations" in present:
+            unfinished = await conn.fetchval(
+                'SELECT count(*) FROM "_prisma_migrations" '
+                "WHERE finished_at IS NULL AND rolled_back_at IS NULL"
+            )
+        return missing, unfinished
+    finally:
+        await conn.close()
+
+
+async def wait_for_schema(database_url: str) -> bool:
+    """Poll until the required schema exists. True = ready, False = timed out."""
+    timeout = float(os.getenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "120"))
+    interval = float(os.getenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "2"))
+    if timeout <= 0:
+        return True
+
+    deadline = time.monotonic() + timeout
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            missing, unfinished = await _schema_status(database_url)
+            if not missing and not unfinished:
+                if attempt > 1:
+                    print("  ✓ Database schema ready")
+                return True
+            state = []
+            if missing:
+                state.append(f"missing tables: {', '.join(missing)}")
+            if unfinished:
+                state.append(f"{unfinished} unfinished migration(s)")
+            reason = "; ".join(state)
+        except Exception as e:
+            reason = f"database not reachable: {e}"
+
+        if time.monotonic() >= deadline:
+            print("  " + "!" * 58)
+            print(f"  ✗ Schema not ready after {timeout:.0f}s ({reason}).")
+            print("  ✗ Serving anyway — run 'prisma migrate deploy' (frontend")
+            print("  ✗ container) to bring the database up to date.")
+            print("  " + "!" * 58)
+            return False
+
+        if attempt == 1 or attempt % 5 == 0:
+            print(f"  ⏳ Waiting for database schema ({reason})")
+        await asyncio.sleep(interval)

--- a/backend/scripts/prove_runtime_role.py
+++ b/backend/scripts/prove_runtime_role.py
@@ -61,6 +61,15 @@ async def main() -> int:
                     break
                 if allowed:
                     failures.append(f"role has {privilege} on {table}")
+
+        # The D1-01 vector: UPDATE on users.role lets a compromised
+        # frontend self-promote to site ADMIN.
+        role_update = await conn.fetchval(
+            "SELECT has_column_privilege(current_user, 'users', 'role',"
+            " 'UPDATE')")
+        if role_update:
+            failures.append(
+                "role can UPDATE users.role — frontend self-promotion open")
     finally:
         await conn.close()
 

--- a/backend/scripts/prove_runtime_role.py
+++ b/backend/scripts/prove_runtime_role.py
@@ -1,0 +1,77 @@
+"""Prove the Golden Rule on the REAL runtime role (flip-runbook step).
+
+The structural test (tests/adversarial/test_golden_rule.py) shows the
+intended grant set blocks the authorization tables — but production
+could still run the frontend as the table owner or a superuser with the
+ban unenforced. This script asks Postgres about the actual principal of
+the DATABASE_URL it is given. Run it after switching the frontend to its
+fenced role:
+
+    DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role
+
+Exit code 0 = the role cannot write any authorization table and is not
+a superuser. Non-zero = the Golden Rule is not structurally enforced on
+this deployment; the output names each offending grant.
+"""
+
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+BANNED_TABLES = [
+    "org_memberships",
+    "user_instance_roles",
+    "user_feature_permissions",
+    "organizations",
+    "oauth_role_mappings",
+    "sites",
+    "instances",
+]
+
+PRIVILEGES = ("INSERT", "UPDATE", "DELETE")
+
+
+async def main() -> int:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is required (the frontend's connection string)")
+        return 2
+
+    conn = await asyncpg.connect(url)
+    failures = []
+    try:
+        role = await conn.fetchval("SELECT current_user")
+        superuser = await conn.fetchval(
+            "SELECT usesuper FROM pg_user WHERE usename = current_user")
+        print(f"runtime role: {role} (superuser: {bool(superuser)})")
+        if superuser:
+            failures.append(
+                "role is a superuser — every table ban is bypassed")
+
+        for table in BANNED_TABLES:
+            for privilege in PRIVILEGES:
+                try:
+                    allowed = await conn.fetchval(
+                        "SELECT has_table_privilege(current_user, $1, $2)",
+                        f'"{table}"', privilege)
+                except asyncpg.UndefinedTableError:
+                    print(f"  {table}: missing (skipped)")
+                    break
+                if allowed:
+                    failures.append(f"role has {privilege} on {table}")
+    finally:
+        await conn.close()
+
+    if failures:
+        print("\nGOLDEN RULE NOT ENFORCED:")
+        for failure in failures:
+            print(f"  ✗ {failure}")
+        return 1
+    print("✓ runtime role cannot write any authorization table")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/backend/session_cookie.py
+++ b/backend/session_cookie.py
@@ -52,3 +52,21 @@ def verify_session_cookie(signed_value: str) -> str | None:
         return None
 
     return session_id
+
+
+# The browser cookie name depends on the deployment: Better Auth prefixes
+# it with __Secure- when secure cookies are enabled (HTTPS). Every read
+# must accept both or secure deployments silently lose session tracking.
+SESSION_COOKIE_NAMES = (
+    "better-auth.session_token",
+    "__Secure-better-auth.session_token",
+)
+
+
+def get_session_cookie(request) -> str | None:
+    """Return the signed session cookie under whichever name is present."""
+    for name in SESSION_COOKIE_NAMES:
+        value = request.cookies.get(name)
+        if value:
+            return value
+    return None

--- a/backend/sso_jwt_verify.py
+++ b/backend/sso_jwt_verify.py
@@ -1,0 +1,137 @@
+"""JWKS verification for stored SSO id_tokens (audit D1-03).
+
+The sso-reconcile endpoint derives group claims from the id_token stored
+in the Better-Auth ``accounts`` table. That table is frontend-writable,
+so a compromised frontend holding the internal secret could plant a
+forged token and mint grants. When the provider has a ``discoveryUrl``,
+we verify the token's signature against the provider's JWKS plus its
+``iss``/``aud``/``exp`` claims before trusting it.
+
+Failure semantics (deliberate asymmetry):
+
+- The token is INVALID (bad signature, wrong issuer/audience, expired)
+  → ``TokenInvalid``: the caller must skip reconciliation for this
+  provider — falling back to the unverified decode would defeat the
+  check.
+- Verification is UNAVAILABLE (no discoveryUrl, discovery/JWKS fetch
+  failed) → ``VerificationUnavailable``: the caller may fall back to the
+  legacy unverified decode (and log), unless
+  ``VYMANAGER_SSO_REQUIRE_JWT_VERIFY=1`` makes that fail closed too.
+"""
+
+import os
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+import jwt
+
+# Asymmetric algorithms only: the JWKS flow hands us public keys, and
+# accepting an HMAC alg here would let a forged token be "signed" with a
+# public value.
+ALLOWED_ALGORITHMS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512",
+                      "PS256", "PS384", "PS512"]
+
+_CACHE_TTL_SECONDS = 3600.0
+
+# discovery_url -> (fetched_at, discovery_doc)
+_discovery_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+# jwks_uri -> (fetched_at, jwks)
+_jwks_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+
+
+class TokenInvalid(Exception):
+    """The id_token failed verification — do not trust it."""
+
+
+class VerificationUnavailable(Exception):
+    """Verification could not be attempted (no discovery/JWKS reachable)."""
+
+
+def require_verification() -> bool:
+    return os.getenv("VYMANAGER_SSO_REQUIRE_JWT_VERIFY") == "1"
+
+
+async def _fetch_json(url: str) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+async def _cached_fetch(cache: Dict[str, Tuple[float, Dict[str, Any]]],
+                        url: str) -> Dict[str, Any]:
+    now = time.monotonic()
+    hit = cache.get(url)
+    if hit and now - hit[0] < _CACHE_TTL_SECONDS:
+        return hit[1]
+    try:
+        doc = await _fetch_json(url)
+    except Exception as e:
+        if hit:  # serve stale rather than failing on a transient blip
+            return hit[1]
+        raise VerificationUnavailable(f"fetch failed for {url}: {e}") from e
+    cache[url] = (now, doc)
+    return doc
+
+
+def _key_for(jwks: Dict[str, Any], kid: Optional[str]):
+    keys = jwks.get("keys") or []
+    for key in keys:
+        if kid is None or key.get("kid") == kid:
+            return jwt.PyJWK(key).key
+    return None
+
+
+async def verified_claims(
+    id_token: str,
+    discovery_url: Optional[str],
+    client_id: Optional[str],
+) -> Dict[str, Any]:
+    """Verify the id_token against the provider's JWKS and return claims.
+
+    Raises TokenInvalid when the token fails verification and
+    VerificationUnavailable when verification cannot be attempted.
+    """
+    if not id_token:
+        raise TokenInvalid("empty id_token")
+    if not discovery_url:
+        raise VerificationUnavailable("provider has no discoveryUrl")
+
+    discovery = await _cached_fetch(_discovery_cache, discovery_url)
+    jwks_uri = discovery.get("jwks_uri")
+    issuer = discovery.get("issuer")
+    if not jwks_uri:
+        raise VerificationUnavailable("discovery document has no jwks_uri")
+
+    try:
+        header = jwt.get_unverified_header(id_token)
+    except jwt.InvalidTokenError as e:
+        raise TokenInvalid(f"malformed token: {e}") from e
+
+    jwks = await _cached_fetch(_jwks_cache, jwks_uri)
+    key = _key_for(jwks, header.get("kid"))
+    if key is None:
+        # An unknown kid usually means key rotation: refetch once.
+        _jwks_cache.pop(jwks_uri, None)
+        jwks = await _cached_fetch(_jwks_cache, jwks_uri)
+        key = _key_for(jwks, header.get("kid"))
+    if key is None:
+        raise TokenInvalid(f"no JWKS key matches kid {header.get('kid')!r}")
+
+    try:
+        return jwt.decode(
+            id_token,
+            key=key,
+            algorithms=ALLOWED_ALGORITHMS,
+            audience=client_id if client_id else None,
+            issuer=issuer if issuer else None,
+            options={
+                "require": ["exp"],
+                "verify_aud": bool(client_id),
+                "verify_iss": bool(issuer),
+            },
+            leeway=60,
+        )
+    except jwt.InvalidTokenError as e:
+        raise TokenInvalid(str(e)) from e

--- a/backend/tests/adversarial/canary_allowlist.py
+++ b/backend/tests/adversarial/canary_allowlist.py
@@ -33,6 +33,19 @@ PERMANENT_GLOBAL = {
         "iterates every instance with active subscribers, a "
         "deployment-wide system service. The request-path streams in "
         "the same file use org-scoped connections per tick.",
+    "revocation_bus.py":
+        "Holds one dedicated LISTEN connection for the deployment-wide "
+        "revocation channel; no request, no org context by nature.",
+    "rbac_permissions.py":
+        "_acquire accepts a Pool on the short-lived /vyos permission "
+        "path (the sanctioned request_scoped_conn design); flagged by "
+        "the broadened .acquire( marker, reviewed as correct.",
+    "routers/console/console.py":
+        "getattr(state, 'db_pool') presence check only - every actual "
+        "acquisition in the WS handler goes through ws_conn/ws_org_conn.",
+    "routers/monitoring/monitoring.py":
+        "getattr(state, 'db_pool') presence check only - acquisitions "
+        "go through ws_conn/ws_org_conn.",
 }
 
 # Files not yet migrated to org-scoped connections. The conversion waves

--- a/backend/tests/adversarial/test_canary.py
+++ b/backend/tests/adversarial/test_canary.py
@@ -12,10 +12,13 @@ from canary_allowlist import MIGRATION_PENDING, PERMANENT_GLOBAL
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
-# Direct pool access markers. org-scoped code never mentions db_pool:
-# handlers take a connection from the org_conn dependencies, and the
-# permission path goes through request_scoped_conn.
-MARKERS = ("db_pool.acquire(", "state.db_pool")
+# Direct pool access markers. org-scoped code never mentions db_pool or
+# acquires connections itself: handlers take a connection from the
+# org_conn dependencies, and the permission path goes through
+# request_scoped_conn. The generic ".acquire(" marker also catches
+# aliased acquisitions (a Pool passed under another name) that the old
+# literal markers were blind to.
+MARKERS = (".acquire(", '"db_pool"', "'db_pool'", "state.db_pool")
 
 EXCLUDED_DIRS = {"tests", "__pycache__", "venv", ".venv", "node_modules"}
 

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -10,9 +10,12 @@
   enforcement path has landed and is proven by the FORCE-RLS rehearsal).
 """
 
+import asyncio
+import os
+
 import pytest
 
-from conftest import IDS, as_user
+from conftest import IDS, USERS, as_user
 
 pytestmark = pytest.mark.usefixtures("adversarial_world")
 
@@ -122,3 +125,34 @@ def test_token_creation_org_confined_under_enforcement(
               "allowed_instance_ids": [IDS["instance_a"]],
               "allowed_site_ids": []})
     assert same.status_code == 200
+
+
+def test_cross_org_grant_is_never_minted(adversarial_world, monkeypatch):
+    # assign_user_to_instances resolves each target's org and asserts it
+    # is the caller's acting org (mirroring remove_assignment). Today the
+    # endpoint is also super-admin-gated, so an org admin sees 403; when
+    # that gate opens to org roles the row check answers 404. Either way
+    # the invariant is: the request fails and no grant row appears.
+    import asyncpg
+    import org_scope
+    monkeypatch.setattr(org_scope, "ORG_ENFORCEMENT", True)
+
+    response = as_user(adversarial_world, "a_admin").post(
+        "/user-management/assignments",
+        json={"user_id": USERS["a_member"][0],
+              "instance_ids": [IDS["instance_b"]],
+              "site_ids": [],
+              "role": "VIEWER"})
+    assert response.status_code >= 400
+
+    async def cross_org_grants() -> int:
+        conn = await asyncpg.connect(os.environ["DATABASE_URL"])
+        try:
+            return await conn.fetchval(
+                'SELECT count(*) FROM user_instance_roles '
+                'WHERE "userId" = $1 AND "instanceId" = $2',
+                USERS["a_member"][0], IDS["instance_b"])
+        finally:
+            await conn.close()
+
+    assert asyncio.run(cross_org_grants()) == 0

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -39,9 +39,11 @@ def test_member_cannot_connect_to_foreign_org_instance(adversarial_world):
 
 
 def test_explicit_org_param_rejects_non_members(adversarial_world):
+    # Uniform 404 (same as a nonexistent org) so org ids cannot be
+    # enumerated by non-members.
     response = as_user(adversarial_world, "a_member").get(
         "/session/sites", params={"org_id": IDS["org_b"]})
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 def test_explicit_org_param_rejects_unknown_org(adversarial_world):

--- a/backend/tests/adversarial/test_cross_org.py
+++ b/backend/tests/adversarial/test_cross_org.py
@@ -158,3 +158,26 @@ def test_cross_org_grant_is_never_minted(adversarial_world, monkeypatch):
             await conn.close()
 
     assert asyncio.run(cross_org_grants()) == 0
+
+def test_token_use_cannot_cross_the_org_boundary(adversarial_world):
+    # Token confinement at USE (RFC §8), not just at creation. a_member
+    # mints a token scoped to their own org-A instance, then presents it
+    # with an X-VyOS-Instance-Id header naming the org-B instance. Two
+    # independent barriers reject it — no grant on the B instance and the
+    # token's allow-list — so no active instance is ever resolved and the
+    # request is denied (never a 2xx, and never a 503 that would mean the
+    # B instance had been selected and contacted).
+    created = as_user(adversarial_world, "a_member").post(
+        "/tokens",
+        json={"name": "adv-use", "scopes": ["read"],
+              "allowed_instance_ids": [IDS["instance_a"]],
+              "allowed_site_ids": []})
+    assert created.status_code == 200
+    token = created.json()["token"]
+
+    cross = adversarial_world.get(
+        "/vyos/access-list/config",
+        headers={"Authorization": f"Bearer {token}",
+                 "X-VyOS-Instance-Id": IDS["instance_b"]})
+    assert cross.status_code in (400, 403, 404)
+    assert cross.status_code not in (200, 503)

--- a/backend/tests/adversarial/test_golden_rule.py
+++ b/backend/tests/adversarial/test_golden_rule.py
@@ -10,9 +10,12 @@ The proof creates a restricted role mirroring the intended frontend grants —
 write access to the Better Auth core tables only — and asserts that INSERT and
 UPDATE on each authz table fail. Needs CREATE ROLE; skips otherwise.
 
-Note: oauth_role_mappings is not covered here — the frontend still writes it
-via the OAuth-config UI. Relocating that write to the backend (like the SSO
-reconcile relocation) is the remaining step before it joins this ban.
+oauth_role_mappings joined the ban once its writes relocated to the backend
+(PR #484); sites and instances are backend-owned and join it too. A second proof
+checks the REAL runtime role instead of a synthetic one — run it on a
+deployment after the enforcement flip (flip-runbook step, not CI):
+
+    DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role
 """
 
 import asyncio
@@ -35,6 +38,11 @@ BANNED_TABLES = [
     "user_instance_roles",
     "user_feature_permissions",
     "organizations",
+    # writes relocated to the backend; the frontend only proxies
+    "oauth_role_mappings",
+    # backend-owned resources — the frontend never writes them directly
+    "sites",
+    "instances",
 ]
 
 
@@ -99,3 +107,4 @@ def test_frontend_role_cannot_write_authz_tables():
 
     if asyncio.run(main()) == "skip":
         pytest.skip("no privilege to CREATE ROLE for the Golden Rule proof")
+

--- a/backend/tests/adversarial/test_golden_rule.py
+++ b/backend/tests/adversarial/test_golden_rule.py
@@ -64,6 +64,22 @@ def test_frontend_role_cannot_write_authz_tables():
             await owner.execute(f"GRANT USAGE ON SCHEMA public TO {FRONTEND}")
             # Frontend gets write access to the Better Auth core tables only.
             for table in CORE_TABLES:
+                if table == "users":
+                    # UPDATE is column-scoped to exclude role: the site-admin
+                    # bit is backend-owned (sso-reconcile applies it), so a
+                    # compromised frontend must not be able to self-promote.
+                    # INSERT stays table-wide — role is legitimately set at
+                    # creation (first-user promotion, SSO mapping).
+                    cols = [r["column_name"] for r in await owner.fetch(
+                        "SELECT column_name FROM information_schema.columns"
+                        " WHERE table_schema = current_schema()"
+                        " AND table_name = 'users' AND column_name <> 'role'")]
+                    quoted = ", ".join(f'"{c}"' for c in cols)
+                    await owner.execute(
+                        f'GRANT SELECT, INSERT, DELETE ON "users" TO {FRONTEND}')
+                    await owner.execute(
+                        f'GRANT UPDATE ({quoted}) ON "users" TO {FRONTEND}')
+                    continue
                 await owner.execute(
                     f'GRANT SELECT, INSERT, UPDATE, DELETE ON "{table}" '
                     f"TO {FRONTEND}")
@@ -81,7 +97,8 @@ def test_frontend_role_cannot_write_authz_tables():
                 finally:
                     await conn.close()
 
-            # Sanity: the frontend role CAN write a core table (users).
+            # Sanity: the frontend role CAN write a core table (users) —
+            # and specifically CANNOT set users.role (the D1-01 vector).
             conn = await asyncpg.connect(os.environ["DATABASE_URL"])
             try:
                 await conn.execute(f"SET ROLE {FRONTEND}")
@@ -92,6 +109,13 @@ def test_frontend_role_cannot_write_authz_tables():
                         "INSERT INTO users (id) VALUES ('u_probe')")
                 assert not isinstance(
                     exc.value, asyncpg.InsufficientPrivilegeError)
+                # Self-promotion must be a privilege error, not a data error.
+                with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                    await conn.execute(
+                        "UPDATE users SET role = 'ADMIN'")
+                # A non-role column update is within the grant (0 rows,
+                # but a privilege failure would raise).
+                await conn.execute("UPDATE users SET name = name WHERE false")
             finally:
                 await conn.close()
         finally:

--- a/backend/tests/adversarial/test_organizations_crud.py
+++ b/backend/tests/adversarial/test_organizations_crud.py
@@ -1,0 +1,146 @@
+"""Adversarial coverage for the organization CRUD + membership router.
+
+The router that mints and alters org roles (create/update/delete org,
+add/set-role/remove member, the last-owner guard) had no tests — audit
+D4 flagged it. Every mutating endpoint is require_super_admin-gated
+today, so the invariants proven here are:
+
+- a non-deployment-admin (even an org ADMIN by membership) cannot touch
+  the org router at all;
+- a System Administrator can run the full lifecycle;
+- the last-OWNER orphan guard holds for both demote and remove.
+
+These run under the two-org fixture; they seed and tear down their own
+throwaway org so they never disturb the shared adversarial world.
+"""
+
+import asyncio
+import os
+
+import asyncpg
+import pytest
+
+from conftest import USERS, as_user
+
+pytestmark = pytest.mark.usefixtures("adversarial_world")
+
+TEST_ORG = "adv_org_crud"
+
+
+def _db():
+    return os.environ["DATABASE_URL"]
+
+
+async def _cleanup_org():
+    conn = await asyncpg.connect(_db())
+    try:
+        await conn.execute('DELETE FROM org_memberships WHERE "orgId" = $1', TEST_ORG)
+        await conn.execute("DELETE FROM organizations WHERE id = $1", TEST_ORG)
+        await conn.execute(
+            "DELETE FROM organizations WHERE name = 'CRUD Probe Org'")
+    finally:
+        await conn.close()
+
+
+@pytest.fixture()
+def clean_org():
+    asyncio.run(_cleanup_org())
+    yield
+    asyncio.run(_cleanup_org())
+
+
+# ---------------------------------------------------------------------------
+# Non-deployment-admins cannot mutate the org router
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("actor", ["a_admin", "a_member", "b_member"])
+def test_non_sysadmin_cannot_create_org(adversarial_world, actor):
+    # a_admin is org-A ADMIN by membership but only a deployment VIEWER;
+    # the org router is deployment-admin-only, so all three are denied.
+    response = as_user(adversarial_world, actor).post(
+        "/organizations", json={"name": "CRUD Probe Org"})
+    assert response.status_code == 403
+
+
+def test_non_sysadmin_cannot_add_member(adversarial_world):
+    from conftest import IDS
+    response = as_user(adversarial_world, "a_admin").post(
+        f"/organizations/{IDS['org_a']}/members",
+        json={"userId": USERS["b_member"][0], "orgRole": "MEMBER"})
+    assert response.status_code == 403
+
+
+def test_non_sysadmin_cannot_delete_org(adversarial_world):
+    from conftest import IDS
+    response = as_user(adversarial_world, "a_member").delete(
+        f"/organizations/{IDS['org_a']}")
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# System Administrator lifecycle + the last-owner guard
+# ---------------------------------------------------------------------------
+
+def test_sysadmin_full_membership_lifecycle(adversarial_world, clean_org):
+    client = as_user(adversarial_world, "sys")
+
+    async def seed_org():
+        conn = await asyncpg.connect(_db())
+        try:
+            await conn.execute(
+                'INSERT INTO organizations (id, name, "createdAt", "updatedAt")'
+                " VALUES ($1, 'CRUD Lifecycle Org', NOW(), NOW())", TEST_ORG)
+            # sys is the sole OWNER; a_member is a MEMBER to demote/promote.
+            await conn.execute(
+                'INSERT INTO org_memberships (id, "userId", "orgId", "orgRole",'
+                ' "createdAt", "updatedAt") VALUES'
+                " ('omc_sys', $1, $3, 'OWNER', NOW(), NOW()),"
+                " ('omc_mem', $2, $3, 'MEMBER', NOW(), NOW())",
+                USERS["sys"][0], USERS["a_member"][0], TEST_ORG)
+        finally:
+            await conn.close()
+
+    asyncio.run(seed_org())
+
+    # Promote the member to OWNER, then the original OWNER can be demoted.
+    promote = client.patch(
+        f"/organizations/{TEST_ORG}/members/{USERS['a_member'][0]}",
+        json={"orgRole": "OWNER"})
+    assert promote.status_code == 200
+
+    demote = client.patch(
+        f"/organizations/{TEST_ORG}/members/{USERS['sys'][0]}",
+        json={"orgRole": "MEMBER"})
+    assert demote.status_code == 200
+
+
+def test_sysadmin_cannot_orphan_the_last_owner(adversarial_world, clean_org):
+    client = as_user(adversarial_world, "sys")
+
+    async def seed_org():
+        conn = await asyncpg.connect(_db())
+        try:
+            await conn.execute(
+                'INSERT INTO organizations (id, name, "createdAt", "updatedAt")'
+                " VALUES ($1, 'CRUD Orphan Org', NOW(), NOW())", TEST_ORG)
+            await conn.execute(
+                'INSERT INTO org_memberships (id, "userId", "orgId", "orgRole",'
+                ' "createdAt", "updatedAt") VALUES'
+                " ('omc_sys', $1, $3, 'OWNER', NOW(), NOW()),"
+                " ('omc_mem', $2, $3, 'MEMBER', NOW(), NOW())",
+                USERS["sys"][0], USERS["a_member"][0], TEST_ORG)
+        finally:
+            await conn.close()
+
+    asyncio.run(seed_org())
+
+    # Demoting the sole OWNER while a member remains must be refused.
+    demote = client.patch(
+        f"/organizations/{TEST_ORG}/members/{USERS['sys'][0]}",
+        json={"orgRole": "MEMBER"})
+    assert demote.status_code == 409
+
+    # Removing the sole OWNER while a member remains must be refused too.
+    remove = client.delete(
+        f"/organizations/{TEST_ORG}/members/{USERS['sys'][0]}")
+    assert remove.status_code == 409

--- a/backend/tests/test_mapper_version_gating.py
+++ b/backend/tests/test_mapper_version_gating.py
@@ -1,0 +1,54 @@
+"""Version-gating corrections from the 2026-07-09 audit (Domain 2).
+
+- IS-IS 1.4 mapper: 1.5-only options must raise, not silently no-op —
+  a direct API call setting TI-LFA on a 1.4 device used to return
+  success while applying nothing.
+- OSPF builder: redistribute nhrp is 1.5-only and must be rejected on
+  1.4 instead of emitting an invalid path.
+- ethernet/zones factories: version selection must substring-match like
+  every other factory, not silently fall back to 1.5 on "1.4.0".
+"""
+
+import pytest
+
+from vyos_builders.ospf.ospf_batch_builder import OspfBatchBuilder
+from vyos_mappers.firewall.zones_versions import get_firewall_zones_mapper
+from vyos_mappers.interfaces.ethernet_versions import get_ethernet_mapper
+from vyos_mappers.isis.isis_versions.v1_4 import IsisMapperV1_4
+
+
+def test_isis_v14_rejects_ti_lfa_instead_of_silent_noop():
+    mapper = IsisMapperV1_4()
+    with pytest.raises(ValueError, match="1.5"):
+        mapper.get_interface_ti_lfa_path("eth0")
+    with pytest.raises(ValueError, match="1.5"):
+        mapper.get_sr_srv6_locator_path("LOC1")
+    with pytest.raises(ValueError, match="1.5"):
+        mapper.get_te_export_path()
+
+
+def test_ospf_14_rejects_redistribute_nhrp():
+    builder = OspfBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_redistribute("nhrp")
+    # supported protocols still pass through
+    builder.set_redistribute("bgp")
+    assert builder.get_operations()
+
+
+def test_ospf_15_allows_redistribute_nhrp():
+    builder = OspfBatchBuilder(version="1.5")
+    builder.set_redistribute("nhrp")
+    assert builder.get_operations()[-1]["path"][-1] == "nhrp"
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.4.0", "1.4.4 sagitta"])
+def test_factories_substring_match_14(version):
+    assert type(get_ethernet_mapper(version)).__name__ == "EthernetMapper_v1_4"
+    assert type(get_firewall_zones_mapper(version)).__name__ == "FirewallZonesMapper_v1_4"
+
+
+@pytest.mark.parametrize("version", ["1.5", "1.5.0", "2025.rolling"])
+def test_factories_default_to_15(version):
+    assert type(get_ethernet_mapper(version)).__name__ == "EthernetMapper_v1_5"
+    assert type(get_firewall_zones_mapper(version)).__name__ == "FirewallZonesMapper_v1_5"

--- a/backend/tests/test_nat_cgnat_version_gate.py
+++ b/backend/tests/test_nat_cgnat_version_gate.py
@@ -1,0 +1,46 @@
+"""CGNAT version gating (audit D2-02).
+
+CGNAT (``nat cgnat ...``) only exists from VyOS 1.5. The 1.4 mapper must
+refuse every CGNAT path instead of emitting a command the device rejects
+at commit — the same convention the firewall groups v1_4 mapper uses for
+domain/remote groups.
+"""
+
+import inspect
+
+import pytest
+
+from vyos_mappers.nat.nat import NATMapper
+from vyos_mappers.nat.nat_versions import get_nat_mapper
+
+
+def _dummy_args(method):
+    """1 for int-ish params, 'x' otherwise — enough to reach the body."""
+    params = list(inspect.signature(method).parameters.values())
+    return ["1" if "number" in p.name or p.name == "seq" else "x" for p in params]
+
+
+CGNAT_METHODS = [
+    name for name, _ in inspect.getmembers(NATMapper, predicate=inspect.isfunction)
+    if name.startswith("get_cgnat")
+]
+
+
+def test_base_mapper_defines_cgnat_methods():
+    assert len(CGNAT_METHODS) >= 17
+
+
+@pytest.mark.parametrize("name", CGNAT_METHODS)
+def test_v14_rejects_every_cgnat_path(name):
+    mapper = get_nat_mapper("1.4")
+    method = getattr(mapper, name)
+    with pytest.raises(ValueError, match="1.5"):
+        method(*_dummy_args(method))
+
+
+@pytest.mark.parametrize("name", CGNAT_METHODS)
+def test_v15_still_emits_cgnat_paths(name):
+    mapper = get_nat_mapper("1.5")
+    method = getattr(mapper, name)
+    path = method(*_dummy_args(method))
+    assert path[:2] == ["nat", "cgnat"]

--- a/backend/tests/test_rbac_firewall_children.py
+++ b/backend/tests/test_rbac_firewall_children.py
@@ -1,0 +1,42 @@
+"""FIREWALL_BRIDGE / FIREWALL_FLOWTABLES must sit on the live grant paths.
+
+Both groups gate their routers, but they only appeared in the dead
+BUILT_IN_PERMISSIONS dicts — so any non-site-ADMIN (instance-ADMIN
+grant, org ADMIN/OWNER under enforcement, FIREWALL=WRITE operator)
+resolved them to NONE and got a hard 403 on the whole bridge-firewall
+and flowtables pages (audit finding, Domain 2 Medium).
+"""
+
+from rbac_permissions import (
+    FeatureGroup,
+    PermissionLevel,
+    _INSTANCE_ADMIN_FEATURES,
+    _apply_parent_child_permissions,
+)
+
+CHILDREN = [FeatureGroup.FIREWALL_BRIDGE, FeatureGroup.FIREWALL_FLOWTABLES]
+
+
+def all_none():
+    return {feature: PermissionLevel.NONE for feature in FeatureGroup}
+
+
+def test_firewall_write_propagates_to_bridge_and_flowtables():
+    permissions = all_none()
+    permissions[FeatureGroup.FIREWALL] = PermissionLevel.WRITE
+    _apply_parent_child_permissions(permissions)
+    for child in CHILDREN:
+        assert permissions[child] == PermissionLevel.WRITE, child
+
+
+def test_firewall_read_propagates_to_bridge_and_flowtables():
+    permissions = all_none()
+    permissions[FeatureGroup.FIREWALL] = PermissionLevel.READ
+    _apply_parent_child_permissions(permissions)
+    for child in CHILDREN:
+        assert permissions[child] == PermissionLevel.READ, child
+
+
+def test_instance_admin_gets_bridge_and_flowtables():
+    for child in CHILDREN:
+        assert child in _INSTANCE_ADMIN_FEATURES, child

--- a/backend/tests/test_revocation_bus.py
+++ b/backend/tests/test_revocation_bus.py
@@ -117,7 +117,11 @@ def test_token_revoke_emits_through_bus(monkeypatch):
                 revoked = client.delete(f"/tokens/{token_id}")
                 assert revoked.status_code == 200
 
-                # The revoke emits token:<id> and user:<owner>.
+                # The revoke emits a single user-scoped payload; the owner's
+                # streams (cookie- and token-authenticated alike) key on the
+                # user id, so user:<owner> tears them all down. The old
+                # token:<id> emit was dead — payload_matches has no token
+                # branch — and was dropped, so it must NOT appear.
                 seen = set()
 
                 async def drain():
@@ -128,8 +132,8 @@ def test_token_revoke_emits_through_bus(monkeypatch):
                         pass
 
                 asyncio.run(drain())
-                assert f"token:{token_id}" in seen
                 assert "user:u_rb" in seen
+                assert f"token:{token_id}" not in seen
             finally:
                 revocation_bus.unsubscribe(q)
     finally:

--- a/backend/tests/test_schema_gate.py
+++ b/backend/tests/test_schema_gate.py
@@ -1,0 +1,65 @@
+"""Startup schema gate behavior (audit D2-03). No database needed."""
+
+import asyncio
+
+import pytest
+
+import schema_gate
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def test_gate_disabled_by_zero_timeout(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "0")
+
+    async def boom(url):  # pragma: no cover - must not be called
+        raise AssertionError("gate should not touch the database when disabled")
+
+    monkeypatch.setattr(schema_gate, "_schema_status", boom)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is True
+
+
+def test_ready_schema_passes_immediately(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "5")
+
+    async def ready(url):
+        return [], 0
+
+    monkeypatch.setattr(schema_gate, "_schema_status", ready)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is True
+
+
+def test_missing_tables_time_out_and_serve_anyway(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "0.05")
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "0.01")
+
+    async def missing(url):
+        return ["organizations"], 0
+
+    monkeypatch.setattr(schema_gate, "_schema_status", missing)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is False
+
+
+def test_unfinished_migration_blocks_until_done(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "5")
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "0.01")
+    states = iter([([], 1), ([], 1), ([], 0)])
+
+    async def sequence(url):
+        return next(states)
+
+    monkeypatch.setattr(schema_gate, "_schema_status", sequence)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is True
+
+
+def test_connection_errors_keep_polling_then_time_out(monkeypatch):
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_TIMEOUT", "0.05")
+    monkeypatch.setenv("VYMANAGER_SCHEMA_WAIT_INTERVAL", "0.01")
+
+    async def down(url):
+        raise ConnectionRefusedError("postgres still starting")
+
+    monkeypatch.setattr(schema_gate, "_schema_status", down)
+    assert _run(schema_gate.wait_for_schema("postgres://unused")) is False

--- a/backend/tests/test_schema_gate.py
+++ b/backend/tests/test_schema_gate.py
@@ -2,8 +2,6 @@
 
 import asyncio
 
-import pytest
-
 import schema_gate
 
 

--- a/backend/tests/test_session_cookie_names.py
+++ b/backend/tests/test_session_cookie_names.py
@@ -1,0 +1,37 @@
+"""Session cookie must be readable under both deployment names (audit D2).
+
+Better Auth prefixes the cookie with __Secure- when secure cookies are
+on (HTTPS). Reads that only checked the bare name silently lost session
+tracking on secure deployments: device-change clears never fired,
+/session/connect stored a NULL sessionToken, and the current-session
+guard in auth-session revocation was defeated.
+"""
+
+from types import SimpleNamespace
+
+from session_cookie import SESSION_COOKIE_NAMES, get_session_cookie
+
+
+def _request_with(cookies):
+    return SimpleNamespace(cookies=cookies)
+
+
+def test_plain_name_wins_when_present():
+    request = _request_with({"better-auth.session_token": "plain"})
+    assert get_session_cookie(request) == "plain"
+
+
+def test_secure_prefixed_name_is_read():
+    request = _request_with({"__Secure-better-auth.session_token": "secure"})
+    assert get_session_cookie(request) == "secure"
+
+
+def test_missing_cookie_returns_none():
+    assert get_session_cookie(_request_with({})) is None
+
+
+def test_both_names_are_covered():
+    assert SESSION_COOKIE_NAMES == (
+        "better-auth.session_token",
+        "__Secure-better-auth.session_token",
+    )

--- a/backend/tests/test_sso_jwt_verify.py
+++ b/backend/tests/test_sso_jwt_verify.py
@@ -1,0 +1,135 @@
+"""JWKS verification of stored SSO id_tokens (audit D1-03). No DB needed.
+
+Generates a real RSA keypair, serves discovery/JWKS from monkeypatched
+fetches, and proves: a properly signed token passes; a tampered or
+expired token, a wrong audience, and an HMAC downgrade are rejected as
+TokenInvalid (never falling back); missing discovery is
+VerificationUnavailable (legacy fallback allowed unless the strict env
+flag is set).
+"""
+
+import asyncio
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import sso_jwt_verify
+from sso_jwt_verify import (
+    TokenInvalid,
+    VerificationUnavailable,
+    verified_claims,
+)
+
+ISSUER = "https://idp.test"
+CLIENT_ID = "vymanager-client"
+DISCOVERY_URL = "https://idp.test/.well-known/openid-configuration"
+JWKS_URI = "https://idp.test/jwks"
+
+
+@pytest.fixture()
+def idp(monkeypatch):
+    """A fake IdP: RSA key, discovery doc and JWKS served from memory."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = jwt.algorithms.RSAAlgorithm.to_jwk(
+        private_key.public_key(), as_dict=True)
+    public_jwk["kid"] = "test-key"
+    public_jwk["alg"] = "RS256"
+
+    documents = {
+        DISCOVERY_URL: {"issuer": ISSUER, "jwks_uri": JWKS_URI},
+        JWKS_URI: {"keys": [public_jwk]},
+    }
+
+    async def fake_fetch(url):
+        if url not in documents:
+            raise VerificationUnavailable(f"fetch failed for {url}")
+        return documents[url]
+
+    monkeypatch.setattr(sso_jwt_verify, "_fetch_json", fake_fetch)
+    sso_jwt_verify._discovery_cache.clear()
+    sso_jwt_verify._jwks_cache.clear()
+
+    def make_token(**overrides):
+        claims = {
+            "iss": ISSUER,
+            "aud": CLIENT_ID,
+            "exp": int(time.time()) + 300,
+            "sub": "user-1",
+            "groups": ["netops"],
+        }
+        claims.update(overrides)
+        return jwt.encode(
+            claims, private_key, algorithm="RS256",
+            headers={"kid": "test-key"})
+
+    return make_token
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+def test_valid_token_yields_claims(idp):
+    claims = _run(verified_claims(idp(), DISCOVERY_URL, CLIENT_ID))
+    assert claims["groups"] == ["netops"]
+
+
+def test_tampered_token_is_invalid(idp):
+    token = idp()
+    header, payload, signature = token.split(".")
+    forged = f"{header}.{payload[:-2]}AA.{signature}"
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(forged, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_expired_token_is_invalid(idp):
+    token = idp(exp=int(time.time()) - 3600)
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(token, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_wrong_audience_is_invalid(idp):
+    token = idp(aud="someone-else")
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(token, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_wrong_issuer_is_invalid(idp):
+    token = idp(iss="https://evil.test")
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(token, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_hmac_downgrade_is_invalid(idp):
+    # A token HMAC-"signed" with public material must not verify: only
+    # asymmetric algorithms are accepted.
+    forged = jwt.encode(
+        {"iss": ISSUER, "aud": CLIENT_ID, "exp": int(time.time()) + 300},
+        "not-a-real-key", algorithm="HS256", headers={"kid": "test-key"})
+    with pytest.raises(TokenInvalid):
+        _run(verified_claims(forged, DISCOVERY_URL, CLIENT_ID))
+
+
+def test_missing_discovery_is_unavailable_not_invalid(idp):
+    with pytest.raises(VerificationUnavailable):
+        _run(verified_claims(idp(), None, CLIENT_ID))
+
+
+def test_unreachable_jwks_is_unavailable(idp, monkeypatch):
+    async def down(url):
+        raise VerificationUnavailable(f"fetch failed for {url}")
+
+    monkeypatch.setattr(sso_jwt_verify, "_fetch_json", down)
+    sso_jwt_verify._discovery_cache.clear()
+    sso_jwt_verify._jwks_cache.clear()
+    with pytest.raises(VerificationUnavailable):
+        _run(verified_claims(idp(), DISCOVERY_URL, CLIENT_ID))
+
+
+def test_strict_mode_flag(monkeypatch):
+    monkeypatch.delenv("VYMANAGER_SSO_REQUIRE_JWT_VERIFY", raising=False)
+    assert sso_jwt_verify.require_verification() is False
+    monkeypatch.setenv("VYMANAGER_SSO_REQUIRE_JWT_VERIFY", "1")
+    assert sso_jwt_verify.require_verification() is True

--- a/backend/vyos_builders/ospf/ospf_batch_builder.py
+++ b/backend/vyos_builders/ospf/ospf_batch_builder.py
@@ -287,16 +287,29 @@ class OspfBatchBuilder:
     # Redistribute
     # ========================================================================
 
+    # Protocols that only exist as redistribute sources from VyOS 1.5.
+    _V15_ONLY_REDISTRIBUTE = frozenset({"nhrp"})
+
+    def _check_redistribute_supported(self, protocol: str) -> None:
+        if protocol in self._V15_ONLY_REDISTRIBUTE and "1.4" in self.version:
+            raise ValueError(
+                f"redistribute {protocol} requires VyOS 1.5+. "
+                "Current device is running v1.4")
+
     def set_redistribute(self, protocol: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute(protocol))
 
     def set_redistribute_metric(self, protocol: str, value: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute_metric(protocol, value))
 
     def set_redistribute_metric_type(self, protocol: str, value: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute_metric_type(protocol, value))
 
     def set_redistribute_route_map(self, protocol: str, value: str) -> "OspfBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_redistribute_route_map(protocol, value))
 
     def delete_redistribute(self, protocol: str) -> "OspfBatchBuilder":

--- a/backend/vyos_mappers/firewall/zones_versions/__init__.py
+++ b/backend/vyos_mappers/firewall/zones_versions/__init__.py
@@ -23,13 +23,11 @@ def get_firewall_zones_mapper(version: str) -> "FirewallZonesMapper":
     from .v1_4 import FirewallZonesMapper_v1_4
     from .v1_5 import FirewallZonesMapper_v1_5
 
-    version_map = {
-        "1.4": FirewallZonesMapper_v1_4,
-        "1.5": FirewallZonesMapper_v1_5,
-    }
-
-    mapper_class = version_map.get(version, FirewallZonesMapper_v1_5)
-    return mapper_class(version)
+    # Substring match like every other factory: exact-key lookup silently
+    # fell back to the 1.5 mapper for strings like "1.4.0" or "sagitta".
+    if "1.4" in version:
+        return FirewallZonesMapper_v1_4(version)
+    return FirewallZonesMapper_v1_5(version)
 
 
 __all__ = ["get_firewall_zones_mapper"]

--- a/backend/vyos_mappers/interfaces/ethernet_versions/__init__.py
+++ b/backend/vyos_mappers/interfaces/ethernet_versions/__init__.py
@@ -27,15 +27,11 @@ def get_ethernet_mapper(version: str) -> "EthernetInterfaceMapper":
     from .v1_4 import EthernetMapper_v1_4
     from .v1_5 import EthernetMapper_v1_5
 
-    version_map = {
-        "1.4": EthernetMapper_v1_4,
-        "1.5": EthernetMapper_v1_5,
-    }
-
-    # Get mapper class for version, fallback to latest (1.5) for unknown versions
-    mapper_class = version_map.get(version, EthernetMapper_v1_5)
-
-    return mapper_class(version)
+    # Substring match like every other factory: exact-key lookup silently
+    # fell back to the 1.5 mapper for strings like "1.4.0" or "sagitta".
+    if "1.4" in version:
+        return EthernetMapper_v1_4(version)
+    return EthernetMapper_v1_5(version)
 
 
 __all__ = ["get_ethernet_mapper"]

--- a/backend/vyos_mappers/isis/isis_versions/v1_4.py
+++ b/backend/vyos_mappers/isis/isis_versions/v1_4.py
@@ -7,61 +7,65 @@ VyOS 1.4 does NOT support:
   - SRv6 locator (segment-routing srv6)
   - Traffic Engineering export
 
-All v1.5-only methods return [] so builder.add_set([]) becomes a no-op.
+All v1.5-only methods raise ValueError: silently dropping the operation
+returned success while applying nothing (a false-positive the audit
+flagged); the router surfaces the error as a 400.
 """
 
 from typing import List
+
+_V15_ONLY = "This IS-IS option requires VyOS 1.5+. Current device is running v1.4"
 
 
 class IsisMapperV1_4:
     # TI-LFA — not supported
     def get_interface_ti_lfa_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level1_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level1_node_protection_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level1_link_fallback_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level2_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level2_node_protection_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_ti_lfa_level2_link_fallback_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     # Remote LFA — not supported
     def get_interface_remote_lfa_level1_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level1_max_metric_path(self, iface: str, val: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level1_tunnel_mpls_ldp_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level2_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level2_max_metric_path(self, iface: str, val: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_interface_remote_lfa_level2_tunnel_mpls_ldp_path(self, iface: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     # SRv6 — not supported
     def get_sr_srv6_locator_path(self, locator: str) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     def get_sr_srv6_path(self) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)
 
     # TE export — not supported
     def get_te_export_path(self) -> List[str]:
-        return []
+        raise ValueError(_V15_ONLY)

--- a/backend/vyos_mappers/nat/nat_versions/v1_4.py
+++ b/backend/vyos_mappers/nat/nat_versions/v1_4.py
@@ -1,11 +1,67 @@
 """NAT mapper for VyOS 1.4."""
+from typing import List
+
 from ..nat import NATMapper
+
+_CGNAT_UNSUPPORTED = "CGNAT requires VyOS 1.5+. Current device is running v1.4"
 
 
 class NATMapper_v1_4(NATMapper):
     """NAT mapper for VyOS 1.4.
 
-    NAT is a core feature available in VyOS 1.4.
-    All commands are supported in this version.
+    Source, destination and static NAT are fully supported. CGNAT
+    (``nat cgnat ...``) only exists from VyOS 1.5, so every CGNAT path
+    raises here — mirroring the firewall groups v1_4 mapper — instead of
+    emitting a path the device would reject at commit.
     """
-    pass
+
+    def get_cgnat_log_allocation(self) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_port_range(self, pool_name: str, port_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_port_range_path(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_per_user_limit_port(self, pool_name: str, port: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_per_user_limit_port_path(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_range(self, pool_name: str, ip_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_range_seq(self, pool_name: str, ip_range: str, seq: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_external_range_seq_path(self, pool_name: str, ip_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_internal(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_internal_range(self, pool_name: str, ip_range: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_pool_internal_range_path(self, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule(self, rule_number: int) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_source_pool(self, rule_number: int, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_source_pool_path(self, rule_number: int) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_translation_pool(self, rule_number: int, pool_name: str) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)
+
+    def get_cgnat_rule_translation_pool_path(self, rule_number: int) -> List[str]:
+        raise ValueError(_CGNAT_UNSUPPORTED)

--- a/container/vymanager-dev/env-file-docker-compose.yml
+++ b/container/vymanager-dev/env-file-docker-compose.yml
@@ -21,6 +21,29 @@ services:
       retries: 5
       start_period: 10s
 
+  # One-shot migration runner: applies Prisma migrations before the
+  # backend serves and before the frontend starts (the backend healthcheck
+  # used to gate the frontend, which ran the migrations — so on upgrades
+  # the backend served against the old schema until the frontend came up).
+  migrate:
+    build:
+      context: ../../frontend
+      dockerfile: Dockerfile
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    volumes:
+      - ../../frontend:/app
+      - /app/node_modules
+      - /app/.next
+    env_file:
+      - ../../frontend/.env
+    restart: "no"
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     build:
       context: ../../backend
@@ -41,6 +64,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
       interval: 30s

--- a/container/vymanager-prod/env-file-docker-compose.yml
+++ b/container/vymanager-prod/env-file-docker-compose.yml
@@ -22,6 +22,23 @@ services:
       retries: 5
       start_period: 10s
 
+  # One-shot migration runner: applies Prisma migrations before the
+  # backend serves and before the frontend starts. The frontend
+  # entrypoint still runs migrate deploy itself (harmless no-op here) so
+  # non-compose deployments keep working.
+  migrate:
+    image: ghcr.io/community-vyprojects/vymanager-frontend:beta
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    env_file:
+      - ../../frontend/.env
+    restart: "no"
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     image: ghcr.io/community-vyprojects/vymanager-backend:beta
     container_name: vymanager-backend
@@ -35,6 +52,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
       interval: 30s
@@ -52,6 +71,11 @@ services:
     restart: unless-stopped
     networks:
       - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
 networks:
   vymanager-network:

--- a/docs-site/docs/architecture/organizations.md
+++ b/docs-site/docs/architecture/organizations.md
@@ -74,15 +74,24 @@ enforcement), grant it narrowly:
 
 ```sql
 GRANT USAGE ON SCHEMA public TO vym_frontend;
-GRANT SELECT, INSERT, UPDATE, DELETE ON users, sessions, accounts, verifications
+GRANT SELECT, INSERT, DELETE ON users TO vym_frontend;
+-- UPDATE on users is column-scoped: everything EXCEPT role. The site-admin
+-- bit is backend-owned (/internal/sso-reconcile applies it), so a
+-- compromised frontend cannot self-promote. role is still set at INSERT
+-- (first-user promotion, SSO mapping at creation) — creation-time only.
+GRANT UPDATE (name, email, "emailVerified", image, "createdAt", "updatedAt")
+    ON users TO vym_frontend;
+GRANT SELECT, INSERT, UPDATE, DELETE ON sessions, accounts, verifications
     TO vym_frontend;
 -- No grant on org_memberships / user_instance_roles /
--- user_feature_permissions / organizations: the frontend never writes them.
+-- user_feature_permissions / organizations / oauth_role_mappings / sites /
+-- instances: the frontend never writes them (oauth config and role
+-- mappings write via backend endpoints since #484/#487).
 ```
 
-`oauth_role_mappings` is not yet in the ban — the frontend still writes it via
-the OAuth-config UI; relocating that write to the backend (as the SSO reconcile
-relocation did for grants) is the remaining step before it joins the list.
+Verify the live role after the switch with
+`DATABASE_URL=<frontend-role-url> python -m scripts.prove_runtime_role`,
+which also asserts `users.role` is not updatable.
 
 ## Row-level security (foundation in place, inert)
 

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -150,35 +150,15 @@
         "summary": "Connect To Instance",
         "description": "Connect to a specific VyOS instance.\n\nThis sets the user's active session to the specified instance.\nOnly one instance can be active at a time per user.",
         "operationId": "connect_to_instance_session_connect_post",
-        "parameters": [
-          {
-            "name": "org_id",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Organization to act in; defaults to your sole organization.",
-              "title": "Org Id"
-            },
-            "description": "Organization to act in; defaults to your sole organization."
-          }
-        ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ConnectRequest"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -40921,19 +40921,14 @@
           "needs_onboarding": {
             "type": "boolean",
             "title": "Needs Onboarding"
-          },
-          "user_count": {
-            "type": "integer",
-            "title": "User Count"
           }
         },
         "type": "object",
         "required": [
-          "needs_onboarding",
-          "user_count"
+          "needs_onboarding"
         ],
         "title": "OnboardingStatusResponse",
-        "description": "Response indicating if system needs onboarding."
+        "description": "Response indicating if system needs onboarding.\n\nPublic pre-auth endpoint: deliberately only the boolean \u2014 the exact\nuser count is unauthenticated info disclosure."
       },
       "OpenfabricBatchOperation": {
         "properties": {

--- a/frontend/src/app/api/auth/[...all]/route.ts
+++ b/frontend/src/app/api/auth/[...all]/route.ts
@@ -85,6 +85,17 @@ export async function POST(request: NextRequest) {
             { status: 403 }
           );
         }
+      } else if (!allowOnboardingFailOpen) {
+        // A non-2xx answer must fail closed like a network error —
+        // otherwise any backend hiccup reopens registration.
+        return NextResponse.json(
+          {
+            error: {
+              message: "Unable to verify onboarding status. Please try again later.",
+            },
+          },
+          { status: 503 }
+        );
       }
     } catch (err) {
       console.error("[Auth] Error checking onboarding status:", err);

--- a/frontend/src/app/api/user-management/[...path]/route.ts
+++ b/frontend/src/app/api/user-management/[...path]/route.ts
@@ -51,8 +51,11 @@ async function proxyRequest(
   const BACKEND_URL = getBackendUrl();
 
   try {
-    // Get the session token from request cookies
-    const sessionToken = request.cookies.get("better-auth.session_token");
+    // Get the session token from request cookies (secure deployments
+    // prefix the cookie name with __Secure-)
+    const sessionToken =
+      request.cookies.get("better-auth.session_token") ??
+      request.cookies.get("__Secure-better-auth.session_token");
 
     // Build the backend URL
     const backendPath = `/user-management/${path.join("/")}`;
@@ -69,7 +72,7 @@ async function proxyRequest(
 
     // Add the session token cookie if it exists
     if (sessionToken) {
-      headers["Cookie"] = `better-auth.session_token=${sessionToken.value}`;
+      headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
     }
 
     // Handle request body

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -154,12 +154,11 @@ async function buildAuth() {
       : null;
 
     if (existing) {
-      if (resolved.siteRole) {
-        await prisma.user.update({
-          where: { id: existing.id },
-          data: { role: resolved.siteRole },
-        });
-      }
+      // users.role is backend-owned: /internal/sso-reconcile re-derives the
+      // claims from the stored account token and applies the site role
+      // itself. Writing it here too would keep the frontend DB role needing
+      // UPDATE on users.role — the exact privilege the Golden Rule wants
+      // revoked (a compromised frontend could self-promote to ADMIN).
       await reconcileGrants(existing.id);
     } else if (
       email &&

--- a/frontend/src/lib/oauth-proxy.ts
+++ b/frontend/src/lib/oauth-proxy.ts
@@ -19,11 +19,15 @@ export async function proxyOauthConfig(
   backendPath: string,
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
 ): Promise<NextResponse> {
-  const sessionToken = request.cookies.get("better-auth.session_token");
+  // Secure-cookie deployments prefix the name with __Secure-; forward
+  // whichever is present under its original name (the backend accepts both).
+  const sessionToken =
+    request.cookies.get("better-auth.session_token") ??
+    request.cookies.get("__Secure-better-auth.session_token");
 
   const headers: Record<string, string> = {};
   if (sessionToken) {
-    headers["Cookie"] = `better-auth.session_token=${sessionToken.value}`;
+    headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
   }
 
   let body: string | undefined;


### PR DESCRIPTION
Consolidates all 18 open audit-fix PRs into one reviewable, pre-integrated branch so they can land with a single review+merge instead of 18 sequential merges (several of which conflict pairwise on `session.py`, `org_scope.py`, `test_cross_org.py`, and the golden-rule tests).

## Why one PR
The 18 branches conflict once stacked (e.g. `routers/session/session.py` is touched by #516/#519/#521/#524; `test_cross_org.py` by #514/#525/#528). Rather than 6+ branch-rebase force-pushes, every commit is cherry-picked here in dependency order with conflicts resolved once and the **whole** result tested together.

## Included (in merge order)
#511 CGNAT 1.4 gate · #512 backend-waits-for-migrations · #513 CI pytest+Postgres · #517 bridge/flowtables grants · #520 mapper version-gating · #522 owner-orphan boundary · #523 SR batch validation · #527 SSO JWKS verify · #514 assignment org row-check · #516 `__Secure-` cookie · #518 middleware polling/log · #519 connect-outside-tx · #521 restore savepoint · #524 unauth surface · #525 org-scope oracle/revocation · #528 org-CRUD + token-use tests · #515 canary/golden-rule guardrails · #526 users.role backend-owned.

## Conflicts resolved
- `test_cross_org.py` (#514 vs #528): kept **both** appended tests (`test_cross_org_grant_is_never_minted` + `test_token_use_cannot_cross_the_org_boundary`).
- All other overlaps auto-3-way-merged; verified each fix survived (get_session_cookie at all 3 sites + org_unit_of_work restructure coexist; POLLING typo fix intact; etc.).

## One integration fix
`test_revocation_bus.py::test_token_revoke_emits_through_bus` asserted the `token:<id>` emit that #525 deliberately removed — updated to assert the user-scoped emit only. This only surfaced because #525's branch predated the DB CI (#513), so its own CI never ran the DB suite.

## Verification (local, Postgres 17 + migrations applied)
- **209 passed** with `DATABASE_URL` set (full adversarial/RLS/golden-rule/SSO-JWKS/org-CRUD/token-use suite) + golden capture.
- 173 passed / 36 skipped without DB.
- Frontend `tsc --noEmit` clean (TS changes in #516/#524/#526).
- OpenAPI spec regenerated (`docs-site/openapi/vymanager.json`) — in sync.
- One pre-existing timing-flaky test (`test_delivery_and_transaction_coupling`, NOTIFY round-trip) noted; green on re-run, unrelated to these changes.

## Landing
Merge as a **merge commit** to preserve the 18 per-PR commits in history (repo otherwise squashes; either works). On merge, the 18 individual PRs can be closed as rolled-up here.
