### PR TITLE
ci: update checkout and setup actions in test workflows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           # Matches the backend production image (python:3.11-slim)
           python-version: '3.11'
@@ -60,7 +60,7 @@ jobs:
         run: pip install -r backend/requirements.txt
 
       - name: Set up Node (Prisma CLI)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 

--- a/.github/workflows/docs-openapi-check.yml
+++ b/.github/workflows/docs-openapi-check.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           # Matches the backend production image (python:3.11-slim)
           python-version: '3.11'


### PR DESCRIPTION
Updates the CI workflow actions to current stable majors.

Changes:
- `actions/checkout` v4 -> v7
- `actions/setup-python` v5 -> v7
- `actions/setup-node` v4 -> v7

Validation:
- both workflow files parse with a YAML parser after the change
- checked v7 release notes: no removed inputs in use (setup-python v7 removed only `pip-install`, not used here)

Scope: `.github/workflows/backend-tests.yml` and `.github/workflows/docs-openapi-check.yml` only. Publish workflows left unchanged.
