### PR TITLE
test: golden paths for as-path-list and BFD builders

### DIFF
--- a/backend/tests/test_as_path_list_builder_paths.py
+++ b/backend/tests/test_as_path_list_builder_paths.py
@@ -1,0 +1,86 @@
+"""Golden (method, args, expected_path) cases for AsPathListBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+"""
+
+import pytest
+
+from vyos_builders.as_path_list.as_path_list import AsPathListBatchBuilder
+
+CASES = [
+    (
+        "set_as_path_list",
+        ("ASPATH1",),
+        "set",
+        ["policy", "as-path-list", "ASPATH1"],
+    ),
+    (
+        "delete_as_path_list",
+        ("ASPATH1",),
+        "delete",
+        ["policy", "as-path-list", "ASPATH1"],
+    ),
+    (
+        "set_as_path_list_description",
+        ("ASPATH1", "core peers"),
+        "set",
+        ["policy", "as-path-list", "ASPATH1", "description", "core peers"],
+    ),
+    (
+        "delete_as_path_list_description",
+        ("ASPATH1",),
+        "delete",
+        ["policy", "as-path-list", "ASPATH1", "description"],
+    ),
+    (
+        "set_rule",
+        ("ASPATH1", "10"),
+        "set",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10"],
+    ),
+    (
+        "delete_rule",
+        ("ASPATH1", "10"),
+        "delete",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10"],
+    ),
+    (
+        "set_rule_action",
+        ("ASPATH1", "10", "permit"),
+        "set",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10", "action", "permit"],
+    ),
+    (
+        "set_rule_description",
+        ("ASPATH1", "10", "match transit"),
+        "set",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10", "description", "match transit"],
+    ),
+    (
+        "delete_rule_description",
+        ("ASPATH1", "10"),
+        "delete",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10", "description"],
+    ),
+    (
+        "set_rule_regex",
+        ("ASPATH1", "10", "_65000_"),
+        "set",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10", "regex", "_65000_"],
+    ),
+    (
+        "delete_rule_regex",
+        ("ASPATH1", "10"),
+        "delete",
+        ["policy", "as-path-list", "ASPATH1", "rule", "10", "regex"],
+    ),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_as_path_list_builder_paths(method, args, op, expected_path, version):
+    builder = AsPathListBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    ops = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in ops] == [(op, expected_path)]

--- a/backend/tests/test_bfd_builder_paths.py
+++ b/backend/tests/test_bfd_builder_paths.py
@@ -1,0 +1,242 @@
+"""Golden (method, args, expected_path) cases for BfdBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+"""
+
+import pytest
+
+from vyos_builders.bfd.bfd_batch_builder import BfdBatchBuilder
+
+PEER = "192.0.2.1"
+PROFILE = "CORE"
+
+CASES = [
+    ("set_peer", (PEER,), "set", ["protocols", "bfd", "peer", PEER]),
+    ("delete_peer", (PEER,), "delete", ["protocols", "bfd", "peer", PEER]),
+    (
+        "set_peer_echo_mode",
+        (PEER,),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "echo-mode"],
+    ),
+    (
+        "set_peer_interval_echo_interval",
+        (PEER, "50"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "interval", "echo-interval", "50"],
+    ),
+    (
+        "delete_peer_interval_echo_interval",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "interval", "echo-interval"],
+    ),
+    (
+        "set_peer_interval_multiplier",
+        (PEER, "3"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "interval", "multiplier", "3"],
+    ),
+    (
+        "delete_peer_interval_multiplier",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "interval", "multiplier"],
+    ),
+    (
+        "set_peer_interval_receive",
+        (PEER, "300"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "interval", "receive", "300"],
+    ),
+    (
+        "delete_peer_interval_receive",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "interval", "receive"],
+    ),
+    (
+        "set_peer_interval_transmit",
+        (PEER, "300"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "interval", "transmit", "300"],
+    ),
+    (
+        "delete_peer_interval_transmit",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "interval", "transmit"],
+    ),
+    (
+        "set_peer_minimum_ttl",
+        (PEER, "2"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "minimum-ttl", "2"],
+    ),
+    (
+        "delete_peer_minimum_ttl",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "minimum-ttl"],
+    ),
+    (
+        "set_peer_multihop",
+        (PEER,),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "multihop"],
+    ),
+    (
+        "set_peer_passive",
+        (PEER,),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "passive"],
+    ),
+    (
+        "set_peer_profile",
+        (PEER, PROFILE),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "profile", PROFILE],
+    ),
+    (
+        "delete_peer_profile",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "profile"],
+    ),
+    (
+        "set_peer_shutdown",
+        (PEER,),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "shutdown"],
+    ),
+    (
+        "set_peer_source_address",
+        (PEER, "192.0.2.8"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "source", "address", "192.0.2.8"],
+    ),
+    (
+        "delete_peer_source_address",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "source", "address"],
+    ),
+    (
+        "set_peer_source_interface",
+        (PEER, "eth0"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "source", "interface", "eth0"],
+    ),
+    (
+        "delete_peer_source_interface",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "source", "interface"],
+    ),
+    (
+        "set_peer_vrf",
+        (PEER, "mgmt"),
+        "set",
+        ["protocols", "bfd", "peer", PEER, "vrf", "mgmt"],
+    ),
+    (
+        "delete_peer_vrf",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "vrf"],
+    ),
+    ("set_profile", (PROFILE,), "set", ["protocols", "bfd", "profile", PROFILE]),
+    (
+        "delete_profile",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE],
+    ),
+    (
+        "set_profile_echo_mode",
+        (PROFILE,),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "echo-mode"],
+    ),
+    (
+        "set_profile_interval_echo_interval",
+        (PROFILE, "50"),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "echo-interval", "50"],
+    ),
+    (
+        "delete_profile_interval_echo_interval",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "echo-interval"],
+    ),
+    (
+        "set_profile_interval_multiplier",
+        (PROFILE, "3"),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "multiplier", "3"],
+    ),
+    (
+        "delete_profile_interval_multiplier",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "multiplier"],
+    ),
+    (
+        "set_profile_interval_receive",
+        (PROFILE, "300"),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "receive", "300"],
+    ),
+    (
+        "delete_profile_interval_receive",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "receive"],
+    ),
+    (
+        "set_profile_interval_transmit",
+        (PROFILE, "300"),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "transmit", "300"],
+    ),
+    (
+        "delete_profile_interval_transmit",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE, "interval", "transmit"],
+    ),
+    (
+        "set_profile_minimum_ttl",
+        (PROFILE, "2"),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "minimum-ttl", "2"],
+    ),
+    (
+        "delete_profile_minimum_ttl",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE, "minimum-ttl"],
+    ),
+    (
+        "set_profile_passive",
+        (PROFILE,),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "passive"],
+    ),
+    (
+        "set_profile_shutdown",
+        (PROFILE,),
+        "set",
+        ["protocols", "bfd", "profile", PROFILE, "shutdown"],
+    ),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_bfd_builder_paths(method, args, op, expected_path, version):
+    builder = BfdBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    ops = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in ops] == [(op, expected_path)]

--- a/backend/tests/test_bfd_builder_paths.py
+++ b/backend/tests/test_bfd_builder_paths.py
@@ -20,6 +20,12 @@ CASES = [
         ["protocols", "bfd", "peer", PEER, "echo-mode"],
     ),
     (
+        "delete_peer_echo_mode",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "echo-mode"],
+    ),
+    (
         "set_peer_interval_echo_interval",
         (PEER, "50"),
         "set",
@@ -86,9 +92,21 @@ CASES = [
         ["protocols", "bfd", "peer", PEER, "multihop"],
     ),
     (
+        "delete_peer_multihop",
+        (PEER,),
+        "delete",
+        ["protocols", "bfd", "peer", PEER, "multihop"],
+    ),
+    (
         "set_peer_passive",
         (PEER,),
         "set",
+        ["protocols", "bfd", "peer", PEER, "passive"],
+    ),
+    (
+        "delete_peer_passive",
+        (PEER,),
+        "delete",
         ["protocols", "bfd", "peer", PEER, "passive"],
     ),
     (
@@ -107,6 +125,12 @@ CASES = [
         "set_peer_shutdown",
         (PEER,),
         "set",
+        ["protocols", "bfd", "peer", PEER, "shutdown"],
+    ),
+    (
+        "delete_peer_shutdown",
+        (PEER,),
+        "delete",
         ["protocols", "bfd", "peer", PEER, "shutdown"],
     ),
     (
@@ -156,6 +180,12 @@ CASES = [
         "set_profile_echo_mode",
         (PROFILE,),
         "set",
+        ["protocols", "bfd", "profile", PROFILE, "echo-mode"],
+    ),
+    (
+        "delete_profile_echo_mode",
+        (PROFILE,),
+        "delete",
         ["protocols", "bfd", "profile", PROFILE, "echo-mode"],
     ),
     (
@@ -225,9 +255,21 @@ CASES = [
         ["protocols", "bfd", "profile", PROFILE, "passive"],
     ),
     (
+        "delete_profile_passive",
+        (PROFILE,),
+        "delete",
+        ["protocols", "bfd", "profile", PROFILE, "passive"],
+    ),
+    (
         "set_profile_shutdown",
         (PROFILE,),
         "set",
+        ["protocols", "bfd", "profile", PROFILE, "shutdown"],
+    ),
+    (
+        "delete_profile_shutdown",
+        (PROFILE,),
+        "delete",
         ["protocols", "bfd", "profile", PROFILE, "shutdown"],
     ),
 ]


### PR DESCRIPTION
backend/tests had no cases for AsPathListBatchBuilder or BfdBatchBuilder, so mapper drift on policy as-path-list or protocols bfd would not fail CI.

Adds (method, args, expected_path) tables for both builders on 1.4 and 1.5. Asserted paths were validateTmplPath VALID on both lab hosts.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_as_path_list_builder_paths.py tests/test_bfd_builder_paths.py -q (100 passed).

Closes #577