### PR TITLE
fix(security): Guard access-list and BGP batch operation names

### DIFF
--- a/backend/routers/access_list/access_list.py
+++ b/backend/routers/access_list/access_list.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/access-list", tags=["access-list"])
 
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors as_path_list.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
+
 # Stub functions for backwards compatibility with app.py
 def set_device_registry(registry):
     """Legacy function - no longer used."""
@@ -352,7 +359,11 @@ async def access_list_batch_configure(http_request: Request, body: AccessListBat
         
         # Process operations using inspect for dynamic method calls
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = list(sig.parameters.keys())
 
@@ -384,6 +395,8 @@ async def access_list_batch_configure(http_request: Request, body: AccessListBat
             data={"message": "Configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Unhandled error")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/routers/bgp/bgp.py
+++ b/backend/routers/bgp/bgp.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/bgp", tags=["bgp"])
 
+# Builder plumbing methods that must not be reachable via a client-supplied
+# operation name in /batch (mirrors bfd.py).
+_INTERNAL_BUILDER_METHODS = frozenset({
+    "add_set", "add_delete", "get_operations", "is_empty", "clear",
+    "operation_count", "get_capabilities",
+})
+
 
 # ============================================================================
 # Pydantic Models
@@ -821,7 +828,11 @@ async def bgp_batch_configure(http_request: Request, body: BgpBatchRequest):
         builder = BgpBatchBuilder(version=version)
 
         for operation in body.operations:
-            method = getattr(builder, operation.op)
+            if operation.op.startswith("_") or operation.op in _INTERNAL_BUILDER_METHODS:
+                raise HTTPException(status_code=400, detail=f"Invalid operation: {operation.op}")
+            method = getattr(builder, operation.op, None)
+            if not callable(method):
+                raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.op}")
             sig = inspect.signature(method)
             params = [p for p in sig.parameters.keys() if p != "self"]
 
@@ -849,6 +860,8 @@ async def bgp_batch_configure(http_request: Request, body: BgpBatchRequest):
             data={"message": "BGP configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
     except Exception as e:

--- a/backend/tests/test_routing_policy_rbac.py
+++ b/backend/tests/test_routing_policy_rbac.py
@@ -71,6 +71,8 @@ DYNAMIC_DISPATCH_FILES = [
     "large_community_list/large_community_list.py",
     "route/route.py",
     "route_map/route_map.py",
+    "access_list/access_list.py",
+    "bgp/bgp.py",
 ]
 
 


### PR DESCRIPTION
access-list and BGP /batch called getattr(builder, operation.op) with no allowlist, so a write-permitted caller could invoke add_set/add_delete and push raw paths past the mappers. The sibling routers already block that.

Both dispatchers now reject underscore-prefixed and infrastructure method names, require a callable, and re-raise HTTP 400 instead of turning it into 500. The routing-policy RBAC source test covers these two files.

Closes #565