### PR TITLE
fix: emit access-list network as sibling leaves

### DIFF
--- a/backend/tests/test_access_list_network_paths.py
+++ b/backend/tests/test_access_list_network_paths.py
@@ -1,0 +1,27 @@
+"""Access-list IPv4 network+mask must be sibling leaves, not a 5-token path.
+
+validateTmplPath rejects `source network ADDR MASK` on 1.4 and 1.5.
+VyOS wants `source network ADDR` plus `source inverse-mask MASK`.
+"""
+
+from vyos_builders.access_list.access_list import AccessListBatchBuilder
+
+
+def test_source_network_emits_sibling_leaves():
+    builder = AccessListBatchBuilder(version="1.4")
+    builder.set_rule_source_network("10", "1", "192.168.80.0", "0.0.0.255")
+    ops = builder.get_operations()
+    assert [op["path"] for op in ops] == [
+        ["policy", "access-list", "10", "rule", "1", "source", "network", "192.168.80.0"],
+        ["policy", "access-list", "10", "rule", "1", "source", "inverse-mask", "0.0.0.255"],
+    ]
+
+
+def test_destination_network_emits_sibling_leaves():
+    builder = AccessListBatchBuilder(version="1.5")
+    builder.set_rule_destination_network("10", "1", "192.168.80.0", "0.0.0.255")
+    ops = builder.get_operations()
+    assert [op["path"] for op in ops] == [
+        ["policy", "access-list", "10", "rule", "1", "destination", "network", "192.168.80.0"],
+        ["policy", "access-list", "10", "rule", "1", "destination", "inverse-mask", "0.0.0.255"],
+    ]

--- a/backend/vyos_builders/access_list/access_list.py
+++ b/backend/vyos_builders/access_list/access_list.py
@@ -156,11 +156,8 @@ class AccessListBatchBuilder:
     def set_rule_source_network(
         self, number: str, rule: str, address: str, mask: str
     ) -> "AccessListBatchBuilder":
-        """Set IPv4 rule source network."""
-        path = self.mappers[self.mapper_key].get_rule_source_network(
-            number, rule, address, mask
-        )
-        return self.add_set(path)
+        """IPv4 network plus mask is two sibling leaves, same as inverse-mask."""
+        return self.set_rule_source_inverse_mask(number, rule, address, mask)
 
     def delete_rule_source(
         self, number: str, rule: str
@@ -205,11 +202,8 @@ class AccessListBatchBuilder:
     def set_rule_destination_network(
         self, number: str, rule: str, address: str, mask: str
     ) -> "AccessListBatchBuilder":
-        """Set IPv4 rule destination network."""
-        path = self.mappers[self.mapper_key].get_rule_destination_network(
-            number, rule, address, mask
-        )
-        return self.add_set(path)
+        """IPv4 network plus mask is two sibling leaves, same as inverse-mask."""
+        return self.set_rule_destination_inverse_mask(number, rule, address, mask)
 
     def delete_rule_destination(
         self, number: str, rule: str

--- a/backend/vyos_mappers/access_list/access_list.py
+++ b/backend/vyos_mappers/access_list/access_list.py
@@ -60,10 +60,6 @@ class AccessListMapper(BaseFeatureMapper):
         """Get command path for rule source inverse-mask."""
         return ["policy", "access-list", number, "rule", rule, "source", "inverse-mask", mask]
 
-    def get_rule_source_network(self, number: str, rule: str, address: str, mask: str) -> List[str]:
-        """Get command path for rule source network."""
-        return ["policy", "access-list", number, "rule", rule, "source", "network", address, mask]
-
     def get_rule_destination_any(self, number: str, rule: str) -> List[str]:
         """Get command path for rule destination any."""
         return ["policy", "access-list", number, "rule", rule, "destination", "any"]
@@ -79,10 +75,6 @@ class AccessListMapper(BaseFeatureMapper):
     def get_rule_destination_inverse_mask_mask(self, number: str, rule: str, mask: str) -> List[str]:
         """Get command path for rule destination inverse-mask."""
         return ["policy", "access-list", number, "rule", rule, "destination", "inverse-mask", mask]
-
-    def get_rule_destination_network(self, number: str, rule: str, address: str, mask: str) -> List[str]:
-        """Get command path for rule destination network."""
-        return ["policy", "access-list", number, "rule", rule, "destination", "network", address, mask]
 
     # ========================================================================
     # Delete Paths (IPv4)


### PR DESCRIPTION
get_rule_source_network and get_rule_destination_network appended ADDR and MASK onto one path. validateTmplPath rejects that on 1.4 and 1.5. VyOS wants source network ADDR plus source inverse-mask MASK, which set_rule_source_inverse_mask already emits.

Removed the 5-token mapper methods. set_rule_source_network and set_rule_destination_network now emit the same two sibling leaves. Frontend op names are unchanged. IPv6 network (single CIDR) is unchanged.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_access_list_network_paths.py, 2 passed. Lab: 5-token INVALID on both hosts; sibling network and inverse-mask VALID on both.

Closes #567