### PR TITLE
fix: apply CORS FRONTEND_URL default to WebSocket Origin

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -17,6 +17,7 @@ from middleware.auth import AuthenticationMiddleware
 from middleware.session import SessionMiddleware
 from middleware.audit import AuditMiddleware
 from fastapi_permissions import get_user_feature_permissions
+from trusted_origins import DEFAULT_FRONTEND_URL
 
 # Import routers
 from routers.session import session as session_router
@@ -308,7 +309,7 @@ app = FastAPI(
 # ============================================================================
 
 # CORS Middleware - Must be added BEFORE authentication middleware
-frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+frontend_url = os.getenv("FRONTEND_URL", DEFAULT_FRONTEND_URL)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[frontend_url],

--- a/backend/routers/console/console.py
+++ b/backend/routers/console/console.py
@@ -20,7 +20,6 @@ WebSocket protocol:
 
 import asyncio
 import logging
-import os
 from datetime import datetime
 from typing import Optional
 
@@ -35,6 +34,7 @@ import revocation_bus
 from rbac_permissions import FeatureGroup, PermissionLevel, check_permission
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key
+from trusted_origins import websocket_origin_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +50,6 @@ DEFAULT_COLS = 220
 DEFAULT_ROWS = 50
 MAX_COLS = 500
 MAX_ROWS = 500
-
-# Defense against Cross-Site WebSocket Hijacking: only accept connections whose
-# Origin header matches an entry in TRUSTED_ORIGINS (comma-separated). Falls back
-# to FRONTEND_URL if TRUSTED_ORIGINS is not set.
-_trusted_origins_raw = os.getenv("TRUSTED_ORIGINS") or os.getenv("FRONTEND_URL", "")
-_TRUSTED_ORIGINS = {o.strip() for o in _trusted_origins_raw.split(",") if o.strip()}
 
 # Hard cap on a single inbound WebSocket "input" payload (raw stdin bytes).
 # Real keystrokes and pastes are tiny; anything larger is almost certainly abuse.
@@ -128,7 +122,7 @@ async def websocket_console(websocket: WebSocket):
 
     origin = websocket.headers.get("origin")
 
-    if _TRUSTED_ORIGINS and (not origin or origin not in _TRUSTED_ORIGINS):
+    if not websocket_origin_allowed(origin):
         logger.warning(
             "Rejected console WebSocket from untrusted origin: %r",
             origin,

--- a/backend/routers/monitoring/monitoring.py
+++ b/backend/routers/monitoring/monitoring.py
@@ -11,7 +11,6 @@ Architecture:
 
 import asyncio
 import logging
-import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -32,6 +31,7 @@ from org_scope import (
 import revocation_bus
 from session_cookie import verify_session_cookie
 from ssh_key_manager import decrypt_private_key, generate_keypair
+from trusted_origins import websocket_origin_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -43,12 +43,6 @@ _active_sessions: dict[str, asyncio.Task] = {}
 # Timeouts
 IDLE_TIMEOUT_SECONDS = 300   # 5 minutes
 MAX_DURATION_SECONDS = 1800  # 30 minutes
-
-# Defense against Cross-Site WebSocket Hijacking: only accept connections whose
-# Origin header matches an entry in TRUSTED_ORIGINS (comma-separated). Falls back
-# to FRONTEND_URL if TRUSTED_ORIGINS is not set.
-_trusted_origins_raw = os.getenv("TRUSTED_ORIGINS") or os.getenv("FRONTEND_URL", "")
-_TRUSTED_ORIGINS = {o.strip() for o in _trusted_origins_raw.split(",") if o.strip()}
 
 
 # ============================================================================
@@ -275,7 +269,7 @@ async def websocket_monitor(websocket: WebSocket):
     # Origin allowlist (defense against Cross-Site WebSocket Hijacking). Done
     # BEFORE accept() so a forged cross-origin handshake never gets upgraded.
     origin = websocket.headers.get("origin")
-    if _TRUSTED_ORIGINS and (not origin or origin not in _TRUSTED_ORIGINS):
+    if not websocket_origin_allowed(origin):
         logger.warning("Rejected monitoring WebSocket from untrusted origin: %r", origin)
         await websocket.close(code=1008)  # Policy Violation
         return

--- a/backend/tests/test_websocket_origin.py
+++ b/backend/tests/test_websocket_origin.py
@@ -1,0 +1,41 @@
+"""WebSocket Origin allowlist must not fail open when FRONTEND_URL is unset (#595)."""
+
+import os
+
+import pytest
+
+from trusted_origins import websocket_origin_allowed, websocket_trusted_origins
+
+
+@pytest.fixture
+def clean_origin_env(monkeypatch):
+    monkeypatch.delenv("TRUSTED_ORIGINS", raising=False)
+    monkeypatch.delenv("FRONTEND_URL", raising=False)
+
+
+def test_unset_frontend_url_defaults_to_localhost(clean_origin_env):
+    assert websocket_trusted_origins() == {"http://localhost:3000"}
+    assert websocket_origin_allowed("http://localhost:3000") is True
+    assert websocket_origin_allowed("https://evil.example") is False
+    assert websocket_origin_allowed(None) is False
+
+
+def test_frontend_url_fallback(monkeypatch, clean_origin_env):
+    monkeypatch.setenv("FRONTEND_URL", "https://vymanager.example")
+    assert websocket_origin_allowed("https://vymanager.example") is True
+    assert websocket_origin_allowed("http://localhost:3000") is False
+
+
+def test_trusted_origins_overrides_frontend_url(monkeypatch, clean_origin_env):
+    monkeypatch.setenv("FRONTEND_URL", "http://localhost:3000")
+    monkeypatch.setenv("TRUSTED_ORIGINS", "https://app.example, http://localhost:3000")
+    assert websocket_origin_allowed("https://app.example") is True
+    assert websocket_origin_allowed("http://localhost:3000") is True
+    assert websocket_origin_allowed("https://evil.example") is False
+
+
+def test_whitespace_only_allowlist_refuses_upgrade(monkeypatch, clean_origin_env):
+    monkeypatch.setenv("TRUSTED_ORIGINS", "  ,  ")
+    assert websocket_trusted_origins() == set()
+    assert websocket_origin_allowed("http://localhost:3000") is False
+    assert websocket_origin_allowed(None) is False

--- a/backend/trusted_origins.py
+++ b/backend/trusted_origins.py
@@ -1,0 +1,25 @@
+"""WebSocket Origin allowlist (CSWSH defense).
+
+CORS uses FRONTEND_URL defaulting to http://localhost:3000. The console and
+monitoring sockets used an empty default and skipped the check when the set
+was empty. Same default, and refuse the upgrade if the allowlist is empty.
+"""
+
+import os
+from typing import Optional
+
+DEFAULT_FRONTEND_URL = "http://localhost:3000"
+
+
+def websocket_trusted_origins() -> set[str]:
+    raw = os.getenv("TRUSTED_ORIGINS") or os.getenv(
+        "FRONTEND_URL", DEFAULT_FRONTEND_URL
+    )
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def websocket_origin_allowed(origin: Optional[str]) -> bool:
+    allowed = websocket_trusted_origins()
+    if not allowed:
+        return False
+    return bool(origin) and origin in allowed


### PR DESCRIPTION
CORS treats a missing FRONTEND_URL as http://localhost:3000. Console and monitoring WebSockets used an empty default and skipped the Origin check when the allowlist was empty, so a backend started without those vars accepted any Origin on the SSH PTY socket.

One helper now builds the allowlist (TRUSTED_ORIGINS, else FRONTEND_URL, else the CORS default) and refuses the upgrade when the set is empty or Origin is missing/unlisted.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_websocket_origin.py -q (4 passed).

Closes #595