### PR TITLE
fix: require CONFIGURATION read on config cache refresh

### DIFF
--- a/backend/routers/config/config.py
+++ b/backend/routers/config/config.py
@@ -341,6 +341,7 @@ async def refresh_config(request: Request):
 
     This is called after any configuration change to ensure the cache is current.
     """
+    await require_read_permission(request, FeatureGroup.CONFIGURATION)
     try:
         service = get_session_vyos_service(request)
         await run_in_threadpool(service.get_full_config, refresh=True)

--- a/backend/tests/test_config_permission.py
+++ b/backend/tests/test_config_permission.py
@@ -1,0 +1,48 @@
+"""Config router handlers must check FeatureGroup.CONFIGURATION (#592).
+
+Snapshot, diff, save, discard, and commit-confirm already called
+require_*_permission. POST /refresh pulled the full device config with
+no check. These tests parse the router source so a missing call fails
+without a database or a device.
+"""
+
+import ast
+from pathlib import Path
+
+CONFIG_ROUTER = Path(__file__).resolve().parents[1] / "routers" / "config" / "config.py"
+
+GATED_HANDLERS = {
+    "get_config_snapshot": "require_read_permission",
+    "get_config_diff": "require_read_permission",
+    "save_config": "require_write_permission",
+    "discard_config": "require_write_permission",
+    "refresh_config": "require_read_permission",
+    "get_commit_confirm_status": "require_read_permission",
+    "confirm_commit": "require_write_permission",
+}
+
+
+def _permission_calls(func_node):
+    calls = set()
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Call):
+            name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            if name and name.startswith("require_"):
+                calls.add(name)
+    return calls
+
+
+def test_config_handlers_call_their_permission_check():
+    tree = ast.parse(CONFIG_ROUTER.read_text())
+    handlers = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+    }
+    for handler, required_call in GATED_HANDLERS.items():
+        assert handler in handlers, f"handler {handler} not found"
+        calls = _permission_calls(handlers[handler])
+        assert required_call in calls, (
+            f"config.py:{handler} must call {required_call} — "
+            "a missing check lets a user without CONFIGURATION through"
+        )


### PR DESCRIPTION
POST /vyos/config/refresh pulled the full device config into the cache with no require_read_permission. Snapshot, diff, save, discard, and commit-confirm already check FeatureGroup.CONFIGURATION.

refresh now awaits require_read_permission. A source test covers every config router handler so a missing check fails CI.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_config_permission.py -q (1 passed). Removing the check failed the test.

Closes #592