### PR TITLE
fix: link console SSH setup hint to Site Manager

### DIFF
--- a/frontend/src/app/console/page.tsx
+++ b/frontend/src/app/console/page.tsx
@@ -9,6 +9,7 @@ import { consoleService, type ConsoleStatus } from "@/lib/api/console";
 import { ConsoleTerminal } from "@/components/console/ConsoleTerminal";
 import type { ConsoleStatus as WsStatus } from "@/hooks/useConsoleWebSocket";
 import { cn } from "@/lib/utils";
+import Link from "next/link";
 
 const STATUS_COLORS: Record<WsStatus, string> = {
   disconnected: "bg-gray-400",
@@ -131,8 +132,10 @@ export default function ConsolePage() {
                 <p className="text-sm font-medium">SSH not configured</p>
                 <p className="text-sm text-muted-foreground">
                   An SSH key must be generated and added to the VyOS device before
-                  using the console. Go to{" "}
-                  <span className="font-medium">Sites &gt; Edit Instance &gt; SSH / Monitoring</span>{" "}
+                  using the console.{" "}
+                  <Link href="/sites" className="font-medium text-foreground underline underline-offset-4 hover:text-primary">
+                    Open Site Manager
+                  </Link>{" "}
                   to set it up.
                 </p>
               </div>

--- a/frontend/src/app/monitoring/page.tsx
+++ b/frontend/src/app/monitoring/page.tsx
@@ -5,6 +5,7 @@ export const dynamic = 'force-dynamic';
 import { useState, useEffect } from "react";
 import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -21,7 +22,6 @@ import { Badge } from "@/components/ui/badge";
 import {
   Activity,
   AlertCircle,
-  ExternalLink,
   Loader2,
   Play,
   SlidersHorizontal,
@@ -245,13 +245,11 @@ function MonitoringPageInner() {
                 SSH key monitoring is not set up for{" "}
                 <span className="font-medium">{session.instance_name}</span>.
               </p>
-              <p className="text-sm text-muted-foreground flex items-center justify-center gap-1 pt-1">
-                Go to{" "}
-                <span className="font-medium inline-flex items-center gap-1">
-                  Sites &rarr; Edit Instance &rarr; SSH
-                  <ExternalLink className="h-3 w-3" />
-                </span>{" "}
-                to configure.
+              <p className="text-sm text-muted-foreground pt-1">
+                <Link href="/sites" className="font-medium text-foreground underline underline-offset-4 hover:text-primary">
+                  Open Site Manager
+                </Link>{" "}
+                to configure SSH.
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
When SSH is not configured, the console page told the operator to go to Sites > Edit Instance > SSH / Monitoring as plain text. Monitoring did the same with a fake ExternalLink icon.

Both empty states now use a /sites link, same destination as ConnectFirstInstance.

Tests: frontend npx tsc --noEmit, npm run lint (0 errors, existing warnings only).

Closes #588