### PR TITLE
fix: guard babel nhrp redistribute on 1.4

### DIFF
--- a/backend/tests/test_mapper_version_gating.py
+++ b/backend/tests/test_mapper_version_gating.py
@@ -11,6 +11,7 @@
 
 import pytest
 
+from vyos_builders.babel.babel_batch_builder import BabelBatchBuilder
 from vyos_builders.ospf.ospf_batch_builder import OspfBatchBuilder
 from vyos_mappers.firewall.zones_versions import get_firewall_zones_mapper
 from vyos_mappers.interfaces.ethernet_versions import get_ethernet_mapper
@@ -40,6 +41,26 @@ def test_ospf_15_allows_redistribute_nhrp():
     builder = OspfBatchBuilder(version="1.5")
     builder.set_redistribute("nhrp")
     assert builder.get_operations()[-1]["path"][-1] == "nhrp"
+
+
+def test_babel_14_rejects_redistribute_nhrp():
+    builder = BabelBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_redistribute_ipv4("nhrp")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_redistribute_ipv6("nhrp")
+    # supported protocols still pass through
+    builder.set_redistribute_ipv4("bgp")
+    assert builder.get_operations()
+
+
+def test_babel_15_allows_redistribute_nhrp():
+    builder = BabelBatchBuilder(version="1.5")
+    builder.set_redistribute_ipv4("nhrp")
+    builder.set_redistribute_ipv6("nhrp")
+    ops = builder.get_operations()
+    assert ops[0]["path"] == ["protocols", "babel", "redistribute", "ipv4", "nhrp"]
+    assert ops[1]["path"] == ["protocols", "babel", "redistribute", "ipv6", "nhrp"]
 
 
 @pytest.mark.parametrize("version", ["1.4", "1.4.0", "1.4.4 sagitta"])

--- a/backend/tests/test_mapper_version_gating.py
+++ b/backend/tests/test_mapper_version_gating.py
@@ -12,7 +12,9 @@
 import pytest
 
 from vyos_builders.babel.babel_batch_builder import BabelBatchBuilder
+from vyos_builders.bgp.bgp_batch_builder import BgpBatchBuilder
 from vyos_builders.ospf.ospf_batch_builder import OspfBatchBuilder
+from vyos_builders.vrf.vrf_batch_builder import VrfBatchBuilder
 from vyos_mappers.firewall.zones_versions import get_firewall_zones_mapper
 from vyos_mappers.interfaces.ethernet_versions import get_ethernet_mapper
 from vyos_mappers.isis.isis_versions.v1_4 import IsisMapperV1_4
@@ -61,6 +63,54 @@ def test_babel_15_allows_redistribute_nhrp():
     ops = builder.get_operations()
     assert ops[0]["path"] == ["protocols", "babel", "redistribute", "ipv4", "nhrp"]
     assert ops[1]["path"] == ["protocols", "babel", "redistribute", "ipv6", "nhrp"]
+
+
+def test_bgp_14_rejects_redistribute_nhrp():
+    builder = BgpBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_af_redistribute("ipv4-unicast", "nhrp")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_af_redistribute_metric("ipv4-unicast", "nhrp", "10")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_af_redistribute_route_map("ipv4-unicast", "nhrp", "RM")
+    # supported protocols still pass through
+    builder.set_af_redistribute("ipv4-unicast", "connected")
+    assert builder.get_operations()
+
+
+def test_bgp_15_allows_redistribute_nhrp():
+    builder = BgpBatchBuilder(version="1.5")
+    builder.set_af_redistribute("ipv4-unicast", "nhrp")
+    assert builder.get_operations()[-1]["path"][-1] == "nhrp"
+
+
+def test_vrf_bgp_14_rejects_redistribute_nhrp():
+    builder = VrfBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_bgp_af_redistribute("blue", "ipv4-unicast,nhrp")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_bgp_af_redistribute_metric("blue", "ipv4-unicast,nhrp,10")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_bgp_af_redistribute_route_map("blue", "ipv4-unicast,nhrp,RM")
+
+
+def test_vrf_ospf_14_rejects_redistribute_nhrp():
+    builder = VrfBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_ospf_redistribute("blue", "nhrp")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_ospf_redistribute_metric("blue", "nhrp,10")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_ospf_redistribute_metric_type("blue", "nhrp,2")
+    with pytest.raises(ValueError, match="1.5"):
+        builder.set_vrf_ospf_redistribute_route_map("blue", "nhrp,RM")
+
+
+def test_vrf_15_allows_redistribute_nhrp():
+    builder = VrfBatchBuilder(version="1.5")
+    builder.set_vrf_bgp_af_redistribute("blue", "ipv4-unicast,nhrp")
+    builder.set_vrf_ospf_redistribute("blue", "nhrp")
+    assert builder.get_operations()
 
 
 @pytest.mark.parametrize("version", ["1.4", "1.4.0", "1.4.4 sagitta"])

--- a/backend/vyos_builders/babel/babel_batch_builder.py
+++ b/backend/vyos_builders/babel/babel_batch_builder.py
@@ -178,7 +178,17 @@ class BabelBatchBuilder:
     # Redistribute Operations
     # ========================================================================
 
+    # Protocols that only exist as redistribute sources from VyOS 1.5.
+    _V15_ONLY_REDISTRIBUTE = frozenset({"nhrp"})
+
+    def _check_redistribute_supported(self, protocol: str) -> None:
+        if protocol in self._V15_ONLY_REDISTRIBUTE and "1.4" in self.version:
+            raise ValueError(
+                f"redistribute {protocol} requires VyOS 1.5+. "
+                "Current device is running v1.4")
+
     def set_redistribute_ipv4(self, protocol: str) -> "BabelBatchBuilder":
+        self._check_redistribute_supported(protocol)
         path = self.mappers[self.mapper_key].get_redistribute_ipv4(protocol)
         return self.add_set(path)
 
@@ -187,6 +197,7 @@ class BabelBatchBuilder:
         return self.add_delete(path)
 
     def set_redistribute_ipv6(self, protocol: str) -> "BabelBatchBuilder":
+        self._check_redistribute_supported(protocol)
         path = self.mappers[self.mapper_key].get_redistribute_ipv6(protocol)
         return self.add_set(path)
 

--- a/backend/vyos_builders/bgp/bgp_batch_builder.py
+++ b/backend/vyos_builders/bgp/bgp_batch_builder.py
@@ -977,13 +977,26 @@ class BgpBatchBuilder:
         return self.add_delete(self.m.get_af_maximum_paths_delete(afi))
 
     # Redistribute
+
+    # Protocols that only exist as redistribute sources from VyOS 1.5.
+    _V15_ONLY_REDISTRIBUTE = frozenset({"nhrp"})
+
+    def _check_redistribute_supported(self, protocol: str) -> None:
+        if protocol in self._V15_ONLY_REDISTRIBUTE and "1.4" in self.version:
+            raise ValueError(
+                f"redistribute {protocol} requires VyOS 1.5+. "
+                "Current device is running v1.4")
+
     def set_af_redistribute(self, afi: str, protocol: str) -> "BgpBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_af_redistribute(afi, protocol))
 
     def set_af_redistribute_metric(self, afi: str, protocol: str, value: str) -> "BgpBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_af_redistribute_metric(afi, protocol, value))
 
     def set_af_redistribute_route_map(self, afi: str, protocol: str, value: str) -> "BgpBatchBuilder":
+        self._check_redistribute_supported(protocol)
         return self.add_set(self.m.get_af_redistribute_route_map(afi, protocol, value))
 
     def set_af_redistribute_table(self, afi: str, table: str) -> "BgpBatchBuilder":

--- a/backend/vyos_builders/vrf/vrf_batch_builder.py
+++ b/backend/vyos_builders/vrf/vrf_batch_builder.py
@@ -56,6 +56,15 @@ class VrfBatchBuilder(
             self._operations.append({"op": "delete", "path": path})
         return self
 
+    # Protocols that only exist as redistribute sources from VyOS 1.5.
+    _V15_ONLY_REDISTRIBUTE = frozenset({"nhrp"})
+
+    def _check_redistribute_supported(self, protocol: str) -> None:
+        if protocol in self._V15_ONLY_REDISTRIBUTE and "1.4" in self.version:
+            raise ValueError(
+                f"redistribute {protocol} requires VyOS 1.5+. "
+                "Current device is running v1.4")
+
     def get_operations(self) -> List[Dict[str, Any]]:
         return self._operations.copy()
 

--- a/backend/vyos_builders/vrf/vrf_bgp_mixin.py
+++ b/backend/vyos_builders/vrf/vrf_bgp_mixin.py
@@ -1501,6 +1501,7 @@ class VrfBgpMixin:
         """Value format: 'afi,protocol'."""
         parts = value.split(",", 1)
         if len(parts) == 2:
+            self._check_redistribute_supported(parts[1])
             path = self.mappers["vrf_bgp"].get_bgp_af_redistribute(name, parts[0], parts[1])
             return self.add_set(path)
         return self
@@ -1509,6 +1510,7 @@ class VrfBgpMixin:
         """Value format: 'afi,protocol,metric'."""
         parts = value.split(",", 2)
         if len(parts) == 3:
+            self._check_redistribute_supported(parts[1])
             path = self.mappers["vrf_bgp"].get_bgp_af_redistribute_metric(name, parts[0], parts[1], parts[2])
             return self.add_set(path)
         return self
@@ -1517,6 +1519,7 @@ class VrfBgpMixin:
         """Value format: 'afi,protocol,route-map'."""
         parts = value.split(",", 2)
         if len(parts) == 3:
+            self._check_redistribute_supported(parts[1])
             path = self.mappers["vrf_bgp"].get_bgp_af_redistribute_route_map(name, parts[0], parts[1], parts[2])
             return self.add_set(path)
         return self

--- a/backend/vyos_builders/vrf/vrf_ospf_mixin.py
+++ b/backend/vyos_builders/vrf/vrf_ospf_mixin.py
@@ -1012,6 +1012,7 @@ class VrfOspfMixin:
 
     def set_vrf_ospf_redistribute(self, name: str, value: str) -> "VrfOspfMixin":
         """Value is the protocol (babel/bgp/connected/isis/kernel/rip/static)."""
+        self._check_redistribute_supported(value)
         path = self.mappers["vrf_ospf"].get_ospf_redistribute(name, value)
         return self.add_set(path)
 
@@ -1024,6 +1025,7 @@ class VrfOspfMixin:
         """Value format: 'protocol,metric'."""
         parts = value.split(",", 1)
         if len(parts) == 2:
+            self._check_redistribute_supported(parts[0])
             path = self.mappers["vrf_ospf"].get_ospf_redistribute_metric(name, parts[0], parts[1])
             return self.add_set(path)
         return self
@@ -1037,6 +1039,7 @@ class VrfOspfMixin:
         """Value format: 'protocol,metric_type'."""
         parts = value.split(",", 1)
         if len(parts) == 2:
+            self._check_redistribute_supported(parts[0])
             path = self.mappers["vrf_ospf"].get_ospf_redistribute_metric_type(name, parts[0], parts[1])
             return self.add_set(path)
         return self
@@ -1050,6 +1053,7 @@ class VrfOspfMixin:
         """Value format: 'protocol,route_map'."""
         parts = value.split(",", 1)
         if len(parts) == 2:
+            self._check_redistribute_supported(parts[0])
             path = self.mappers["vrf_ospf"].get_ospf_redistribute_route_map(name, parts[0], parts[1])
             return self.add_set(path)
         return self


### PR DESCRIPTION
get_capabilities() flags redistribute_nhrp as 1.5-only, but BabelBatchBuilder.set_redistribute_ipv4/ipv6 emitted protocols babel redistribute ipv4/ipv6 nhrp with no version guard. A direct API call with protocol nhrp on a 1.4 device failed at the router instead of returning a clean 400.

set_redistribute_ipv4 and set_redistribute_ipv6 now call _check_redistribute_supported, which raises ValueError on 1.4 for nhrp, matching OspfBatchBuilder. The batch dispatcher maps that to HTTP 400. Deletes stay unguarded so stale config can be removed on either version. Frontend already gates the nhrp checkbox off capabilities.redistribute_protocols, so no UI change is needed.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_mapper_version_gating.py, 11 passed. Confirmed the new 1.4 test fails without the guard.

Closes #566