### PR TITLE
deps: bump asyncssh to 2.23.1 (GHSA-2wxc-x7rj-hg8f)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ python-multipart==0.0.31
 bcrypt==5.0.0
 passlib==1.7.4
 email-validator==2.3.0
-asyncssh==2.23.0
+asyncssh==2.23.1
 cryptography==50.0.0
 PyJWT==2.13.0
 tzdata==2026.2


### PR DESCRIPTION
Updates `asyncssh` to address GHSA-2wxc-x7rj-hg8f.

Evidence:
- `backend/requirements.txt` referenced `asyncssh@2.23.0`
- osv-scanner reported GHSA-2wxc-x7rj-hg8f and GHSA-qr67-gv47-xwwh before the update
- updated version: `2.23.1`

Validation:
- osv-scanner no longer reports GHSA-2wxc-x7rj-hg8f or GHSA-qr67-gv47-xwwh after the update
- `python -m pytest tests/` (backend, without `tests/adversarial`) passes: 170 passed, 16 skipped

Scope: dependency update only (`backend/requirements.txt`).
