### PR TITLE
fix: share cookie forwarding for Next API proxies

### DIFF
--- a/frontend/src/app/api/dashboard/[...path]/route.ts
+++ b/frontend/src/app/api/dashboard/[...path]/route.ts
@@ -2,103 +2,27 @@
  * Dashboard API Proxy Route
  *
  * Forwards all /api/dashboard/* requests to the backend.
- * Uses BACKEND_URL environment variable (runtime configurable).
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
-// Runtime environment variable - NOT NEXT_PUBLIC_ so it's read at runtime
-// This allows users to configure the backend URL without rebuilding
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+type Ctx = { params: Promise<{ path: string[] }> };
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
+async function handle(request: NextRequest, params: Ctx["params"], method: string) {
   const { path } = await params;
-  return proxyRequest(request, path, "GET");
+  return proxyToBackend(request, {
+    path: `/dashboard/${path.join("/")}`,
+    method,
+    response: "json-or-text",
+    logLabel: "DashboardProxy",
+  });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "POST");
+export async function GET(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "GET");
 }
 
-async function proxyRequest(
-  request: NextRequest,
-  path: string[],
-  method: string
-) {
-  const BACKEND_URL = getBackendUrl();
-
-  try {
-    // Get the session token from request cookies
-    // Secure-cookie deployments prefix the name with __Secure-; read whichever is present
-    const sessionToken =
-      request.cookies.get("better-auth.session_token") ??
-      request.cookies.get("__Secure-better-auth.session_token");
-
-    // Build the backend URL
-    const backendPath = `/dashboard/${path.join("/")}`;
-    const backendUrl = `${BACKEND_URL}${backendPath}`;
-
-    // Copy search params
-    const url = new URL(backendUrl);
-    request.nextUrl.searchParams.forEach((value, key) => {
-      url.searchParams.append(key, value);
-    });
-
-    // Prepare headers
-    const headers: HeadersInit = {};
-
-    // Add the session token cookie if it exists
-    if (sessionToken) {
-      headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
-    }
-
-    // Handle request body
-    let body: BodyInit | undefined;
-
-    if (method === "POST") {
-      headers["Content-Type"] = "application/json";
-      try {
-        const json = await request.json();
-        body = JSON.stringify(json);
-      } catch {
-        // No body or invalid JSON
-      }
-    }
-
-    // Forward the request to the backend
-    const response = await fetch(url.toString(), {
-      method,
-      headers,
-      body,
-    });
-
-    // Parse response
-    const responseText = await response.text();
-
-    try {
-      const data = JSON.parse(responseText);
-      return NextResponse.json(data, { status: response.status });
-    } catch {
-      return new NextResponse(responseText, {
-        status: response.status,
-        headers: { "Content-Type": response.headers.get("Content-Type") || "text/plain" },
-      });
-    }
-  } catch (error) {
-    console.error("[DashboardProxy] Error:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to proxy request to backend",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
-  }
+export async function POST(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "POST");
 }

--- a/frontend/src/app/api/organizations/[[...path]]/route.ts
+++ b/frontend/src/app/api/organizations/[[...path]]/route.ts
@@ -4,55 +4,35 @@
  * Forwards /api/organizations/* to the backend organization-management
  * endpoints, passing the session cookie through for auth.
  */
-import { NextRequest, NextResponse } from "next/server";
-
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
-
-async function proxy(
-  request: NextRequest,
-  path: string[] | undefined,
-  method: string,
-) {
-  // Secure-cookie deployments prefix the name with __Secure-; read whichever is present
-  const sessionToken =
-    request.cookies.get("better-auth.session_token") ??
-    request.cookies.get("__Secure-better-auth.session_token");
-  const suffix = path && path.length ? `/${path.map(encodeURIComponent).join("/")}` : "";
-  const url = new URL(`${getBackendUrl()}/organizations${suffix}`);
-  request.nextUrl.searchParams.forEach((v, k) => url.searchParams.append(k, v));
-
-  const headers: Record<string, string> = {};
-  if (sessionToken) {
-    headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
-  }
-
-  let body: string | undefined;
-  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
-    headers["Content-Type"] = "application/json";
-    body = await request.text();
-  }
-
-  const res = await fetch(url.toString(), { method, headers, body: body || undefined });
-  const text = await res.text();
-  return new NextResponse(text || null, {
-    status: res.status,
-    headers: { "Content-Type": res.headers.get("Content-Type") || "application/json" },
-  });
-}
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
 type Ctx = { params: Promise<{ path?: string[] }> };
 
+async function handle(request: NextRequest, params: Ctx["params"], method: string) {
+  const { path } = await params;
+  const suffix =
+    path && path.length ? `/${path.map(encodeURIComponent).join("/")}` : "";
+  return proxyToBackend(request, {
+    path: `/organizations${suffix}`,
+    method,
+    body: "text",
+    response: "passthrough",
+    logLabel: "OrganizationsProxy",
+  });
+}
+
 export async function GET(request: NextRequest, { params }: Ctx) {
-  return proxy(request, (await params).path, "GET");
+  return handle(request, params, "GET");
 }
 export async function POST(request: NextRequest, { params }: Ctx) {
-  return proxy(request, (await params).path, "POST");
+  return handle(request, params, "POST");
 }
 export async function PATCH(request: NextRequest, { params }: Ctx) {
-  return proxy(request, (await params).path, "PATCH");
+  return handle(request, params, "PATCH");
 }
 export async function DELETE(request: NextRequest, { params }: Ctx) {
-  return proxy(request, (await params).path, "DELETE");
+  return handle(request, params, "DELETE");
 }
 
 export const runtime = "nodejs";

--- a/frontend/src/app/api/session/[...path]/route.ts
+++ b/frontend/src/app/api/session/[...path]/route.ts
@@ -1,153 +1,37 @@
 /**
  * Session API Proxy Route
  *
- * Forwards all /api/session/* requests to the backend with proper cookie handling.
- * This ensures authentication cookies are correctly passed through to the backend.
+ * Forwards all /api/session/* requests to the backend with cookie handling.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
-// Runtime environment variable - NOT NEXT_PUBLIC_ so it's read at runtime
-// This allows users to configure the backend URL without rebuilding
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+type Ctx = { params: Promise<{ path: string[] }> };
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
+async function handle(request: NextRequest, params: Ctx["params"], method: string) {
   const { path } = await params;
-  return proxyRequest(request, path, "GET");
+  return proxyToBackend(request, {
+    path: `/session/${path.join("/")}`,
+    method,
+    body: "auto",
+    attachments: true,
+    logLabel: "SessionProxy",
+  });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "POST");
+export async function GET(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "GET");
 }
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "PUT");
+export async function POST(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "POST");
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "DELETE");
+export async function PUT(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "PUT");
 }
 
-async function proxyRequest(
-  request: NextRequest,
-  path: string[],
-  method: string
-) {
-  const BACKEND_URL = getBackendUrl();
-
-  try {
-    // Get the session token from request cookies
-    // Secure-cookie deployments prefix the name with __Secure-; read whichever is present
-    const sessionToken =
-      request.cookies.get("better-auth.session_token") ??
-      request.cookies.get("__Secure-better-auth.session_token");
-
-    // Build the backend URL
-    const backendPath = `/session/${path.join("/")}`;
-    const backendUrl = `${BACKEND_URL}${backendPath}`;
-
-    // Copy search params
-    const url = new URL(backendUrl);
-    request.nextUrl.searchParams.forEach((value, key) => {
-      url.searchParams.append(key, value);
-    });
-
-    // Prepare headers
-    const headers: HeadersInit = {};
-
-    // Add the session token cookie if it exists
-    if (sessionToken) {
-      headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
-    }
-
-    // Handle request body
-    let body: BodyInit | undefined;
-    const contentType = request.headers.get("content-type");
-
-    if (["POST", "PUT", "PATCH"].includes(method)) {
-      // Check if this is a file upload (multipart/form-data)
-      if (contentType && contentType.includes("multipart/form-data")) {
-        // For file uploads, pass the FormData directly
-        const formData = await request.formData();
-        body = formData as BodyInit;
-        // Don't set Content-Type header - let fetch set it with boundary
-      } else {
-        // For JSON requests
-        headers["Content-Type"] = "application/json";
-        try {
-          const json = await request.json();
-          body = JSON.stringify(json);
-        } catch {
-          // No body or invalid JSON
-        }
-      }
-    }
-
-    // Forward the request to the backend
-    const response = await fetch(url.toString(), {
-      method,
-      headers,
-      body,
-    });
-
-    // Check if this is a file download (e.g. an encrypted backup). Any response
-    // the backend marks as an attachment is streamed through as a binary blob.
-    const responseContentType = response.headers.get("content-type");
-    const contentDisposition = response.headers.get("content-disposition");
-    if (contentDisposition && contentDisposition.includes("attachment")) {
-      const blob = await response.blob();
-      const responseHeaders = new Headers();
-      responseHeaders.set("Content-Disposition", contentDisposition);
-      responseHeaders.set(
-        "Content-Type",
-        responseContentType || "application/octet-stream"
-      );
-
-      return new NextResponse(blob, {
-        status: response.status,
-        headers: responseHeaders,
-      });
-    }
-
-    // Default: assume JSON response
-    const responseText = await response.text();
-
-    try {
-      const data = JSON.parse(responseText);
-      // Return the response with the same status code
-      return NextResponse.json(data, { status: response.status });
-    } catch {
-      return NextResponse.json(
-        {
-          error: "Backend returned invalid JSON",
-          details: responseText.substring(0, 200),
-        },
-        { status: 500 }
-      );
-    }
-  } catch (error) {
-    console.error("Session proxy error:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to proxy request to backend",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
-  }
+export async function DELETE(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "DELETE");
 }

--- a/frontend/src/app/api/tokens/[[...path]]/route.ts
+++ b/frontend/src/app/api/tokens/[[...path]]/route.ts
@@ -1,90 +1,32 @@
 /**
  * API Tokens Proxy Route
  *
- * Forwards /api/tokens and /api/tokens/* requests to the backend /tokens
- * endpoints, passing the auth session cookie through for identity.
+ * Forwards /api/tokens and /api/tokens/* to the backend /tokens endpoints.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+type Ctx = { params: Promise<{ path?: string[] }> };
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ path?: string[] }> }
-) {
+async function handle(request: NextRequest, params: Ctx["params"], method: string) {
   const { path } = await params;
-  return proxyRequest(request, path, "GET");
+  const backendPath = path && path.length ? `/tokens/${path.join("/")}` : "/tokens";
+  return proxyToBackend(request, {
+    path: backendPath,
+    method,
+    logLabel: "TokensProxy",
+  });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ path?: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "POST");
+export async function GET(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "GET");
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ path?: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "DELETE");
+export async function POST(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "POST");
 }
 
-async function proxyRequest(
-  request: NextRequest,
-  path: string[] | undefined,
-  method: string
-) {
-  const BACKEND_URL = getBackendUrl();
-
-  try {
-    const backendPath = path && path.length ? `/tokens/${path.join("/")}` : "/tokens";
-    const url = new URL(`${BACKEND_URL}${backendPath}`);
-    request.nextUrl.searchParams.forEach((value, key) => {
-      url.searchParams.append(key, value);
-    });
-
-    // Forward the auth session cookie (both better-auth variants) for identity.
-    const headers: HeadersInit = {};
-    const sessionToken = request.cookies.get("better-auth.session_token");
-    const secureToken = request.cookies.get("__Secure-better-auth.session_token");
-    const cookieParts: string[] = [];
-    if (sessionToken) cookieParts.push(`better-auth.session_token=${sessionToken.value}`);
-    if (secureToken) cookieParts.push(`__Secure-better-auth.session_token=${secureToken.value}`);
-    if (cookieParts.length) headers["Cookie"] = cookieParts.join("; ");
-
-    let body: BodyInit | undefined;
-    if (["POST", "PUT", "PATCH"].includes(method)) {
-      headers["Content-Type"] = "application/json";
-      try {
-        body = JSON.stringify(await request.json());
-      } catch {
-        // No body
-      }
-    }
-
-    const response = await fetch(url.toString(), { method, headers, body });
-    const responseText = await response.text();
-
-    try {
-      return NextResponse.json(JSON.parse(responseText), { status: response.status });
-    } catch {
-      return NextResponse.json(
-        { error: "Backend returned invalid JSON", details: responseText.substring(0, 200) },
-        { status: 500 }
-      );
-    }
-  } catch (error) {
-    console.error("Tokens proxy error:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to proxy request to backend",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
-  }
+export async function DELETE(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "DELETE");
 }

--- a/frontend/src/app/api/user-management/[...path]/route.ts
+++ b/frontend/src/app/api/user-management/[...path]/route.ts
@@ -1,123 +1,35 @@
 /**
  * User Management API Proxy Route
  *
- * Forwards all /api/user-management/* requests to the backend with proper cookie handling.
- * This ensures authentication cookies are correctly passed through to the backend.
+ * Forwards all /api/user-management/* requests to the backend with cookie handling.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
-// Runtime environment variable - NOT NEXT_PUBLIC_ so it's read at runtime
-// This allows users to configure the backend URL without rebuilding
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+type Ctx = { params: Promise<{ path: string[] }> };
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
+async function handle(request: NextRequest, params: Ctx["params"], method: string) {
   const { path } = await params;
-  return proxyRequest(request, path, "GET");
+  return proxyToBackend(request, {
+    path: `/user-management/${path.join("/")}`,
+    method,
+    logLabel: "UserManagementProxy",
+  });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "POST");
+export async function GET(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "GET");
 }
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "PUT");
+export async function POST(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "POST");
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "DELETE");
+export async function PUT(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "PUT");
 }
 
-async function proxyRequest(
-  request: NextRequest,
-  path: string[],
-  method: string
-) {
-  const BACKEND_URL = getBackendUrl();
-
-  try {
-    // Get the session token from request cookies (secure deployments
-    // prefix the cookie name with __Secure-)
-    const sessionToken =
-      request.cookies.get("better-auth.session_token") ??
-      request.cookies.get("__Secure-better-auth.session_token");
-
-    // Build the backend URL
-    const backendPath = `/user-management/${path.join("/")}`;
-    const backendUrl = `${BACKEND_URL}${backendPath}`;
-
-    // Copy search params
-    const url = new URL(backendUrl);
-    request.nextUrl.searchParams.forEach((value, key) => {
-      url.searchParams.append(key, value);
-    });
-
-    // Prepare headers
-    const headers: HeadersInit = {};
-
-    // Add the session token cookie if it exists
-    if (sessionToken) {
-      headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
-    }
-
-    // Handle request body
-    let body: BodyInit | undefined;
-
-    if (["POST", "PUT", "PATCH"].includes(method)) {
-      headers["Content-Type"] = "application/json";
-      try {
-        const json = await request.json();
-        body = JSON.stringify(json);
-      } catch {
-        // No body or invalid JSON
-      }
-    }
-
-    // Forward the request to the backend
-    const response = await fetch(url.toString(), {
-      method,
-      headers,
-      body,
-    });
-
-    // Parse response
-    const responseText = await response.text();
-
-    try {
-      const data = JSON.parse(responseText);
-      return NextResponse.json(data, { status: response.status });
-    } catch {
-      return NextResponse.json(
-        {
-          error: "Backend returned invalid JSON",
-          details: responseText.substring(0, 200),
-        },
-        { status: 500 }
-      );
-    }
-  } catch (error) {
-    console.error("[UserManagementProxy] Error:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to proxy request to backend",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
-  }
+export async function DELETE(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "DELETE");
 }

--- a/frontend/src/app/api/vyos/[...path]/route.ts
+++ b/frontend/src/app/api/vyos/[...path]/route.ts
@@ -2,142 +2,40 @@
  * VyOS API Proxy Route
  *
  * Forwards all /api/vyos/* requests to the backend.
- * Uses BACKEND_URL environment variable (runtime configurable).
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
-// Runtime environment variable - NOT NEXT_PUBLIC_ so it's read at runtime
-// This allows users to configure the backend URL without rebuilding
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+type Ctx = { params: Promise<{ path: string[] }> };
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
+async function handle(request: NextRequest, params: Ctx["params"], method: string) {
   const { path } = await params;
-  return proxyRequest(request, path, "GET");
+  return proxyToBackend(request, {
+    path: `/vyos/${path.join("/")}`,
+    method,
+    response: "json-or-text",
+    sse: true,
+    logLabel: "VyOSProxy",
+  });
 }
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "POST");
+export async function GET(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "GET");
 }
 
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "PUT");
+export async function POST(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "POST");
 }
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "DELETE");
+export async function PUT(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "PUT");
 }
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ path: string[] }> }
-) {
-  const { path } = await params;
-  return proxyRequest(request, path, "PATCH");
+export async function DELETE(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "DELETE");
 }
 
-async function proxyRequest(
-  request: NextRequest,
-  path: string[],
-  method: string
-) {
-  const BACKEND_URL = getBackendUrl();
-
-  try {
-    // Get the session token from request cookies
-    // Secure-cookie deployments prefix the name with __Secure-; read whichever is present
-    const sessionToken =
-      request.cookies.get("better-auth.session_token") ??
-      request.cookies.get("__Secure-better-auth.session_token");
-
-    // Build the backend URL
-    const backendPath = `/vyos/${path.join("/")}`;
-    const backendUrl = `${BACKEND_URL}${backendPath}`;
-
-    // Copy search params
-    const url = new URL(backendUrl);
-    request.nextUrl.searchParams.forEach((value, key) => {
-      url.searchParams.append(key, value);
-    });
-
-    // Prepare headers
-    const headers: HeadersInit = {};
-
-    // Add the session token cookie if it exists
-    if (sessionToken) {
-      headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
-    }
-
-    // Handle request body
-    let body: BodyInit | undefined;
-
-    if (["POST", "PUT", "PATCH"].includes(method)) {
-      headers["Content-Type"] = "application/json";
-      try {
-        const json = await request.json();
-        body = JSON.stringify(json);
-      } catch {
-        // No body or invalid JSON
-      }
-    }
-
-    // Forward the request to the backend
-    const response = await fetch(url.toString(), {
-      method,
-      headers,
-      body,
-    });
-
-    // Stream SSE responses directly without buffering
-    const contentType = response.headers.get("Content-Type") || "";
-    if (contentType.includes("text/event-stream")) {
-      return new Response(response.body, {
-        status: response.status,
-        headers: {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          "X-Accel-Buffering": "no",
-          "Connection": "keep-alive",
-        },
-      });
-    }
-
-    // Parse response
-    const responseText = await response.text();
-
-    try {
-      const data = JSON.parse(responseText);
-      return NextResponse.json(data, { status: response.status });
-    } catch {
-      // Return as-is if not JSON
-      return new NextResponse(responseText, {
-        status: response.status,
-        headers: { "Content-Type": response.headers.get("Content-Type") || "text/plain" },
-      });
-    }
-  } catch (error) {
-    console.error("[VyOSProxy] Error:", error);
-    return NextResponse.json(
-      {
-        error: "Failed to proxy request to backend",
-        details: error instanceof Error ? error.message : String(error),
-      },
-      { status: 500 }
-    );
-  }
+export async function PATCH(request: NextRequest, { params }: Ctx) {
+  return handle(request, params, "PATCH");
 }

--- a/frontend/src/lib/backend-proxy.ts
+++ b/frontend/src/lib/backend-proxy.ts
@@ -1,0 +1,186 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const JSON_BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
+const TEXT_BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function getBackendUrl(): string {
+  return process.env.BACKEND_URL || "http://backend:8000";
+}
+
+/** Forward whichever better-auth session cookie is present, under its original name. */
+export function sessionCookieHeader(
+  request: NextRequest,
+): Record<string, string> {
+  const sessionToken =
+    request.cookies.get("better-auth.session_token") ??
+    request.cookies.get("__Secure-better-auth.session_token");
+  if (!sessionToken) {
+    return {};
+  }
+  return { Cookie: `${sessionToken.name}=${sessionToken.value}` };
+}
+
+export type ProxyBodyMode = "json" | "text" | "auto" | "none";
+export type ProxyResponseMode = "json" | "json-or-text" | "passthrough";
+
+export type ProxyToBackendOptions = {
+  path: string;
+  method: string;
+  body?: ProxyBodyMode;
+  response?: ProxyResponseMode;
+  sse?: boolean;
+  attachments?: boolean;
+  logLabel?: string;
+  onSuccess?: () => void;
+};
+
+async function readBody(
+  request: NextRequest,
+  method: string,
+  mode: ProxyBodyMode,
+): Promise<{ headers: Record<string, string>; body: BodyInit | undefined }> {
+  const headers: Record<string, string> = {};
+  if (mode === "none") {
+    return { headers, body: undefined };
+  }
+
+  const wantsBody =
+    mode === "text" ? TEXT_BODY_METHODS.has(method) : JSON_BODY_METHODS.has(method);
+  if (!wantsBody) {
+    return { headers, body: undefined };
+  }
+
+  if (mode === "auto") {
+    const contentType = request.headers.get("content-type");
+    if (contentType?.includes("multipart/form-data")) {
+      return { headers, body: await request.formData() };
+    }
+    mode = "json";
+  }
+
+  if (mode === "text") {
+    headers["Content-Type"] = "application/json";
+    const text = await request.text();
+    return { headers, body: text || undefined };
+  }
+
+  headers["Content-Type"] = "application/json";
+  try {
+    return { headers, body: JSON.stringify(await request.json()) };
+  } catch {
+    return { headers, body: undefined };
+  }
+}
+
+export async function proxyToBackend(
+  request: NextRequest,
+  {
+    path,
+    method,
+    body: bodyMode = "json",
+    response: responseMode = "json",
+    sse = false,
+    attachments = false,
+    logLabel = "BackendProxy",
+    onSuccess,
+  }: ProxyToBackendOptions,
+): Promise<Response> {
+  try {
+    const url = new URL(`${getBackendUrl()}${path}`);
+    request.nextUrl.searchParams.forEach((value, key) => {
+      url.searchParams.append(key, value);
+    });
+
+    const { headers: bodyHeaders, body } = await readBody(
+      request,
+      method,
+      bodyMode,
+    );
+    const headers: Record<string, string> = {
+      ...sessionCookieHeader(request),
+      ...bodyHeaders,
+    };
+
+    const upstream = await fetch(url.toString(), { method, headers, body });
+
+    if (onSuccess && upstream.ok) {
+      onSuccess();
+    }
+
+    if (sse) {
+      const contentType = upstream.headers.get("Content-Type") || "";
+      if (contentType.includes("text/event-stream")) {
+        return new Response(upstream.body, {
+          status: upstream.status,
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            Connection: "keep-alive",
+          },
+        });
+      }
+    }
+
+    if (attachments) {
+      const contentDisposition = upstream.headers.get("content-disposition");
+      if (contentDisposition?.includes("attachment")) {
+        const blob = await upstream.blob();
+        const responseHeaders = new Headers();
+        responseHeaders.set("Content-Disposition", contentDisposition);
+        responseHeaders.set(
+          "Content-Type",
+          upstream.headers.get("content-type") || "application/octet-stream",
+        );
+        return new NextResponse(blob, {
+          status: upstream.status,
+          headers: responseHeaders,
+        });
+      }
+    }
+
+    const responseText = await upstream.text();
+
+    if (responseMode === "passthrough") {
+      return new NextResponse(responseText || null, {
+        status: upstream.status,
+        headers: {
+          "Content-Type":
+            upstream.headers.get("Content-Type") || "application/json",
+        },
+      });
+    }
+
+    try {
+      return NextResponse.json(JSON.parse(responseText), {
+        status: upstream.status,
+      });
+    } catch {
+      if (responseMode === "json-or-text") {
+        return new NextResponse(responseText, {
+          status: upstream.status,
+          headers: {
+            "Content-Type":
+              upstream.headers.get("Content-Type") || "text/plain",
+          },
+        });
+      }
+      return NextResponse.json(
+        {
+          error: "Backend returned invalid JSON",
+          details: responseText.substring(0, 200),
+        },
+        { status: 500 },
+      );
+    }
+  } catch (error) {
+    console.error(`[${logLabel}] Error:`, error);
+    return NextResponse.json(
+      {
+        error: "Failed to proxy request to backend",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/lib/oauth-proxy.ts
+++ b/frontend/src/lib/oauth-proxy.ts
@@ -1,8 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { invalidateAuth } from "@/lib/auth";
-
-// Runtime env, not NEXT_PUBLIC_, so the backend URL is configurable without a rebuild.
-const getBackendUrl = () => process.env.BACKEND_URL || "http://backend:8000";
+import { proxyToBackend } from "@/lib/backend-proxy";
 
 /**
  * Forward an oauth-config request (providers or role mappings) to the backend,
@@ -18,36 +16,13 @@ export async function proxyOauthConfig(
   request: NextRequest,
   backendPath: string,
   method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
-): Promise<NextResponse> {
-  // Secure-cookie deployments prefix the name with __Secure-; forward
-  // whichever is present under its original name (the backend accepts both).
-  const sessionToken =
-    request.cookies.get("better-auth.session_token") ??
-    request.cookies.get("__Secure-better-auth.session_token");
-
-  const headers: Record<string, string> = {};
-  if (sessionToken) {
-    headers["Cookie"] = `${sessionToken.name}=${sessionToken.value}`;
-  }
-
-  let body: string | undefined;
-  if (method === "POST" || method === "PUT" || method === "PATCH") {
-    headers["Content-Type"] = "application/json";
-    body = await request.text();
-  }
-
-  const res = await fetch(`${getBackendUrl()}${backendPath}`, { method, headers, body });
-  const text = await res.text();
-
-  // A successful write can change how logins resolve roles; refresh the cache.
-  if (method !== "GET" && res.ok) {
-    invalidateAuth();
-  }
-
-  return new NextResponse(text || null, {
-    status: res.status,
-    headers: {
-      "Content-Type": res.headers.get("Content-Type") || "application/json",
-    },
+): Promise<Response> {
+  return proxyToBackend(request, {
+    path: backendPath,
+    method,
+    body: "text",
+    response: "passthrough",
+    logLabel: "OauthConfigProxy",
+    onSuccess: method === "GET" ? undefined : () => invalidateAuth(),
   });
 }


### PR DESCRIPTION
vyos, session, dashboard, tokens, and user-management each defined getBackendUrl and proxyRequest with the same better-auth cookie forwarding. The copies already disagreed on methods and on whether to send one cookie or both.

Cookie and body handling now live in frontend/src/lib/backend-proxy.ts. Each catch-all route still exports only the methods it needs. Organizations and oauth-config use the same helper so a third copy does not remain.

Tests: frontend npx tsc --noEmit, npm run lint (0 errors, existing warnings only).

Closes #574