### PR TITLE
refactor: replace nhrp denylist with mapper allowlists

### DIFF
--- a/backend/tests/test_mapper_version_gating.py
+++ b/backend/tests/test_mapper_version_gating.py
@@ -37,21 +37,21 @@ def test_isis_v14_rejects_ti_lfa_instead_of_silent_noop():
 
 def test_mappers_14_reject_redistribute_nhrp():
     babel = get_babel_mapper("1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         babel.get_redistribute_ipv4("nhrp")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         babel.get_redistribute_ipv6("nhrp")
     ospf = get_ospf_mapper("1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         ospf.get_redistribute("nhrp")
     bgp = get_bgp_mapper("1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         bgp.get_af_redistribute("ipv4-unicast", "nhrp")
     vrf_ospf = VrfOspfMapper("1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         vrf_ospf.get_ospf_redistribute("blue", "nhrp")
     vrf_bgp = VrfBgpMapper("1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         vrf_bgp.get_bgp_af_redistribute("blue", "ipv4-unicast", "nhrp")
 
 
@@ -64,7 +64,7 @@ def test_mappers_14_delete_redistribute_nhrp():
 
 def test_ospf_14_rejects_redistribute_nhrp():
     builder = OspfBatchBuilder(version="1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_redistribute("nhrp")
     # supported protocols still pass through
     builder.set_redistribute("bgp")
@@ -79,9 +79,9 @@ def test_ospf_15_allows_redistribute_nhrp():
 
 def test_babel_14_rejects_redistribute_nhrp():
     builder = BabelBatchBuilder(version="1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_redistribute_ipv4("nhrp")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_redistribute_ipv6("nhrp")
     # supported protocols still pass through
     builder.set_redistribute_ipv4("bgp")
@@ -101,11 +101,11 @@ def test_babel_15_allows_redistribute_nhrp():
 
 def test_bgp_14_rejects_redistribute_nhrp():
     builder = BgpBatchBuilder(version="1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_af_redistribute("ipv4-unicast", "nhrp")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_af_redistribute_metric("ipv4-unicast", "nhrp", "10")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_af_redistribute_route_map("ipv4-unicast", "nhrp", "RM")
     # supported protocols still pass through
     builder.set_af_redistribute("ipv4-unicast", "connected")
@@ -120,23 +120,23 @@ def test_bgp_15_allows_redistribute_nhrp():
 
 def test_vrf_bgp_14_rejects_redistribute_nhrp():
     builder = VrfBatchBuilder(version="1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_bgp_af_redistribute("blue", "ipv4-unicast,nhrp")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_bgp_af_redistribute_metric("blue", "ipv4-unicast,nhrp,10")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_bgp_af_redistribute_route_map("blue", "ipv4-unicast,nhrp,RM")
 
 
 def test_vrf_ospf_14_rejects_redistribute_nhrp():
     builder = VrfBatchBuilder(version="1.4")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_ospf_redistribute("blue", "nhrp")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_ospf_redistribute_metric("blue", "nhrp,10")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_ospf_redistribute_metric_type("blue", "nhrp,2")
-    with pytest.raises(ValueError, match="1.5"):
+    with pytest.raises(ValueError, match="not supported"):
         builder.set_vrf_ospf_redistribute_route_map("blue", "nhrp,RM")
 
 
@@ -145,6 +145,26 @@ def test_vrf_15_allows_redistribute_nhrp():
     builder.set_vrf_bgp_af_redistribute("blue", "ipv4-unicast,nhrp")
     builder.set_vrf_ospf_redistribute("blue", "nhrp")
     assert builder.get_operations()
+
+
+def test_allowlist_rejects_unknown_redistribute_protocol():
+    with pytest.raises(ValueError, match="not supported"):
+        get_ospf_mapper("1.5").get_redistribute("not-a-protocol")
+    with pytest.raises(ValueError, match="not supported"):
+        get_babel_mapper("1.5").get_redistribute_ipv4("not-a-protocol")
+
+
+def test_capabilities_read_mapper_allowlist():
+    caps_14 = OspfBatchBuilder(version="1.4").get_capabilities()
+    assert "nhrp" not in caps_14["redistribute_protocols"]
+    assert caps_14["features"]["redistribute_nhrp"]["supported"] is False
+    caps_15 = OspfBatchBuilder(version="1.5").get_capabilities()
+    assert "nhrp" in caps_15["redistribute_protocols"]
+    assert caps_15["features"]["redistribute_nhrp"]["supported"] is True
+    babel_14 = BabelBatchBuilder(version="1.4").get_capabilities()
+    assert "nhrp" not in babel_14["redistribute_protocols"]["ipv4"]
+    babel_15 = BabelBatchBuilder(version="1.5").get_capabilities()
+    assert "nhrp" in babel_15["redistribute_protocols"]["ipv4"]
 
 
 @pytest.mark.parametrize("version", ["1.4", "1.4.0", "1.4.4 sagitta"])

--- a/backend/vyos_builders/babel/babel_batch_builder.py
+++ b/backend/vyos_builders/babel/babel_batch_builder.py
@@ -414,7 +414,7 @@ class BabelBatchBuilder:
                     "description": "Distribute lists for route filtering",
                 },
                 "redistribute_nhrp": {
-                    "supported": is_1_5,
+                    "supported": "nhrp" in self.mappers[self.mapper_key].redistribute_ipv4_protocols(),
                     "description": "Redistribute NHRP routes (VyOS 1.5+)",
                 },
             },
@@ -423,19 +423,7 @@ class BabelBatchBuilder:
                 "is_1_5": is_1_5,
             },
             "redistribute_protocols": {
-                "ipv4": self._get_ipv4_redistribute_protocols(is_1_5),
-                "ipv6": self._get_ipv6_redistribute_protocols(is_1_5),
+                "ipv4": sorted(self.mappers[self.mapper_key].redistribute_ipv4_protocols()),
+                "ipv6": sorted(self.mappers[self.mapper_key].redistribute_ipv6_protocols()),
             },
         }
-
-    def _get_ipv4_redistribute_protocols(self, is_1_5: bool) -> List[str]:
-        protocols = ["bgp", "connected", "isis", "kernel", "openfabric", "ospf", "rip", "static"]
-        if is_1_5:
-            protocols.append("nhrp")
-        return sorted(protocols)
-
-    def _get_ipv6_redistribute_protocols(self, is_1_5: bool) -> List[str]:
-        protocols = ["bgp", "connected", "isis", "kernel", "openfabric", "ospfv3", "ripng", "static"]
-        if is_1_5:
-            protocols.append("nhrp")
-        return sorted(protocols)

--- a/backend/vyos_builders/bgp/bgp_batch_builder.py
+++ b/backend/vyos_builders/bgp/bgp_batch_builder.py
@@ -1180,7 +1180,7 @@ class BgpBatchBuilder:
                     "description": "Path attribute filtering (discard/treat-as-withdraw)",
                 },
                 "redistribute_nhrp": {
-                    "supported": is_1_5,
+                    "supported": "nhrp" in self.m.redistribute_protocols(),
                     "description": "Redistribute NHRP routes (VyOS 1.5+)",
                 },
             },

--- a/backend/vyos_builders/ospf/ospf_batch_builder.py
+++ b/backend/vyos_builders/ospf/ospf_batch_builder.py
@@ -621,7 +621,7 @@ class OspfBatchBuilder:
                     "description": "Route redistribution (connected, static, bgp, kernel, rip, isis, babel)",
                 },
                 "redistribute_nhrp": {
-                    "supported": is_1_5,
+                    "supported": "nhrp" in self.m.redistribute_protocols(),
                     "description": "Redistribute NHRP routes (VyOS 1.5+)",
                 },
                 "retransmit_window": {
@@ -649,9 +649,7 @@ class OspfBatchBuilder:
                     "description": "Max-metric router-LSA settings",
                 },
             },
-            "redistribute_protocols": [
-                "connected", "static", "bgp", "kernel", "rip", "isis", "babel",
-            ] + (["nhrp"] if is_1_5 else []),
+            "redistribute_protocols": self.m.redistribute_protocol_list(),
             "network_types": [
                 "broadcast", "non-broadcast", "point-to-multipoint", "point-to-point",
             ],

--- a/backend/vyos_builders/vrf/vrf_batch_builder.py
+++ b/backend/vyos_builders/vrf/vrf_batch_builder.py
@@ -264,7 +264,7 @@ class VrfBatchBuilder(
                     "description": "OSPF retransmit-window on interfaces/virtual-links (VyOS 1.5+ only)",
                 },
                 "ospf_redistribute_nhrp": {
-                    "supported": is_1_5,
+                    "supported": "nhrp" in self.mappers["vrf_ospf"].redistribute_protocols(),
                     "description": "OSPF redistribute NHRP (VyOS 1.5+ only)",
                 },
                 "isis_fast_reroute": {
@@ -272,7 +272,7 @@ class VrfBatchBuilder(
                     "description": "IS-IS fast-reroute (LFA, TI-LFA) (VyOS 1.5+ only)",
                 },
                 "bgp_redistribute_nhrp": {
-                    "supported": is_1_5,
+                    "supported": "nhrp" in self.mappers["vrf_bgp"].redistribute_protocols(),
                     "description": "BGP redistribute NHRP (VyOS 1.5+ only)",
                 },
             },

--- a/backend/vyos_mappers/babel/babel.py
+++ b/backend/vyos_mappers/babel/babel.py
@@ -5,15 +5,42 @@ Handles command path generation for Babel routing protocol configuration.
 Version-specific logic is in version-specific files.
 """
 
-from typing import List
-from ..base import BaseFeatureMapper, reject_nhrp_redistribute_on_14
+from typing import FrozenSet, List
+from ..base import BaseFeatureMapper
 
 
 class BabelMapper(BaseFeatureMapper):
     """Base mapper with common operations shared between VyOS 1.4 and 1.5."""
 
+    _REDIST_IPV4 = frozenset(
+        {"bgp", "connected", "isis", "kernel", "openfabric", "ospf", "rip", "static"}
+    )
+    _REDIST_IPV6 = frozenset(
+        {"bgp", "connected", "isis", "kernel", "openfabric", "ospfv3", "ripng", "static"}
+    )
+
     def __init__(self, version: str):
         super().__init__(version)
+
+    def redistribute_ipv4_protocols(self) -> FrozenSet[str]:
+        if "1.4" in self.version:
+            return self._REDIST_IPV4
+        return self._REDIST_IPV4 | {"nhrp"}
+
+    def redistribute_ipv6_protocols(self) -> FrozenSet[str]:
+        if "1.4" in self.version:
+            return self._REDIST_IPV6
+        return self._REDIST_IPV6 | {"nhrp"}
+
+    def _require_redistribute_ipv4(self, protocol: str) -> None:
+        if protocol not in self.redistribute_ipv4_protocols():
+            raise ValueError(
+                f"redistribute {protocol} is not supported on this device")
+
+    def _require_redistribute_ipv6(self, protocol: str) -> None:
+        if protocol not in self.redistribute_ipv6_protocols():
+            raise ValueError(
+                f"redistribute {protocol} is not supported on this device")
 
     # ========================================================================
     # Interface Paths
@@ -76,14 +103,14 @@ class BabelMapper(BaseFeatureMapper):
     # ========================================================================
 
     def get_redistribute_ipv4(self, protocol: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute_ipv4(protocol)
         return ["protocols", "babel", "redistribute", "ipv4", protocol]
 
     def get_redistribute_ipv4_delete(self, protocol: str) -> List[str]:
         return ["protocols", "babel", "redistribute", "ipv4", protocol]
 
     def get_redistribute_ipv6(self, protocol: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute_ipv6(protocol)
         return ["protocols", "babel", "redistribute", "ipv6", protocol]
 
     def get_redistribute_ipv6_delete(self, protocol: str) -> List[str]:

--- a/backend/vyos_mappers/base.py
+++ b/backend/vyos_mappers/base.py
@@ -8,18 +8,6 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Type, Union, Callable
 
 
-def reject_nhrp_redistribute_on_14(version: str, protocol: str) -> None:
-    """Raise when a 1.4 mapper is asked to emit redistribute nhrp.
-
-    Deletes must not call this. Removing a stale 1.4-invalid node is a no-op
-    on the router and should still succeed through the API.
-    """
-    if protocol == "nhrp" and "1.4" in version:
-        raise ValueError(
-            "redistribute nhrp requires VyOS 1.5+. "
-            "Current device is running v1.4")
-
-
 class BaseFeatureMapper(ABC):
     """
     Base class for feature-specific mappers.

--- a/backend/vyos_mappers/bgp/bgp.py
+++ b/backend/vyos_mappers/bgp/bgp.py
@@ -8,15 +8,29 @@ listen ranges, BMP, SID, SRv6, and interface MPLS settings.
 Version-specific logic is in version-specific files.
 """
 
-from typing import List
-from ..base import BaseFeatureMapper, reject_nhrp_redistribute_on_14
+from typing import FrozenSet, List
+from ..base import BaseFeatureMapper
 
 
 class BgpMapper(BaseFeatureMapper):
     """Base mapper with common operations shared between VyOS 1.4 and 1.5."""
 
+    _REDIST = (
+        "connected", "kernel", "ospf", "rip", "static", "babel", "isis",
+    )
+
     def __init__(self, version: str):
         super().__init__(version)
+
+    def redistribute_protocols(self) -> FrozenSet[str]:
+        if "1.4" in self.version:
+            return frozenset(self._REDIST)
+        return frozenset(self._REDIST) | {"nhrp"}
+
+    def _require_redistribute(self, protocol: str) -> None:
+        if protocol not in self.redistribute_protocols():
+            raise ValueError(
+                f"redistribute {protocol} is not supported on this device")
 
     # ========================================================================
     # Helper base paths
@@ -831,15 +845,15 @@ class BgpMapper(BaseFeatureMapper):
 
     # Redistribute
     def get_af_redistribute(self, afi: str, protocol: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._af(afi) + ["redistribute", protocol]
 
     def get_af_redistribute_metric(self, afi: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._af(afi) + ["redistribute", protocol, "metric", value]
 
     def get_af_redistribute_route_map(self, afi: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._af(afi) + ["redistribute", protocol, "route-map", value]
 
     def get_af_redistribute_table(self, afi: str, table: str) -> List[str]:

--- a/backend/vyos_mappers/ospf/ospf.py
+++ b/backend/vyos_mappers/ospf/ospf.py
@@ -10,15 +10,35 @@ ldp-sync, mpls-te, summary-address, segment-routing, aggregation, capability.
 Version-specific logic is in version-specific files.
 """
 
-from typing import List
-from ..base import BaseFeatureMapper, reject_nhrp_redistribute_on_14
+from typing import FrozenSet, List
+from ..base import BaseFeatureMapper
 
 
 class OspfMapper(BaseFeatureMapper):
     """Base mapper with common operations shared between VyOS 1.4 and 1.5."""
 
+    _REDIST = (
+        "connected", "static", "bgp", "kernel", "rip", "isis", "babel",
+    )
+
     def __init__(self, version: str):
         super().__init__(version)
+
+    def redistribute_protocols(self) -> FrozenSet[str]:
+        if "1.4" in self.version:
+            return frozenset(self._REDIST)
+        return frozenset(self._REDIST) | {"nhrp"}
+
+    def redistribute_protocol_list(self) -> List[str]:
+        protocols: List[str] = list(self._REDIST)
+        if "1.4" not in self.version:
+            protocols.append("nhrp")
+        return protocols
+
+    def _require_redistribute(self, protocol: str) -> None:
+        if protocol not in self.redistribute_protocols():
+            raise ValueError(
+                f"redistribute {protocol} is not supported on this device")
 
     # ========================================================================
     # Helper base paths
@@ -281,19 +301,19 @@ class OspfMapper(BaseFeatureMapper):
     # ========================================================================
 
     def get_redistribute(self, protocol: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._redistribute(protocol)
 
     def get_redistribute_metric(self, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._redistribute(protocol) + ["metric", value]
 
     def get_redistribute_metric_type(self, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._redistribute(protocol) + ["metric-type", value]
 
     def get_redistribute_route_map(self, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._redistribute(protocol) + ["route-map", value]
 
     def get_redistribute_delete(self, protocol: str) -> List[str]:

--- a/backend/vyos_mappers/vrf/vrf_bgp.py
+++ b/backend/vyos_mappers/vrf/vrf_bgp.py
@@ -11,15 +11,28 @@ Version-specific methods (nhrp redistribute, ipv6-unicast table redistribute,
 bmp local-rib, peer-group solo) will be in version-specific files.
 """
 
-from typing import List
-from ..base import reject_nhrp_redistribute_on_14
+from typing import FrozenSet, List
 
 
 class VrfBgpMapper:
     """Mapper for VRF BGP paths. Common between VyOS 1.4 and 1.5."""
 
+    _REDIST = (
+        "connected", "kernel", "ospf", "rip", "static", "babel", "isis",
+    )
+
     def __init__(self, version: str = ""):
         self.version = version
+
+    def redistribute_protocols(self) -> FrozenSet[str]:
+        if "1.4" in self.version:
+            return frozenset(self._REDIST)
+        return frozenset(self._REDIST) | {"nhrp"}
+
+    def _require_redistribute(self, protocol: str) -> None:
+        if protocol not in self.redistribute_protocols():
+            raise ValueError(
+                f"redistribute {protocol} is not supported on this device")
 
     def _base(self, name: str) -> List[str]:
         return ["vrf", "name", name, "protocols", "bgp"]
@@ -915,15 +928,15 @@ class VrfBgpMapper:
 
     # Redistribute
     def get_bgp_af_redistribute(self, name: str, afi: str, protocol: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._af(name, afi) + ["redistribute", protocol]
 
     def get_bgp_af_redistribute_metric(self, name: str, afi: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._af(name, afi) + ["redistribute", protocol, "metric", value]
 
     def get_bgp_af_redistribute_route_map(self, name: str, afi: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._af(name, afi) + ["redistribute", protocol, "route-map", value]
 
     def get_bgp_af_redistribute_table(self, name: str, afi: str, table: str) -> List[str]:

--- a/backend/vyos_mappers/vrf/vrf_ospf.py
+++ b/backend/vyos_mappers/vrf/vrf_ospf.py
@@ -26,15 +26,28 @@ Config tree: vrf name <NAME> protocols ospf
   timers (throttle/spf: delay, initial-holdtime, max-holdtime)
 """
 
-from typing import List
-from ..base import reject_nhrp_redistribute_on_14
+from typing import FrozenSet, List
 
 
 class VrfOspfMapper:
     """Mapper for VRF OSPF paths. Common between VyOS 1.4 and 1.5."""
 
+    _REDIST = (
+        "connected", "static", "bgp", "kernel", "rip", "isis", "babel",
+    )
+
     def __init__(self, version: str = ""):
         self.version = version
+
+    def redistribute_protocols(self) -> FrozenSet[str]:
+        if "1.4" in self.version:
+            return frozenset(self._REDIST)
+        return frozenset(self._REDIST) | {"nhrp"}
+
+    def _require_redistribute(self, protocol: str) -> None:
+        if protocol not in self.redistribute_protocols():
+            raise ValueError(
+                f"redistribute {protocol} is not supported on this device")
 
     def _base(self, name: str) -> List[str]:
         return ["vrf", "name", name, "protocols", "ospf"]
@@ -343,22 +356,22 @@ class VrfOspfMapper:
     # ========================================================================
 
     def get_ospf_redistribute(self, name: str, protocol: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._base(name) + ["redistribute", protocol]
 
     def get_ospf_redistribute_delete(self, name: str, protocol: str) -> List[str]:
         return self._base(name) + ["redistribute", protocol]
 
     def get_ospf_redistribute_metric(self, name: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._base(name) + ["redistribute", protocol, "metric", value]
 
     def get_ospf_redistribute_metric_type(self, name: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._base(name) + ["redistribute", protocol, "metric-type", value]
 
     def get_ospf_redistribute_route_map(self, name: str, protocol: str, value: str) -> List[str]:
-        reject_nhrp_redistribute_on_14(self.version, protocol)
+        self._require_redistribute(protocol)
         return self._base(name) + ["redistribute", protocol, "route-map", value]
 
     def get_ospf_redistribute_table(self, name: str, table: str) -> List[str]:


### PR DESCRIPTION
reject_nhrp_redistribute_on_14 lived on vyos_mappers/base.py and named one protocol on the shared foundation. Each builder also kept a handwritten nhrp flag in get_capabilities().

Deleted that helper. Babel, OSPF, BGP, and VRF mappers now own a versioned redistribute allowlist. Set paths reject any protocol not in the set. Deletes stay unguarded. get_capabilities() reads the same set for the frontend.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_mapper_version_gating.py, 20 passed.

Closes #581