### PR TITLE
fix(sso): Entra id_token group claims + correct OAuth error redirect

### DIFF
--- a/frontend/src/app/api/auth/[...all]/route.ts
+++ b/frontend/src/app/api/auth/[...all]/route.ts
@@ -44,7 +44,15 @@ export async function GET(request: NextRequest) {
     request.nextUrl.pathname.includes("/oauth2/callback/") &&
     response.status >= 500
   ) {
-    return NextResponse.redirect(new URL("/login?error=oauth", request.url));
+    // Build the redirect off the configured PUBLIC base URL, not request.url.
+    // Behind a TLS-terminating reverse proxy the incoming request host is the
+    // internal container address (e.g. https://localhost:3000), so redirecting
+    // relative to request.url sends the browser to a dead internal origin.
+    const publicBase =
+      process.env.BETTER_AUTH_URL ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      request.nextUrl.origin;
+    return NextResponse.redirect(new URL("/login?error=oauth", publicBase));
   }
   return response;
 }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -71,6 +71,120 @@ type GenericOAuthProviderConfig = NonNullable<
   Parameters<typeof genericOAuth>[0]["config"]
 >[number];
 
+/**
+ * Decode a JWT payload WITHOUT verifying its signature.
+ *
+ * We only use these claims for the frontend deny-gate (does this login match a
+ * permitted group?). The authoritative, security-sensitive read happens in the
+ * backend /internal/sso-reconcile, which re-verifies the stored id_token against
+ * the provider JWKS before trusting its groups. Here we just need the claim
+ * values, and the id_token was handed to us directly over the back-channel token
+ * exchange, so no untrusted party sat in between.
+ */
+function decodeJwtClaims(
+  token: string | undefined | null,
+): Record<string, unknown> | null {
+  if (!token) return null;
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const json = Buffer.from(payload, "base64").toString("utf8");
+    const parsed = JSON.parse(json);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// OIDC discovery cache: discoveryUrl -> userinfo_endpoint (or null if the doc
+// has none / the fetch failed). Populated lazily on first login per provider.
+const discoveredUserInfoUrls = new Map<string, string | null>();
+
+async function resolveUserInfoUrl(
+  userInfoUrl: string | null,
+  discoveryUrl: string | null,
+): Promise<string | null> {
+  if (userInfoUrl) return userInfoUrl;
+  if (!discoveryUrl) return null;
+  if (discoveredUserInfoUrls.has(discoveryUrl)) {
+    return discoveredUserInfoUrls.get(discoveryUrl) ?? null;
+  }
+  let endpoint: string | null = null;
+  try {
+    const res = await fetch(discoveryUrl);
+    if (res.ok) {
+      const doc = (await res.json()) as { userinfo_endpoint?: string };
+      endpoint = doc.userinfo_endpoint ?? null;
+    }
+  } catch (e) {
+    console.error("[SSO] OIDC discovery fetch failed:", e);
+  }
+  discoveredUserInfoUrls.set(discoveryUrl, endpoint);
+  return endpoint;
+}
+
+type OAuthTokensLike = {
+  idToken?: string | null;
+  accessToken?: string | null;
+};
+
+/**
+ * Custom getUserInfo that preserves the FULL id_token claim set.
+ *
+ * Better Auth's default getUserInfo decodes the id_token but reduces it to a
+ * fixed whitelist (sub/email/email_verified/name/picture), silently dropping
+ * `groups`. Some IdPs (notably Microsoft Entra) emit group claims ONLY in the
+ * id_token and never via the /userinfo endpoint, so the default profile arrives
+ * with no groups and the role-mapping deny-gate rejects every Entra login even
+ * when the user is in a permitted group. (Authentik works because it returns
+ * groups from /userinfo.)
+ *
+ * We therefore: keep every id_token claim (so `groups` survives), and backfill
+ * from /userinfo for providers that keep identity fields out of the id_token.
+ */
+function buildGetUserInfo(userInfoUrl: string | null, discoveryUrl: string | null) {
+  return async (tokens: OAuthTokensLike): Promise<Record<string, unknown> | null> => {
+    const idClaims = decodeJwtClaims(tokens.idToken);
+
+    let userInfo: Record<string, unknown> | null = null;
+    const url = await resolveUserInfoUrl(userInfoUrl, discoveryUrl);
+    if (url && tokens.accessToken) {
+      try {
+        const res = await fetch(url, {
+          headers: {
+            Authorization: `Bearer ${tokens.accessToken}`,
+            Accept: "application/json",
+          },
+        });
+        if (res.ok) userInfo = (await res.json()) as Record<string, unknown>;
+      } catch (e) {
+        console.error("[SSO] userinfo fetch failed:", e);
+      }
+    }
+
+    if (!idClaims && !userInfo) return null;
+
+    // id_token claims win over /userinfo: they carry the group claim Entra only
+    // exposes there and hold the authoritative sub/email. /userinfo backfills
+    // any fields a provider leaves out of the id_token.
+    const claims = { ...(userInfo ?? {}), ...(idClaims ?? {}) };
+
+    // Normalize the standard identity fields Better Auth consumes, while keeping
+    // every raw claim (incl. `groups`) for mapProfileToUser/applyRoleMapping.
+    return {
+      ...claims,
+      id: claims.sub ?? claims.id,
+      email: claims.email,
+      emailVerified: claims.email_verified ?? false,
+      name: claims.name ?? claims.preferred_username ?? claims.email,
+      image: claims.picture ?? claims.image,
+    };
+  };
+}
+
 const isProd = process.env.NODE_ENV === "production";
 
 const trustedOrigins = process.env.TRUSTED_ORIGINS
@@ -181,9 +295,13 @@ async function buildAuth() {
     ...(p.discoveryUrl ? { discoveryUrl: p.discoveryUrl } : {}),
     ...(p.authorizationUrl ? { authorizationUrl: p.authorizationUrl } : {}),
     ...(p.tokenUrl ? { tokenUrl: p.tokenUrl } : {}),
-    ...(p.userInfoUrl ? { getUserInfo: undefined, userInfoUrl: p.userInfoUrl } : {}),
+    ...(p.userInfoUrl ? { userInfoUrl: p.userInfoUrl } : {}),
     scopes: p.scopes ? p.scopes.split(" ").filter(Boolean) : ["openid", "email", "profile"],
     pkce: p.pkce,
+    // Override profile fetching so group claims that live only in the id_token
+    // (e.g. Microsoft Entra) survive into mapProfileToUser. See buildGetUserInfo.
+    getUserInfo: buildGetUserInfo(p.userInfoUrl, p.discoveryUrl) as unknown as
+      GenericOAuthProviderConfig["getUserInfo"],
     // Cast: the returned `role` is a declared additionalField, persisted at
     // runtime, but absent from the plugin's base-user return type.
     mapProfileToUser: ((profile: Record<string, unknown>) =>


### PR DESCRIPTION
## Summary

Fixes #531 — Microsoft Entra SSO logins were rejected with *"your account is not a member of any group permitted to access VyManager"* and the failure redirected to `https://localhost:3000/login?error=oauth`.

### Root cause 1 — dropped group claims (the deny)
Better Auth's default `getUserInfo` decodes the id_token but reduces it to a fixed whitelist (`sub`/`email`/`email_verified`/`name`/`picture`), **silently dropping `groups`**. Microsoft Entra emits group claims **only in the id_token** (never via `/userinfo`), so the profile handed to `mapProfileToUser` had no groups → `resolveRoleMapping` returned `denied`. Authentik worked only because it returns groups from `/userinfo`. (The backend `/internal/sso-reconcile` already reads groups from the stored id_token, so frontend and backend were sourcing groups from two places that only agree for Authentik.)

**Fix:** a custom `getUserInfo` that keeps the full id_token claim set (so `groups` survives), backfills from `/userinfo` via OIDC discovery for providers that keep identity out of the id_token, and normalizes the standard identity fields Better Auth consumes.

### Root cause 2 — wrong error redirect host
The OAuth error redirect was built with `new URL("/login?error=oauth", request.url)`. Behind a TLS-terminating reverse proxy, `request.url`'s host is the internal container origin → `https://localhost:3000`.

**Fix:** build the redirect off the configured public base URL (`BETTER_AUTH_URL` → `NEXT_PUBLIC_APP_URL` → `request.nextUrl.origin`).

## Changes
- `frontend/src/lib/auth.ts` — custom `getUserInfo` (`buildGetUserInfo`) + JWT decode / OIDC discovery helpers; attached to every provider.
- `frontend/src/app/api/auth/[...all]/route.ts` — error redirect uses the public base URL.

## Testing
- ESLint: clean on both files.
- `tsc --noEmit`: no errors in the changed files.
- ⏳ Not yet verified against a live Entra tenant — needs the reporter to confirm.

## Notes for reviewers / reporter
Two Entra-specific caveats that can still block a match even with this fix:
1. Entra sends group **Object IDs (GUIDs)** by default, so mapping rules' `claimValue` must be the GUIDs.
2. **Groups overage**: for users in >~200 groups, Entra omits `groups` entirely and sends `_claim_names`/`_claim_sources` pointing at Graph — not handled here.