### PR TITLE
chore: drop unused imports

### DIFF
--- a/backend/commit_confirm_state.py
+++ b/backend/commit_confirm_state.py
@@ -8,7 +8,7 @@ until the user confirms or the timer expires (and VyOS auto-reverts).
 
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import logging
 
 logger = logging.getLogger(__name__)

--- a/backend/events/event_manager.py
+++ b/backend/events/event_manager.py
@@ -15,8 +15,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Dict, Optional, Set
+from typing import Any, Dict, Optional, Set
 
 logger = logging.getLogger(__name__)
 

--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -6,8 +6,6 @@ Integrates with PostgreSQL-based session storage.
 """
 
 import logging
-import os
-from typing import Optional
 from fastapi import Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse

--- a/backend/middleware/session.py
+++ b/backend/middleware/session.py
@@ -10,7 +10,6 @@ import logging
 
 from fastapi import Request, HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
 import asyncpg
 from typing import Optional
 from session_cookie import get_session_cookie, verify_session_cookie

--- a/backend/pyvyos/core/device.py
+++ b/backend/pyvyos/core/device.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import List, Literal
 
-from .rest_client import ApiResponse, RestClient
+from .rest_client import RestClient
 
 
 class VyDevice(RestClient):

--- a/backend/pyvyos/specs/commands/configure.py
+++ b/backend/pyvyos/specs/commands/configure.py
@@ -1,6 +1,6 @@
 """Pydantic models for configure operations."""
 
-from typing import Dict, List, Literal, Union, Any
+from typing import List, Literal, Union
 
 try:
     from pydantic import BaseModel, Field

--- a/backend/routers/config/config.py
+++ b/backend/routers/config/config.py
@@ -13,7 +13,6 @@ from session_vyos_service import get_session_vyos_service
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
 import commit_confirm_state
-import json
 import logging
 from events.event_manager import event_manager, EVENT_CONFIG_DIFF, EVENT_COMMIT_CONFIRM
 logger = logging.getLogger(__name__)

--- a/backend/routers/console/console.py
+++ b/backend/routers/console/console.py
@@ -23,7 +23,6 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-import asyncpg
 import asyncssh
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel

--- a/backend/routers/container/container.py
+++ b/backend/routers/container/container.py
@@ -19,7 +19,6 @@ import shlex
 from datetime import datetime, timezone
 
 import asyncssh
-import asyncpg
 import httpx
 from packaging.version import InvalidVersion, Version
 

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -8,11 +8,9 @@ Layouts are stored per user + per instance.
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from typing import Dict, Any, Optional
-import asyncpg
 import json
 import uuid
 
-from session_vyos_service import get_session_vyos_service
 from fastapi_permissions import require_read_permission, require_write_permission
 from org_scope import request_scoped_conn
 from rbac_permissions import FeatureGroup

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -11,11 +11,10 @@ and /vyos/power/status with a single persistent connection.
 import asyncio
 import json
 import logging
-from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 from starlette.concurrency import run_in_threadpool
 

--- a/backend/routers/monitoring/monitoring.py
+++ b/backend/routers/monitoring/monitoring.py
@@ -14,7 +14,6 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-import asyncpg
 import asyncssh
 from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field

--- a/backend/routers/nat64/nat64.py
+++ b/backend/routers/nat64/nat64.py
@@ -6,7 +6,6 @@ Supports source NAT64 rules with IPv6-to-IPv4 translation pools.
 """
 
 import inspect
-import json
 import logging
 
 from fastapi import APIRouter, HTTPException, Request

--- a/backend/routers/power.py
+++ b/backend/routers/power.py
@@ -10,10 +10,9 @@ Uses session-based architecture - VyOS instance comes from user's active session
 from fastapi import APIRouter, HTTPException, Request
 from starlette.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, Any, Literal
+from typing import Optional, Literal
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
-import asyncpg
 import re
 import uuid
 

--- a/backend/routers/user_management.py
+++ b/backend/routers/user_management.py
@@ -10,15 +10,12 @@ from fastapi import Depends, APIRouter, HTTPException, Request
 from org_scope import assert_row_in_acting_org, org_conn_admin
 import revocation_bus
 from pydantic import BaseModel, Field, EmailStr
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional
 from datetime import datetime
 import asyncpg
 import httpx
 
 from rbac_permissions import (
-    FeatureGroup,
-    PermissionLevel,
-    BuiltInRole,
     get_user_permissions,
 )
 from fastapi_permissions import require_super_admin

--- a/backend/session_vyos_service.py
+++ b/backend/session_vyos_service.py
@@ -6,7 +6,6 @@ Replaces the single-device pattern with dynamic multi-instance support.
 """
 
 from fastapi import Request, HTTPException
-from typing import Optional
 from vyos_service import VyOSService, VyOSDeviceConfig, VyOSDeviceRegistry
 import logging
 

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,4 +1,3 @@
-import pytest
 
 from fastapi.testclient import TestClient
 

--- a/backend/tests/test_websocket_origin.py
+++ b/backend/tests/test_websocket_origin.py
@@ -1,6 +1,5 @@
 """WebSocket Origin allowlist must not fail open when FRONTEND_URL is unset (#595)."""
 
-import os
 
 import pytest
 

--- a/backend/vyos_builders/wireguard/wireguard.py
+++ b/backend/vyos_builders/wireguard/wireguard.py
@@ -5,7 +5,7 @@ Provides all batch operations for WireGuard VPN configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
 
 

--- a/backend/vyos_mappers/__init__.py
+++ b/backend/vyos_mappers/__init__.py
@@ -6,7 +6,7 @@ This keeps the codebase organized and maintainable as it grows.
 """
 
 from .base import BaseFeatureMapper, CommandMapperRegistry
-from .interfaces import EthernetInterfaceMapper, DummyInterfaceMapper, BondingInterfaceMapper, BridgeInterfaceMapper, GeneveInterfaceMapper, InputInterfaceMapper, L2TPv3InterfaceMapper, LoopbackInterfaceMapper, MacsecInterfaceMapper, OpenvpnInterfaceMapper, PppoeInterfaceMapper, VtiInterfaceMapper
+from .interfaces import EthernetInterfaceMapper, DummyInterfaceMapper, BondingInterfaceMapper, BridgeInterfaceMapper, GeneveInterfaceMapper, InputInterfaceMapper, L2TPv3InterfaceMapper, LoopbackInterfaceMapper, MacsecInterfaceMapper, OpenvpnInterfaceMapper, PppoeInterfaceMapper
 from .interfaces.ethernet_versions import get_ethernet_mapper
 from .interfaces.dummy_versions import get_dummy_mapper
 from .interfaces.bonding_versions import get_bonding_mapper
@@ -77,7 +77,6 @@ from .system.system_mapper import SystemMapper
 from .system.system_versions import get_system_mapper
 from .high_availability import HighAvailabilityMapper
 from .high_availability.high_availability_versions import get_high_availability_mapper
-from .load_balancing import LoadBalancingMapper
 from .load_balancing.load_balancing_versions import get_load_balancing_mapper
 from .isis import IsisMapper
 from .isis.isis_versions import get_isis_mapper
@@ -101,9 +100,7 @@ from .pim import PimMapper
 from .pim.pim_versions import get_pim_mapper
 from .pim6 import Pim6Mapper
 from .pim6.pim6_versions import get_pim6_mapper
-from .rip import RipMapper
 from .rip.rip_versions import get_rip_mapper
-from .ripng import RipNgMapper
 from .ripng.ripng_versions import get_ripng_mapper
 from .rpki import RpkiMapper
 from .rpki.rpki_versions import get_rpki_mapper
@@ -111,7 +108,6 @@ from .segment_routing import SegmentRoutingMapper
 from .segment_routing.segment_routing_versions import get_segment_routing_mapper
 from .traffic_engineering import TrafficEngineeringMapper
 from .traffic_engineering.traffic_engineering_versions import get_traffic_engineering_mapper
-from .broadcast_relay import BroadcastRelayMapper
 from .broadcast_relay.broadcast_relay_versions import get_broadcast_relay_mapper
 from .dhcp_relay import DHCPRelayMapper
 from .dhcp_relay.dhcp_relay_versions import get_dhcp_relay_mapper

--- a/backend/vyos_mappers/base.py
+++ b/backend/vyos_mappers/base.py
@@ -4,8 +4,8 @@ Base classes for VyOS command mappers.
 Provides the foundation for version-specific command translation.
 """
 
-from abc import ABC, abstractmethod
-from typing import List, Dict, Type, Union, Callable
+from abc import ABC
+from typing import Dict, Type, Union, Callable
 
 
 class BaseFeatureMapper(ABC):

--- a/backend/vyos_mappers/firewall_global_options/firewall_global_options_versions/v1_4.py
+++ b/backend/vyos_mappers/firewall_global_options/firewall_global_options_versions/v1_4.py
@@ -3,7 +3,6 @@
 VyOS 1.4 supports all base global-options commands.
 No additional features specific to this version.
 """
-from typing import List
 
 
 class FirewallGlobalOptionsMapperV1_4:

--- a/backend/vyos_mappers/pki/pki.py
+++ b/backend/vyos_mappers/pki/pki.py
@@ -6,7 +6,7 @@ The PKI command tree is nearly identical between VyOS 1.4 and 1.5.
 Only difference: VyOS 1.5 ACME listen-address supports IPv6.
 """
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 
 class PKIMapper:

--- a/backend/vyos_mappers/route/route_versions/v1_4.py
+++ b/backend/vyos_mappers/route/route_versions/v1_4.py
@@ -2,7 +2,6 @@
 VyOS 1.4 specific route policy commands.
 """
 
-from typing import List
 
 
 class RouteMapperV1_4:

--- a/backend/vyos_mappers/wireguard/wireguard.py
+++ b/backend/vyos_mappers/wireguard/wireguard.py
@@ -5,7 +5,7 @@ Handles command path generation for WireGuard VPN configuration.
 Version-specific logic is in version-specific files.
 """
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 
 class WireGuardMapper:

--- a/backend/vyos_mappers/wireguard/wireguard_versions/v1_4.py
+++ b/backend/vyos_mappers/wireguard/wireguard_versions/v1_4.py
@@ -1,6 +1,5 @@
 """VyOS 1.4 specific WireGuard commands."""
 
-from typing import List
 
 
 class WireGuardMapperV1_4:

--- a/backend/vyos_mappers/wireguard/wireguard_versions/v1_5.py
+++ b/backend/vyos_mappers/wireguard/wireguard_versions/v1_5.py
@@ -1,6 +1,5 @@
 """VyOS 1.5 specific WireGuard commands."""
 
-from typing import List
 
 
 class WireGuardMapperV1_5:

--- a/backend/vyos_service.py
+++ b/backend/vyos_service.py
@@ -6,7 +6,6 @@ Much cleaner and easier to maintain!
 """
 
 from typing import Optional, Union, Dict, Any, List
-from contextlib import contextmanager
 import json
 import requests as _requests
 

--- a/frontend/src/components/ui/unified-view.tsx
+++ b/frontend/src/components/ui/unified-view.tsx
@@ -5,11 +5,9 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-import { ExternalLink, Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
 import { getUnifiedViewConfig, type UnifiedViewSection } from "@/lib/unified-view/registry";
 
 interface UnifiedViewProps {
@@ -20,7 +18,6 @@ interface UnifiedViewProps {
 }
 
 export function UnifiedView({ isOpen, onClose, type, data }: UnifiedViewProps) {
-  const router = useRouter();
   const [fetchedData, setFetchedData] = useState<unknown>(null);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/frontend/src/lib/unified-view/registry.ts
+++ b/frontend/src/lib/unified-view/registry.ts
@@ -81,7 +81,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 import type { LucideIcon } from "lucide-react";
-import { Network, Users, Activity, Shield, Route, Wifi, Database } from "lucide-react";
+import { Network, Users, Activity, Database } from "lucide-react";
 import { dhcpService, type DHCPLease } from "@/lib/api/dhcp";
 
 export interface UnifiedViewField {


### PR DESCRIPTION
Unused imports were left in backend tests and elsewhere. ruff F401 is clean on the backend. Frontend unified-view no longer imports Button, ExternalLink, useRouter, Shield, Route, or Wifi.

Tests: ruff check --select F401 (clean). pytest tests/test_websocket_origin.py tests/test_config_permission.py tests/test_config_save_path.py (6 passed). frontend tsc and lint (0 errors).