### PR TITLE
fix: construct only needed mappers in batch builders

### DIFF
--- a/backend/routers/high_availability/high_availability.py
+++ b/backend/routers/high_availability/high_availability.py
@@ -42,8 +42,8 @@ async def get_config(request: Request, refresh: bool = False):
     service = get_session_vyos_service(request)
     full_config = service.get_full_config(refresh=refresh)
     from vyos_mappers import CommandMapperRegistry
-    mappers = CommandMapperRegistry.get_all_mappers(service.get_version())
-    return mappers["high_availability"].parse_config(full_config)
+    mapper = CommandMapperRegistry.get_mapper("high_availability", service.get_version())
+    return mapper.parse_config(full_config)
 
 
 @router.post("/batch", response_model=VyOSResponse)

--- a/backend/routers/load_balancing/load_balancing.py
+++ b/backend/routers/load_balancing/load_balancing.py
@@ -67,8 +67,8 @@ async def get_config(request: Request, refresh: bool = False):
     service = get_session_vyos_service(request)
     full_config = service.get_full_config(refresh=refresh)
     from vyos_mappers import CommandMapperRegistry
-    mappers = CommandMapperRegistry.get_all_mappers(service.get_version())
-    return mappers["load_balancing"].parse_config(full_config)
+    mapper = CommandMapperRegistry.get_mapper("load_balancing", service.get_version())
+    return mapper.parse_config(full_config)
 
 
 @router.post("/batch", response_model=VyOSResponse)

--- a/backend/tests/test_batch_builder_mappers.py
+++ b/backend/tests/test_batch_builder_mappers.py
@@ -1,0 +1,70 @@
+"""Batch builders construct only the feature mappers they use."""
+
+from pathlib import Path
+
+from vyos_builders.bgp.bgp_batch_builder import BgpBatchBuilder
+from vyos_builders.lldp.lldp_batch_builder import LLDPBatchBuilder
+from vyos_builders.vrf.vrf_batch_builder import VrfBatchBuilder
+from vyos_mappers.base import CommandMapperRegistry
+
+VRF_MAPPER_KEYS = (
+    "vrf",
+    "vrf_static",
+    "vrf_rpki",
+    "vrf_failover",
+    "vrf_ospf",
+    "vrf_ospfv3",
+    "vrf_isis",
+    "vrf_bgp",
+    "vrf_dhcp",
+    "vrf_dhcpv6",
+)
+
+
+def _spy_get_mapper(monkeypatch):
+    requested = []
+    real = CommandMapperRegistry.get_mapper.__func__
+
+    def spy(cls, feature, version):
+        requested.append(feature)
+        return real(cls, feature, version)
+
+    monkeypatch.setattr(CommandMapperRegistry, "get_mapper", classmethod(spy))
+    return requested
+
+
+def test_bgp_builder_constructs_only_bgp_mapper(monkeypatch):
+    requested = _spy_get_mapper(monkeypatch)
+    BgpBatchBuilder(version="1.4")
+    assert requested == ["bgp"]
+
+
+def test_lldp_builder_constructs_only_lldp_mapper(monkeypatch):
+    requested = _spy_get_mapper(monkeypatch)
+    LLDPBatchBuilder(version="1.4")
+    assert requested == ["lldp"]
+
+
+def test_vrf_builder_constructs_only_mixin_mappers(monkeypatch):
+    requested = _spy_get_mapper(monkeypatch)
+    VrfBatchBuilder(version="1.4")
+    assert requested == list(VRF_MAPPER_KEYS)
+    assert len(requested) < len(CommandMapperRegistry._features)
+
+
+def test_get_mappers_constructs_only_requested_features(monkeypatch):
+    requested = _spy_get_mapper(monkeypatch)
+    CommandMapperRegistry.get_mappers(("bgp", "ospf"), "1.4")
+    assert requested == ["bgp", "ospf"]
+
+
+def test_callers_do_not_use_get_all_mappers():
+    root = Path(__file__).resolve().parents[1]
+    offenders = sorted(
+        str(p.relative_to(root))
+        for p in root.rglob("*.py")
+        if "tests" not in p.parts
+        and p != root / "vyos_mappers" / "base.py"
+        and "get_all_mappers" in p.read_text()
+    )
+    assert offenders == []

--- a/backend/vyos_builders/access_list/access_list.py
+++ b/backend/vyos_builders/access_list/access_list.py
@@ -17,9 +17,8 @@ class AccessListBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "access_list"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/as_path_list/as_path_list.py
+++ b/backend/vyos_builders/as_path_list/as_path_list.py
@@ -17,9 +17,8 @@ class AsPathListBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "as_path_list"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/babel/babel_batch_builder.py
+++ b/backend/vyos_builders/babel/babel_batch_builder.py
@@ -15,8 +15,8 @@ class BabelBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "babel"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/bfd/bfd_batch_builder.py
+++ b/backend/vyos_builders/bfd/bfd_batch_builder.py
@@ -15,8 +15,8 @@ class BfdBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "bfd"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/bgp/bgp_batch_builder.py
+++ b/backend/vyos_builders/bgp/bgp_batch_builder.py
@@ -18,8 +18,8 @@ class BgpBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "bgp"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/broadcast_relay/broadcast_relay_batch_builder.py
+++ b/backend/vyos_builders/broadcast_relay/broadcast_relay_batch_builder.py
@@ -28,8 +28,7 @@ class BroadcastRelayBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["broadcast_relay"]
+        self.m = CommandMapperRegistry.get_mapper("broadcast_relay", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/config_sync/config_sync_batch_builder.py
+++ b/backend/vyos_builders/config_sync/config_sync_batch_builder.py
@@ -43,8 +43,7 @@ class ConfigSyncBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["config_sync"]
+        self.m = CommandMapperRegistry.get_mapper("config_sync", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/conntrack_sync/conntrack_sync_batch_builder.py
+++ b/backend/vyos_builders/conntrack_sync/conntrack_sync_batch_builder.py
@@ -37,8 +37,7 @@ class ConntrackSyncBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["conntrack_sync"]
+        self.m = CommandMapperRegistry.get_mapper("conntrack_sync", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/console_server/console_server_batch_builder.py
+++ b/backend/vyos_builders/console_server/console_server_batch_builder.py
@@ -30,8 +30,7 @@ class ConsoleServerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["console_server"]
+        self.m = CommandMapperRegistry.get_mapper("console_server", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/container/container_batch_builder.py
+++ b/backend/vyos_builders/container/container_batch_builder.py
@@ -20,8 +20,7 @@ class ContainerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["container"]
+        self.m = CommandMapperRegistry.get_mapper("container", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/dhcp/dhcp.py
+++ b/backend/vyos_builders/dhcp/dhcp.py
@@ -17,9 +17,8 @@ class DHCPBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get DHCP mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "dhcp"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/dhcp_relay/dhcp_relay_batch_builder.py
+++ b/backend/vyos_builders/dhcp_relay/dhcp_relay_batch_builder.py
@@ -30,8 +30,7 @@ class DHCPRelayBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["dhcp_relay"]
+        self.m = CommandMapperRegistry.get_mapper("dhcp_relay", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/dhcpv6_relay/dhcpv6_relay_batch_builder.py
+++ b/backend/vyos_builders/dhcpv6_relay/dhcpv6_relay_batch_builder.py
@@ -28,8 +28,7 @@ class DHCPv6RelayBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["dhcpv6_relay"]
+        self.m = CommandMapperRegistry.get_mapper("dhcpv6_relay", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/dhcpv6_server/dhcpv6_server_batch_builder.py
+++ b/backend/vyos_builders/dhcpv6_server/dhcpv6_server_batch_builder.py
@@ -17,8 +17,7 @@ class DHCPv6ServerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["dhcpv6_server"]
+        self.m = CommandMapperRegistry.get_mapper("dhcpv6_server", version)
 
     # -------------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/dns_dynamic/dns_dynamic_batch_builder.py
+++ b/backend/vyos_builders/dns_dynamic/dns_dynamic_batch_builder.py
@@ -38,8 +38,7 @@ class DNSDynamicBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["dns_dynamic"]
+        self.m = CommandMapperRegistry.get_mapper("dns_dynamic", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
+++ b/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
@@ -24,8 +24,7 @@ class DNSForwardingBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["dns_forwarding"]
+        self.m = CommandMapperRegistry.get_mapper("dns_forwarding", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/event_handler/event_handler_batch_builder.py
+++ b/backend/vyos_builders/event_handler/event_handler_batch_builder.py
@@ -20,8 +20,7 @@ class EventHandlerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["event_handler"]
+        self.m = CommandMapperRegistry.get_mapper("event_handler", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/failover/failover_batch_builder.py
+++ b/backend/vyos_builders/failover/failover_batch_builder.py
@@ -15,8 +15,8 @@ class FailoverBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "failover"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall/bridge.py
+++ b/backend/vyos_builders/firewall/bridge.py
@@ -17,9 +17,8 @@ class BridgeFirewallBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get bridge firewall mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_bridge"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall/flowtables.py
+++ b/backend/vyos_builders/firewall/flowtables.py
@@ -15,8 +15,8 @@ class FlowtablesBatchBuilder:
         """Initialize flowtables batch builder."""
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_flowtables"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall/groups.py
+++ b/backend/vyos_builders/firewall/groups.py
@@ -30,9 +30,8 @@ class FirewallGroupsBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get firewall groups mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_groups"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall/ipv4.py
+++ b/backend/vyos_builders/firewall/ipv4.py
@@ -17,9 +17,8 @@ class FirewallIPv4BatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get firewall IPv4 mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_ipv4"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall/ipv6.py
+++ b/backend/vyos_builders/firewall/ipv6.py
@@ -17,9 +17,8 @@ class FirewallIPv6BatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get firewall IPv6 mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_ipv6"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall/zones.py
+++ b/backend/vyos_builders/firewall/zones.py
@@ -19,8 +19,8 @@ class FirewallZonesBatchBuilder:
         """Initialize firewall zones batch builder."""
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_zones"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/firewall_global_options/firewall_global_options.py
+++ b/backend/vyos_builders/firewall_global_options/firewall_global_options.py
@@ -17,9 +17,8 @@ class FirewallGlobalOptionsBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "firewall_global_options"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/high_availability/high_availability.py
+++ b/backend/vyos_builders/high_availability/high_availability.py
@@ -20,8 +20,8 @@ class HighAvailabilityBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "high_availability"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     def add_set(self, path: List[str]) -> "HighAvailabilityBatchBuilder":
         if path:

--- a/backend/vyos_builders/https/https_batch_builder.py
+++ b/backend/vyos_builders/https/https_batch_builder.py
@@ -24,8 +24,7 @@ class HTTPSBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["https"]
+        self.m = CommandMapperRegistry.get_mapper("https", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/igmp_proxy/igmp_proxy_batch_builder.py
+++ b/backend/vyos_builders/igmp_proxy/igmp_proxy_batch_builder.py
@@ -15,8 +15,8 @@ class IgmpProxyBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "igmp_proxy"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/bonding.py
+++ b/backend/vyos_builders/interfaces/bonding.py
@@ -19,8 +19,8 @@ class BondingInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_bonding"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/bridge.py
+++ b/backend/vyos_builders/interfaces/bridge.py
@@ -19,8 +19,8 @@ class BridgeInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_bridge"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/dummy.py
+++ b/backend/vyos_builders/interfaces/dummy.py
@@ -20,8 +20,8 @@ class DummyInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_dummy"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/ethernet.py
+++ b/backend/vyos_builders/interfaces/ethernet.py
@@ -16,9 +16,8 @@ class EthernetInterfaceBuilderMixin:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get all feature mappers for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_ethernet"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/geneve.py
+++ b/backend/vyos_builders/interfaces/geneve.py
@@ -19,8 +19,8 @@ class GeneveInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_geneve"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/input.py
+++ b/backend/vyos_builders/interfaces/input.py
@@ -20,8 +20,8 @@ class InputInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_input"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/l2tpv3.py
+++ b/backend/vyos_builders/interfaces/l2tpv3.py
@@ -19,8 +19,8 @@ class L2TPv3InterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_l2tpv3"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/loopback.py
+++ b/backend/vyos_builders/interfaces/loopback.py
@@ -20,8 +20,8 @@ class LoopbackInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_loopback"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/macsec.py
+++ b/backend/vyos_builders/interfaces/macsec.py
@@ -22,8 +22,8 @@ class MacsecInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_macsec"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/openvpn.py
+++ b/backend/vyos_builders/interfaces/openvpn.py
@@ -25,8 +25,8 @@ class OpenvpnInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_openvpn"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/pppoe.py
+++ b/backend/vyos_builders/interfaces/pppoe.py
@@ -25,8 +25,8 @@ class PppoeInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_pppoe"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/pseudo_ethernet.py
+++ b/backend/vyos_builders/interfaces/pseudo_ethernet.py
@@ -24,8 +24,8 @@ class PseudoEthernetInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_pseudo_ethernet"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core batch helpers

--- a/backend/vyos_builders/interfaces/sstpc.py
+++ b/backend/vyos_builders/interfaces/sstpc.py
@@ -23,8 +23,8 @@ class SstpcInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_sstpc"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/virtual_ethernet.py
+++ b/backend/vyos_builders/interfaces/virtual_ethernet.py
@@ -26,8 +26,8 @@ class VirtualEthernetInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_virtual_ethernet"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core batch helpers

--- a/backend/vyos_builders/interfaces/vpp.py
+++ b/backend/vyos_builders/interfaces/vpp.py
@@ -21,8 +21,8 @@ class VppInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "interface_vpp"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # =========================================================================
     # Core batch helpers

--- a/backend/vyos_builders/interfaces/vti.py
+++ b/backend/vyos_builders/interfaces/vti.py
@@ -21,8 +21,8 @@ class VtiInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.interface_mapper_key = "interface_vti"
+        self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # =========================================================================
     # Core batch helpers

--- a/backend/vyos_builders/interfaces/wireless.py
+++ b/backend/vyos_builders/interfaces/wireless.py
@@ -25,8 +25,8 @@ class WirelessInterfaceBuilderMixin:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "interface_wireless"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/interfaces/wwan.py
+++ b/backend/vyos_builders/interfaces/wwan.py
@@ -25,8 +25,8 @@ class WwanInterfaceBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "interface_wwan"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/ipoe_server/ipoe_server_batch_builder.py
+++ b/backend/vyos_builders/ipoe_server/ipoe_server_batch_builder.py
@@ -10,8 +10,8 @@ class IPoEServerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "ipoe_server"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core infrastructure

--- a/backend/vyos_builders/ipsec/ipsec.py
+++ b/backend/vyos_builders/ipsec/ipsec.py
@@ -15,8 +15,8 @@ class IPSecBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "ipsec"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/isis/isis_batch_builder.py
+++ b/backend/vyos_builders/isis/isis_batch_builder.py
@@ -16,8 +16,7 @@ class IsisBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["isis"]
+        self.m = CommandMapperRegistry.get_mapper("isis", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/l2tp/l2tp.py
+++ b/backend/vyos_builders/l2tp/l2tp.py
@@ -15,8 +15,8 @@ class L2TPBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "l2tp"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/lldp/lldp_batch_builder.py
+++ b/backend/vyos_builders/lldp/lldp_batch_builder.py
@@ -38,8 +38,7 @@ class LLDPBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["lldp"]
+        self.m = CommandMapperRegistry.get_mapper("lldp", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/load_balancing/load_balancing.py
+++ b/backend/vyos_builders/load_balancing/load_balancing.py
@@ -23,8 +23,8 @@ class LoadBalancingBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "load_balancing"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     def _m(self):
         return self.mappers[self.mapper_key]

--- a/backend/vyos_builders/local_route/local_route.py
+++ b/backend/vyos_builders/local_route/local_route.py
@@ -17,9 +17,8 @@ class LocalRouteBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "local_route"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/mpls/mpls_batch_builder.py
+++ b/backend/vyos_builders/mpls/mpls_batch_builder.py
@@ -19,8 +19,7 @@ class MplsBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["mpls"]
+        self.m = CommandMapperRegistry.get_mapper("mpls", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/nat/nat.py
+++ b/backend/vyos_builders/nat/nat.py
@@ -16,9 +16,8 @@ class NATBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get NAT mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "nat"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/nat64/nat64.py
+++ b/backend/vyos_builders/nat64/nat64.py
@@ -13,8 +13,8 @@ class NAT64BatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "nat64"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     def add_set(self, path: List[str]) -> "NAT64BatchBuilder":
         if path:

--- a/backend/vyos_builders/nat66/nat66.py
+++ b/backend/vyos_builders/nat66/nat66.py
@@ -15,8 +15,8 @@ class NAT66BatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "nat66"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     def add_set(self, path: List[str]) -> "NAT66BatchBuilder":
         if path:

--- a/backend/vyos_builders/ndp_proxy/ndp_proxy_batch_builder.py
+++ b/backend/vyos_builders/ndp_proxy/ndp_proxy_batch_builder.py
@@ -28,8 +28,7 @@ class NdpProxyBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["ndp_proxy"]
+        self.m = CommandMapperRegistry.get_mapper("ndp_proxy", version)
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/nhrp/nhrp_batch_builder.py
+++ b/backend/vyos_builders/nhrp/nhrp_batch_builder.py
@@ -22,8 +22,7 @@ class NhrpBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["nhrp"]
+        self.m = CommandMapperRegistry.get_mapper("nhrp", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/ntp/ntp_batch_builder.py
+++ b/backend/vyos_builders/ntp/ntp_batch_builder.py
@@ -30,8 +30,7 @@ class NTPBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["ntp"]
+        self.m = CommandMapperRegistry.get_mapper("ntp", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/openfabric/openfabric_batch_builder.py
+++ b/backend/vyos_builders/openfabric/openfabric_batch_builder.py
@@ -8,8 +8,7 @@ class OpenfabricBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["openfabric"]
+        self.m = CommandMapperRegistry.get_mapper("openfabric", version)
 
     # ── Internals ─────────────────────────────────────────────────────────
 

--- a/backend/vyos_builders/ospf/ospf_batch_builder.py
+++ b/backend/vyos_builders/ospf/ospf_batch_builder.py
@@ -20,8 +20,8 @@ class OspfBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "ospf"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/ospfv3/ospfv3_batch_builder.py
+++ b/backend/vyos_builders/ospfv3/ospfv3_batch_builder.py
@@ -18,8 +18,8 @@ class Ospfv3BatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "ospfv3"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/pim/pim_batch_builder.py
+++ b/backend/vyos_builders/pim/pim_batch_builder.py
@@ -20,8 +20,8 @@ class PimBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "pim"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/pim6/pim6_batch_builder.py
+++ b/backend/vyos_builders/pim6/pim6_batch_builder.py
@@ -17,8 +17,8 @@ class Pim6BatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "pim6"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/pki/pki.py
+++ b/backend/vyos_builders/pki/pki.py
@@ -21,8 +21,8 @@ class PKIBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "pki"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/pppoe_server/pppoe_server_batch_builder.py
+++ b/backend/vyos_builders/pppoe_server/pppoe_server_batch_builder.py
@@ -10,8 +10,8 @@ class PPPoEServerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "pppoe_server"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core infrastructure

--- a/backend/vyos_builders/prefix_list/prefix_list.py
+++ b/backend/vyos_builders/prefix_list/prefix_list.py
@@ -17,9 +17,8 @@ class PrefixListBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "prefix_list"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/qos/qos_batch_builder.py
+++ b/backend/vyos_builders/qos/qos_batch_builder.py
@@ -60,8 +60,7 @@ class QoSBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["qos"]
+        self.m = CommandMapperRegistry.get_mapper("qos", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/rip/rip_batch_builder.py
+++ b/backend/vyos_builders/rip/rip_batch_builder.py
@@ -15,8 +15,8 @@ class RipBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "rip"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/ripng/ripng_batch_builder.py
+++ b/backend/vyos_builders/ripng/ripng_batch_builder.py
@@ -15,8 +15,8 @@ class RipNgBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "ripng"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/route/route_batch_builder.py
+++ b/backend/vyos_builders/route/route_batch_builder.py
@@ -17,9 +17,8 @@ class RouteBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "route"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/route_map/route_map_batch_builder.py
+++ b/backend/vyos_builders/route_map/route_map_batch_builder.py
@@ -17,9 +17,8 @@ class RouteMapBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "route_map"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/router_advert/router_advert_batch_builder.py
+++ b/backend/vyos_builders/router_advert/router_advert_batch_builder.py
@@ -14,8 +14,7 @@ class RouterAdvertBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["router_advert"]
+        self.m = CommandMapperRegistry.get_mapper("router_advert", version)
 
     # ========================================================================
     # Core helpers

--- a/backend/vyos_builders/rpki/rpki_batch_builder.py
+++ b/backend/vyos_builders/rpki/rpki_batch_builder.py
@@ -14,8 +14,8 @@ class RpkiBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "rpki"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/salt_minion/salt_minion_batch_builder.py
+++ b/backend/vyos_builders/salt_minion/salt_minion_batch_builder.py
@@ -26,8 +26,7 @@ class SaltMinionBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["salt_minion"]
+        self.m = CommandMapperRegistry.get_mapper("salt_minion", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/segment_routing/segment_routing_batch_builder.py
+++ b/backend/vyos_builders/segment_routing/segment_routing_batch_builder.py
@@ -14,8 +14,8 @@ class SegmentRoutingBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "segment_routing"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/service_monitoring/service_monitoring_batch_builder.py
+++ b/backend/vyos_builders/service_monitoring/service_monitoring_batch_builder.py
@@ -30,8 +30,7 @@ class ServiceMonitoringBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["service_monitoring"]
+        self.m = CommandMapperRegistry.get_mapper("service_monitoring", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/sla/sla_batch_builder.py
+++ b/backend/vyos_builders/sla/sla_batch_builder.py
@@ -24,8 +24,7 @@ class SLABatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["sla"]
+        self.m = CommandMapperRegistry.get_mapper("sla", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/snmp/snmp_batch_builder.py
+++ b/backend/vyos_builders/snmp/snmp_batch_builder.py
@@ -22,8 +22,7 @@ class SNMPBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["snmp"]
+        self.m = CommandMapperRegistry.get_mapper("snmp", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/ssh/ssh_batch_builder.py
+++ b/backend/vyos_builders/ssh/ssh_batch_builder.py
@@ -76,8 +76,7 @@ class SSHBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["ssh"]
+        self.m = CommandMapperRegistry.get_mapper("ssh", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/static_routes/static_routes_batch_builder.py
+++ b/backend/vyos_builders/static_routes/static_routes_batch_builder.py
@@ -17,9 +17,8 @@ class StaticRoutesBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "static_routes"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/tftp_server/tftp_server_batch_builder.py
+++ b/backend/vyos_builders/tftp_server/tftp_server_batch_builder.py
@@ -17,8 +17,7 @@ class TFTPServerBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["tftp_server"]
+        self.m = CommandMapperRegistry.get_mapper("tftp_server", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/traffic_engineering/traffic_engineering_batch_builder.py
+++ b/backend/vyos_builders/traffic_engineering/traffic_engineering_batch_builder.py
@@ -16,8 +16,8 @@ class TrafficEngineeringBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "traffic_engineering"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/tunnel/tunnel_batch_builder.py
+++ b/backend/vyos_builders/tunnel/tunnel_batch_builder.py
@@ -21,8 +21,8 @@ class TunnelBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "tunnel"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/vrf/vrf_batch_builder.py
+++ b/backend/vyos_builders/vrf/vrf_batch_builder.py
@@ -39,8 +39,22 @@ class VrfBatchBuilder(
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "vrf"
+        self.mappers = CommandMapperRegistry.get_mappers(
+            (
+                "vrf",
+                "vrf_static",
+                "vrf_rpki",
+                "vrf_failover",
+                "vrf_ospf",
+                "vrf_ospfv3",
+                "vrf_isis",
+                "vrf_bgp",
+                "vrf_dhcp",
+                "vrf_dhcpv6",
+            ),
+            version,
+        )
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/vxlan/vxlan_batch_builder.py
+++ b/backend/vyos_builders/vxlan/vxlan_batch_builder.py
@@ -21,8 +21,8 @@ class VxlanBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "vxlan"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_builders/webproxy/webproxy_batch_builder.py
+++ b/backend/vyos_builders/webproxy/webproxy_batch_builder.py
@@ -28,8 +28,7 @@ class WebProxyBatchBuilder:
     def __init__(self, version: str):
         self.version = version
         self._operations: List[Dict[str, Any]] = []
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
-        self.m = self.mappers["webproxy"]
+        self.m = CommandMapperRegistry.get_mapper("webproxy", version)
 
     # -----------------------------------------------------------------------
     # Core helpers

--- a/backend/vyos_builders/wireguard/wireguard.py
+++ b/backend/vyos_builders/wireguard/wireguard.py
@@ -17,9 +17,8 @@ class WireGuardBatchBuilder:
         self.version = version
         self._operations: List[Dict[str, Any]] = []
 
-        # Get mapper for this version
-        self.mappers = CommandMapperRegistry.get_all_mappers(version)
         self.mapper_key = "wireguard"
+        self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations

--- a/backend/vyos_mappers/base.py
+++ b/backend/vyos_mappers/base.py
@@ -5,7 +5,7 @@ Provides the foundation for version-specific command translation.
 """
 
 from abc import ABC
-from typing import Dict, Type, Union, Callable
+from typing import Dict, Iterable, Type, Union, Callable
 
 
 class BaseFeatureMapper(ABC):
@@ -83,6 +83,11 @@ class CommandMapperRegistry:
             return mapper_or_factory(version)
 
     @classmethod
+    def get_mappers(cls, features: Iterable[str], version: str) -> Dict[str, BaseFeatureMapper]:
+        """Get mapper instances for the given feature names only."""
+        return {name: cls.get_mapper(name, version) for name in features}
+
+    @classmethod
     def get_all_mappers(cls, version: str) -> Dict[str, BaseFeatureMapper]:
         """
         Get all mapper instances for a specific version.
@@ -93,7 +98,4 @@ class CommandMapperRegistry:
         Returns:
             Dictionary mapping feature names to mapper instances
         """
-        return {
-            name: cls.get_mapper(name, version)
-            for name in cls._features.keys()
-        }
+        return cls.get_mappers(tuple(cls._features), version)


### PR DESCRIPTION
Single-feature batch builders called CommandMapperRegistry.get_all_mappers then kept one key, so each batch constructed about 100 mapper objects. They now call get_mapper for that feature. VRF requests only the mapper keys its mixins use. Load-balancing and high-availability config reads do the same.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_batch_builder_mappers.py tests/test_mapper_version_gating.py tests/test_access_list_network_paths.py tests/test_bfd_builder_paths.py -q (128 passed). PYTHONPATH=. uv run --with pytest --with-requirements requirements.txt pytest tests/test_batch_dispatch.py tests/test_segment_routing.py -q (17 passed).

Closes #597