### PR TITLE
fix: reject read-only tokens on bug-report writes

### DIFF
--- a/backend/fastapi_permissions.py
+++ b/backend/fastapi_permissions.py
@@ -35,6 +35,15 @@ def is_read_only_token(request: Request) -> bool:
     return bool(scopes) and "read" in scopes
 
 
+def reject_read_only_token(
+    request: Request,
+    detail: str = "This API token is read-only and cannot perform write operations.",
+) -> None:
+    """403 if this request was authenticated with a read-only API token."""
+    if is_read_only_token(request):
+        raise HTTPException(status_code=403, detail=detail)
+
+
 async def require_permission(
     request: Request,
     feature: FeatureGroup,
@@ -64,11 +73,8 @@ async def require_permission(
 
     # Read-only API tokens cannot write — enforced before the site-ADMIN bypass
     # so even an admin's read-only token is denied write operations.
-    if level == PermissionLevel.WRITE and is_read_only_token(request):
-        raise HTTPException(
-            status_code=403,
-            detail="This API token is read-only and cannot perform write operations."
-        )
+    if level == PermissionLevel.WRITE:
+        reject_read_only_token(request)
 
     # The active instance is resolved by SessionMiddleware for both auth paths:
     # the browser cookie session, or (for token clients) the X-VyOS-Instance-Id

--- a/backend/routers/bug_report/bug_report.py
+++ b/backend/routers/bug_report/bug_report.py
@@ -40,6 +40,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from middleware.session import _SecureStr
+from fastapi_permissions import reject_read_only_token
 from .redaction import redact
 
 logger = logging.getLogger(__name__)
@@ -110,6 +111,13 @@ def _get_user_id(request: Request) -> str:
         # Should not happen behind the auth middleware, but fail closed.
         raise HTTPException(status_code=401, detail="Authentication required")
     return user["id"]
+
+
+def _require_writable_user(request: Request) -> str:
+    """Auth plus the read-only-token write gate (same class as /tokens)."""
+    user_id = _get_user_id(request)
+    reject_read_only_token(request)
+    return user_id
 
 
 def _store_token(user_id: str, token: str) -> None:
@@ -281,7 +289,7 @@ async def status(request: Request) -> StatusResponse:
 @router.post("/github/device/start", response_model=DeviceStartResponse)
 async def device_start(request: Request) -> DeviceStartResponse:
     _ensure_enabled()
-    user_id = _get_user_id(request)
+    user_id = _require_writable_user(request)
 
     async with httpx.AsyncClient(timeout=15) as client:
         resp = await client.post(
@@ -318,7 +326,7 @@ async def device_start(request: Request) -> DeviceStartResponse:
 @router.post("/github/device/poll", response_model=DevicePollResponse)
 async def device_poll(request: Request) -> DevicePollResponse:
     _ensure_enabled()
-    user_id = _get_user_id(request)
+    user_id = _require_writable_user(request)
 
     pending = _pending_device.get(user_id)
     if not pending:
@@ -361,7 +369,7 @@ async def device_poll(request: Request) -> DevicePollResponse:
 @router.post("/preview", response_model=PreviewResponse)
 async def preview(request: Request, body: ReportRequest) -> PreviewResponse:
     _ensure_enabled()
-    _get_user_id(request)  # auth check
+    _require_writable_user(request)
     title, md = _build_issue(body)
     return PreviewResponse(title=title, body=md)
 
@@ -369,7 +377,7 @@ async def preview(request: Request, body: ReportRequest) -> PreviewResponse:
 @router.post("/submit", response_model=SubmitResponse)
 async def submit(request: Request, body: ReportRequest) -> SubmitResponse:
     _ensure_enabled()
-    user_id = _get_user_id(request)
+    user_id = _require_writable_user(request)
 
     token = _get_token(user_id)
     if not token:

--- a/backend/routers/tokens/tokens.py
+++ b/backend/routers/tokens/tokens.py
@@ -18,7 +18,7 @@ import logging
 
 from middleware.auth import get_current_user
 from api_token_crypto import generate_api_token
-from fastapi_permissions import is_read_only_token
+from fastapi_permissions import reject_read_only_token
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +82,10 @@ def _row_to_metadata(row: asyncpg.Record) -> TokenMetadata:
 
 def _reject_read_only(request: Request) -> None:
     """Read-only tokens manage nothing — block them from minting/revoking tokens."""
-    if is_read_only_token(request):
-        raise HTTPException(
-            status_code=403,
-            detail="This API token is read-only and cannot manage tokens."
-        )
+    reject_read_only_token(
+        request,
+        detail="This API token is read-only and cannot manage tokens.",
+    )
 
 
 @router.post("", response_model=TokenCreateResponse)

--- a/backend/tests/test_bug_report_readonly_token.py
+++ b/backend/tests/test_bug_report_readonly_token.py
@@ -1,0 +1,60 @@
+"""Read-only API tokens must not hit bug-report write POSTs (#591)."""
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from routers.bug_report.bug_report import (
+    ReportRequest,
+    device_poll,
+    device_start,
+    preview,
+    status,
+    submit,
+)
+
+BODY = ReportRequest(
+    title="console crash",
+    category="bug",
+    description="repro steps here",
+)
+
+
+def _request(*, scopes=None) -> Request:
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [],
+        }
+    )
+    request.state.user = {"id": "user-1"}
+    if scopes is not None:
+        request.state.api_token_scopes = scopes
+    return request
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda req: device_start(req),
+        lambda req: device_poll(req),
+        lambda req: preview(req, BODY),
+        lambda req: submit(req, BODY),
+    ],
+    ids=["device_start", "device_poll", "preview", "submit"],
+)
+def test_bug_report_posts_reject_read_only_token(call):
+    request = _request(scopes=["read"])
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(call(request))
+    assert exc.value.status_code == 403
+    assert "read-only" in exc.value.detail
+
+
+def test_bug_report_status_allows_read_only_token():
+    result = asyncio.run(status(_request(scopes=["read"])))
+    assert result.connected is False


### PR DESCRIPTION
Read-only tokens are supposed to never write so they can go to MCP. Bug-report device-start, poll, preview, and submit only checked that a user was on the request.

reject_read_only_token now lives in fastapi_permissions (also used by require_permission WRITE and /tokens). The four bug-report POSTs call it. GET status still allows a read-only token.

Tests: PYTHONPATH=. uv run --with-requirements requirements.txt pytest tests/test_bug_report_readonly_token.py tests/test_bug_report_redaction.py -q (18 passed). Dropping the gate made preview not raise and submit return 401 instead of 403.

Closes #591