### PR TITLE
fix: Resolve GUID group claims bug in resolving role mapping

### DIFF
--- a/backend/routers/internal/sso_reconcile.py
+++ b/backend/routers/internal/sso_reconcile.py
@@ -15,6 +15,7 @@ import base64
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 import asyncpg
@@ -119,13 +120,29 @@ def _build_grants(matched: List[dict], key: str) -> List[dict]:
     return list(by_id.values())
 
 
+def _normalize_claim_value(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    cleaned = value.strip().removeprefix("{").removesuffix("}").strip()
+    lowered = cleaned.lower()
+    if re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        lowered,
+    ):
+        return lowered.replace("-", "")
+    return lowered
+
+
 def resolve_role_mapping(enabled: bool, rules: List[dict],
                          claim_values: List[str]) -> dict:
     if not enabled:
         return {"denied": False, "siteRole": None,
                 "instanceGrants": [], "siteGrants": []}
-    claim_set = set(claim_values)
-    matched = [r for r in rules if r["claimValue"] in claim_set]
+    normalized_claims = {_normalize_claim_value(v) for v in claim_values}
+    matched = [
+        r for r in rules
+        if _normalize_claim_value(r.get("claimValue")) in normalized_claims
+    ]
     if not matched:
         return {"denied": True, "siteRole": None,
                 "instanceGrants": [], "siteGrants": []}

--- a/backend/tests/test_sso_reconcile.py
+++ b/backend/tests/test_sso_reconcile.py
@@ -62,6 +62,16 @@ def test_resolve_instance_grant():
     assert r["instanceGrants"][0]["instanceRole"] == "OPERATOR"
 
 
+def test_resolve_guid_group_claims_case_insensitive():
+    admin_guid = "{11111111-2222-3333-4444-555555555555}"
+    rules = [{"claimValue": admin_guid, "siteRole": "ADMIN",
+              "instanceId": None, "siteId": None,
+              "instanceRole": None, "featurePermissions": None}]
+    resolved = resolve_role_mapping(True, rules, ["11111111-2222-3333-4444-555555555555"])
+    assert resolved["denied"] is False
+    assert resolved["siteRole"] == "ADMIN"
+
+
 # ---------------------------------------------------------------------------
 # Endpoint (real DB): reconciliation + forged-claims property
 # ---------------------------------------------------------------------------

--- a/frontend/src/lib/sso-role-mapping.test.ts
+++ b/frontend/src/lib/sso-role-mapping.test.ts
@@ -84,6 +84,15 @@ test("enabled + matching claim is allowed", () => {
   assert.equal(r.denied, false);
   assert.equal(r.siteRole, ADMIN);
 });
+test("matches Entra GUID strings case-insensitively and ignores braces", () => {
+  const guid = "{11111111-2222-3333-4444-555555555555}";
+  const r = resolveRoleMapping(
+    config([rule({ claimValue: guid, siteRole: ADMIN })]),
+    ["11111111-2222-3333-4444-555555555555"],
+  );
+  assert.equal(r.denied, false);
+  assert.equal(r.siteRole, ADMIN);
+});
 
 console.log("resolveRoleMapping — site role precedence");
 test("ADMIN outranks VIEWER when both match", () => {

--- a/frontend/src/lib/sso-role-mapping.ts
+++ b/frontend/src/lib/sso-role-mapping.ts
@@ -100,6 +100,16 @@ export function extractClaimValues(
   return [];
 }
 
+function normalizeClaimValue(value: string): string {
+  const trimmed = value.trim();
+  const withoutBraces = trimmed.replace(/[{}]/g, "").trim();
+  const lowered = withoutBraces.toLowerCase();
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(lowered)) {
+    return lowered.replace(/-/g, "");
+  }
+  return lowered;
+}
+
 /**
  * Resolve a provider's mapping rules against the claim values seen on a login.
  *
@@ -115,8 +125,10 @@ export function resolveRoleMapping(
     return { denied: false, siteRole: null, instanceGrants: [], siteGrants: [] };
   }
 
-  const claimSet = new Set(claimValues);
-  const matched = config.rules.filter((rule) => claimSet.has(rule.claimValue));
+  const claimSet = new Set(claimValues.map((value) => normalizeClaimValue(value)));
+  const matched = config.rules.filter((rule) =>
+    claimSet.has(normalizeClaimValue(rule.claimValue)),
+  );
 
   if (matched.length === 0) {
     return { denied: true, siteRole: null, instanceGrants: [], siteGrants: [] };


### PR DESCRIPTION
Should resolve #550 
Resolved possible formatting inconsistencies between SSO providers and the parsing used for role mapping, resulting in failure to apply correct group membership permissions.