### PR TITLE
fix: gate BGP BMP monitor policies to real CLI nodes

### DIFF
--- a/backend/tests/test_mapper_version_gating.py
+++ b/backend/tests/test_mapper_version_gating.py
@@ -167,6 +167,44 @@ def test_capabilities_read_mapper_allowlist():
     assert "nhrp" in babel_15["redistribute_protocols"]["ipv4"]
 
 
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_bgp_rejects_bmp_monitor_local_rib(version):
+    # local-rib is not a real CLI node on 1.4 or 1.5.
+    mapper = get_bgp_mapper(version)
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_bmp_target_monitor("T1", "ipv4-unicast", "local-rib")
+    builder = BgpBatchBuilder(version=version)
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_bmp_target_monitor("T1", "ipv4-unicast", "local-rib")
+    # real policies still pass through
+    assert mapper.get_bmp_target_monitor("T1", "ipv4-unicast", "pre-policy")[-1] == "pre-policy"
+    assert mapper.get_bmp_target_monitor("T1", "ipv4-unicast", "post-policy")[-1] == "post-policy"
+
+
+def test_bgp_capabilities_drop_bmp_local_rib():
+    for version in ("1.4", "1.5"):
+        caps = BgpBatchBuilder(version=version).get_capabilities()
+        assert "bmp_local_rib" not in caps["features"]
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_vrf_bgp_rejects_bmp_monitor_local_rib(version):
+    mapper = VrfBgpMapper(version)
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_bgp_bmp_target_monitor("blue", "T1", "ipv4-unicast", "local-rib")
+    builder = VrfBatchBuilder(version=version)
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_vrf_bgp_bmp_target_monitor("blue", "T1,ipv4-unicast,local-rib")
+    # real policy still passes through
+    assert mapper.get_bgp_bmp_target_monitor("blue", "T1", "ipv4-unicast", "pre-policy")[-1] == "pre-policy"
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_allowlist_rejects_unknown_bmp_monitor_policy(version):
+    with pytest.raises(ValueError, match="not supported"):
+        get_bgp_mapper(version).get_bmp_target_monitor("T1", "ipv4-unicast", "not-a-policy")
+
+
 @pytest.mark.parametrize("version", ["1.4", "1.4.0", "1.4.4 sagitta"])
 def test_factories_substring_match_14(version):
     assert type(get_ethernet_mapper(version)).__name__ == "EthernetMapper_v1_4"

--- a/backend/vyos_builders/bgp/bgp_batch_builder.py
+++ b/backend/vyos_builders/bgp/bgp_batch_builder.py
@@ -1163,10 +1163,6 @@ class BgpBatchBuilder:
                     "supported": True,
                     "description": "BGP Monitoring Protocol",
                 },
-                "bmp_local_rib": {
-                    "supported": is_1_5,
-                    "description": "BMP local-rib monitoring (VyOS 1.5+)",
-                },
                 "srv6": {
                     "supported": True,
                     "description": "Segment Routing v6",

--- a/backend/vyos_mappers/bgp/bgp.py
+++ b/backend/vyos_mappers/bgp/bgp.py
@@ -19,6 +19,12 @@ class BgpMapper(BaseFeatureMapper):
         "connected", "kernel", "ospf", "rip", "static", "babel", "isis",
     )
 
+    # BMP monitor policies that exist as CLI nodes. local-rib is not a real
+    # node on 1.4 or 1.5, so it is excluded on every version.
+    _BMP_MONITOR_POLICIES = (
+        "pre-policy", "post-policy",
+    )
+
     def __init__(self, version: str):
         super().__init__(version)
 
@@ -31,6 +37,14 @@ class BgpMapper(BaseFeatureMapper):
         if protocol not in self.redistribute_protocols():
             raise ValueError(
                 f"redistribute {protocol} is not supported on this device")
+
+    def bmp_monitor_policies(self) -> FrozenSet[str]:
+        return frozenset(self._BMP_MONITOR_POLICIES)
+
+    def _require_bmp_monitor_policy(self, policy: str) -> None:
+        if policy not in self.bmp_monitor_policies():
+            raise ValueError(
+                f"BMP monitor policy {policy} is not supported on this device")
 
     # ========================================================================
     # Helper base paths
@@ -1081,6 +1095,7 @@ class BgpMapper(BaseFeatureMapper):
         return self._bgp() + ["bmp", "target", name, "mirror"]
 
     def get_bmp_target_monitor(self, name: str, afi: str, policy: str) -> List[str]:
+        self._require_bmp_monitor_policy(policy)
         return self._bgp() + ["bmp", "target", name, "monitor", afi, policy]
 
     def get_bmp_target_delete(self, name: str) -> List[str]:

--- a/backend/vyos_mappers/bgp/bgp_versions/v1_5.py
+++ b/backend/vyos_mappers/bgp/bgp_versions/v1_5.py
@@ -2,16 +2,10 @@
 VyOS 1.5 specific BGP mapper overrides.
 
 BGP command trees are nearly identical between 1.4 and 1.5.
-VyOS 1.5 adds BMP local-rib monitoring and nhrp in redistribute.
 This file exists for the version-aware factory pattern.
 """
 
-from typing import List
-
 
 class BgpMapperV1_5:
-    """VyOS 1.5 specific BGP paths."""
-
-    def get_bmp_target_monitor_local_rib(self, name: str, afi: str) -> List[str]:
-        """BMP local-rib monitoring (1.5 only)."""
-        return ["protocols", "bgp", "bmp", "target", name, "monitor", afi, "local-rib"]
+    """VyOS 1.5 specific BGP paths. Currently no overrides needed."""
+    pass

--- a/backend/vyos_mappers/vrf/vrf_bgp.py
+++ b/backend/vyos_mappers/vrf/vrf_bgp.py
@@ -21,6 +21,12 @@ class VrfBgpMapper:
         "connected", "kernel", "ospf", "rip", "static", "babel", "isis",
     )
 
+    # BMP monitor policies that exist as CLI nodes. local-rib is not a real
+    # node on 1.4 or 1.5, so it is excluded on every version.
+    _BMP_MONITOR_POLICIES = (
+        "pre-policy", "post-policy",
+    )
+
     def __init__(self, version: str = ""):
         self.version = version
 
@@ -33,6 +39,14 @@ class VrfBgpMapper:
         if protocol not in self.redistribute_protocols():
             raise ValueError(
                 f"redistribute {protocol} is not supported on this device")
+
+    def bmp_monitor_policies(self) -> FrozenSet[str]:
+        return frozenset(self._BMP_MONITOR_POLICIES)
+
+    def _require_bmp_monitor_policy(self, policy: str) -> None:
+        if policy not in self.bmp_monitor_policies():
+            raise ValueError(
+                f"BMP monitor policy {policy} is not supported on this device")
 
     def _base(self, name: str) -> List[str]:
         return ["vrf", "name", name, "protocols", "bgp"]
@@ -1164,6 +1178,7 @@ class VrfBgpMapper:
         return self._base(name) + ["bmp", "target", target, "mirror"]
 
     def get_bgp_bmp_target_monitor(self, name: str, target: str, afi: str, policy: str) -> List[str]:
+        self._require_bmp_monitor_policy(policy)
         return self._base(name) + ["bmp", "target", target, "monitor", afi, policy]
 
     def get_bgp_bmp_target_delete(self, name: str, target: str) -> List[str]:

--- a/frontend/src/lib/api/bgp.ts
+++ b/frontend/src/lib/api/bgp.ts
@@ -244,7 +244,6 @@ export interface BgpCapabilities {
     address_families: { supported: boolean; description: string };
     listen_ranges: { supported: boolean; description: string };
     bmp: { supported: boolean; description: string };
-    bmp_local_rib: { supported: boolean; description: string };
     srv6: { supported: boolean; description: string };
     local_role: { supported: boolean; description: string };
     path_attribute: { supported: boolean; description: string };


### PR DESCRIPTION
Both 1.4 and 1.5 reject `protocols bgp bmp target <name> monitor <afi> local-rib`. The mapper emitted whatever monitor policy the batch sent, and get_capabilities advertised a bmp_local_rib feature that is not a real node on either version.

Add a bmp_monitor_policies allowlist (pre-policy, post-policy) to the BGP and VRF BGP mappers, mirroring the redistribute allowlist. get_bmp_target_monitor now raises for any policy off the list, which the batch dispatcher maps to HTTP 400. Dropped the bmp_local_rib capability and its frontend type, and removed the dead local-rib path method from the 1.5 mapper.

Lab-validated on 1.4 and 1.5: local-rib INVALID on both, pre-policy and post-policy VALID on both.

Tests: backend/tests/test_mapper_version_gating.py (27 passed). New cases fail without the guard.

Closes #596
