### PR TITLE
refactor: drop unused set_device_registry router stubs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -478,12 +478,6 @@ router = APIRouter(prefix="/vyos/{device_name}/bridge", tags=["bridge-interface"
 device_registry: VyOSDeviceRegistry = None
 
 
-def set_device_registry(registry: VyOSDeviceRegistry):
-    """Set the device registry for this router."""
-    global device_registry
-    device_registry = registry
-
-
 # ============================================================================
 # Request Models (for WRITE operations)
 # ============================================================================
@@ -651,7 +645,6 @@ __all__ = [..., "BridgeBatchBuilder"]
 **Router** (`app.py`):
 ```python
 from routers.interfaces import bridge
-bridge.set_device_registry(device_registry)
 app.include_router(bridge.router)
 ```
 

--- a/backend/routers/access_list/access_list.py
+++ b/backend/routers/access_list/access_list.py
@@ -26,16 +26,6 @@ _INTERNAL_BUILDER_METHODS = frozenset({
     "operation_count", "get_capabilities",
 })
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/as_path_list/as_path_list.py
+++ b/backend/routers/as_path_list/as_path_list.py
@@ -26,16 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/as-path-list", tags=["as-path-list"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/community_list/community_list.py
+++ b/backend/routers/community_list/community_list.py
@@ -26,16 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/community-list", tags=["community-list"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/config/config.py
+++ b/backend/routers/config/config.py
@@ -20,16 +20,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/config", tags=["config"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # In-memory storage for saved configuration snapshots per instance
 # Key: instance_id, Value: config snapshot

--- a/backend/routers/dhcp/__init__.py
+++ b/backend/routers/dhcp/__init__.py
@@ -1,4 +1,4 @@
 """DHCP Server router."""
-from .dhcp import router, set_device_registry, set_configured_device_name
+from .dhcp import router
 
-__all__ = ["router", "set_device_registry", "set_configured_device_name"]
+__all__ = ["router"]

--- a/backend/routers/dhcp/dhcp.py
+++ b/backend/routers/dhcp/dhcp.py
@@ -23,17 +23,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/dhcp", tags=["dhcp"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request/Response Models
 # ============================================================================

--- a/backend/routers/extcommunity_list/extcommunity_list.py
+++ b/backend/routers/extcommunity_list/extcommunity_list.py
@@ -26,16 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/extcommunity-list", tags=["extcommunity-list"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/firewall/bridge.py
+++ b/backend/routers/firewall/bridge.py
@@ -18,9 +18,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/firewall/bridge", tags=["firewall-bridge"])
 
 
-# Stub functions for backwards compatibility
-
-
 # Request/Response Models
 class BridgeBatchOperation(BaseModel):
     """Single operation in a batch request."""

--- a/backend/routers/firewall/bridge.py
+++ b/backend/routers/firewall/bridge.py
@@ -19,14 +19,6 @@ router = APIRouter(prefix="/vyos/firewall/bridge", tags=["firewall-bridge"])
 
 
 # Stub functions for backwards compatibility
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
 
 
 # Request/Response Models

--- a/backend/routers/firewall/groups.py
+++ b/backend/routers/firewall/groups.py
@@ -18,18 +18,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/firewall/groups", tags=["firewall-groups"])
 
 
-# Stub functions for backwards compatibility with app.py
-# These are no longer used since we use session-based services
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # Request/Response Models
 class GroupBatchOperation(BaseModel):
     """Single operation in a batch request."""

--- a/backend/routers/firewall/ipv4.py
+++ b/backend/routers/firewall/ipv4.py
@@ -19,17 +19,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/firewall/ipv4", tags=["firewall_ipv4"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ========================================================================
 # Pydantic Models
 # ========================================================================

--- a/backend/routers/firewall/ipv6.py
+++ b/backend/routers/firewall/ipv6.py
@@ -19,17 +19,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/firewall/ipv6", tags=["firewall_ipv6"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ========================================================================
 # Pydantic Models
 # ========================================================================

--- a/backend/routers/firewall_global_options/firewall_global_options.py
+++ b/backend/routers/firewall_global_options/firewall_global_options.py
@@ -20,17 +20,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/firewall/global-options", tags=["firewall-global-options"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Pydantic Models
 # ============================================================================

--- a/backend/routers/interfaces/dummy.py
+++ b/backend/routers/interfaces/dummy.py
@@ -22,17 +22,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/dummy", tags=["dummy-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/ethernet.py
+++ b/backend/routers/interfaces/ethernet.py
@@ -20,18 +20,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/ethernet", tags=["ethernet-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-# These are no longer used since we use session-based services
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request Models (for WRITE operations)
 # ============================================================================

--- a/backend/routers/interfaces/geneve.py
+++ b/backend/routers/interfaces/geneve.py
@@ -22,17 +22,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/geneve", tags=["geneve-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/input.py
+++ b/backend/routers/interfaces/input.py
@@ -22,17 +22,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/input", tags=["input-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/l2tpv3.py
+++ b/backend/routers/interfaces/l2tpv3.py
@@ -21,17 +21,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/l2tpv3", tags=["l2tpv3-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/loopback.py
+++ b/backend/routers/interfaces/loopback.py
@@ -23,17 +23,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/loopback", tags=["loopback-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/macsec.py
+++ b/backend/routers/interfaces/macsec.py
@@ -23,17 +23,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/macsec", tags=["macsec-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/openvpn.py
+++ b/backend/routers/interfaces/openvpn.py
@@ -25,17 +25,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/openvpn", tags=["openvpn-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/pppoe.py
+++ b/backend/routers/interfaces/pppoe.py
@@ -23,17 +23,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/pppoe", tags=["pppoe-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/interfaces/pseudo_ethernet.py
+++ b/backend/routers/interfaces/pseudo_ethernet.py
@@ -24,17 +24,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/pseudo-ethernet", tags=["pseudo-ethernet-interface"])
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # ============================================================================
 # Request / Response Models
 # ============================================================================

--- a/backend/routers/large_community_list/large_community_list.py
+++ b/backend/routers/large_community_list/large_community_list.py
@@ -26,16 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/large-community-list", tags=["large-community-list"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/local_route/local_route.py
+++ b/backend/routers/local_route/local_route.py
@@ -26,16 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/local-route", tags=["local-route"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/nat/__init__.py
+++ b/backend/routers/nat/__init__.py
@@ -1,4 +1,4 @@
 """NAT routers package."""
-from .nat import router, set_device_registry, set_configured_device_name
+from .nat import router
 
-__all__ = ["router", "set_device_registry", "set_configured_device_name"]
+__all__ = ["router"]

--- a/backend/routers/nat/nat.py
+++ b/backend/routers/nat/nat.py
@@ -26,17 +26,6 @@ _INTERNAL_BUILDER_METHODS = frozenset({
 })
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # Request/Response Models
 class NATBatchOperation(BaseModel):
     """Single operation in a batch request."""

--- a/backend/routers/prefix_list/__init__.py
+++ b/backend/routers/prefix_list/__init__.py
@@ -1,8 +1,4 @@
 """Prefix List router module."""
-from .prefix_list import (
-    router,
-    set_device_registry,
-    set_configured_device_name,
-)
+from .prefix_list import router
 
-__all__ = ["router", "set_device_registry", "set_configured_device_name"]
+__all__ = ["router"]

--- a/backend/routers/prefix_list/prefix_list.py
+++ b/backend/routers/prefix_list/prefix_list.py
@@ -19,16 +19,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/prefix-list", tags=["prefix-list"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/route/route.py
+++ b/backend/routers/route/route.py
@@ -25,16 +25,6 @@ _INTERNAL_BUILDER_METHODS = frozenset({
     "add_set", "add_delete", "get_operations", "is_empty", "clear", "operation_count",
 })
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models - Match Conditions

--- a/backend/routers/route_map/route_map.py
+++ b/backend/routers/route_map/route_map.py
@@ -26,16 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/route-map", tags=["route-map"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/static_routes/static_routes.py
+++ b/backend/routers/static_routes/static_routes.py
@@ -19,16 +19,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/static-routes", tags=["static-routes"])
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
 
 # ============================================================================
 # Pydantic Models

--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -39,17 +39,6 @@ _INTERNAL_BUILDER_METHODS = frozenset({
 })
 
 
-# Stub functions for backwards compatibility with app.py
-def set_device_registry(registry):
-    """Legacy function - no longer used."""
-    pass
-
-
-def set_configured_device_name(name):
-    """Legacy function - no longer used."""
-    pass
-
-
 # =============================================================================
 # Pydantic models — Response
 # =============================================================================


### PR DESCRIPTION
About 30 routers defined no-op set_device_registry and set_configured_device_name for old app.py wiring. app.py never calls them. backend/README.md still told you to copy that glue when adding a feature.

Deleted the stubs from every router, dropped the re-exports on nat/dhcp/prefix_list, and removed the README register step plus the example setter. python3 -m compileall -q backend/routers succeeded.

Closes #569