### PR TITLE
fix: NAT64 unused capabilities, onboarding client helper, service path tests

### DIFF
--- a/backend/tests/test_config_sync_builder_paths.py
+++ b/backend/tests/test_config_sync_builder_paths.py
@@ -1,20 +1,42 @@
+"""Golden (method, args, expected_path) cases for ConfigSyncBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+"""
+
 import pytest
 
 from routers.config_sync.config_sync import _parse_sections
 from vyos_builders.config_sync.config_sync_batch_builder import ConfigSyncBatchBuilder
 
 
-@pytest.mark.parametrize("version", ["1.4", "1.5"])
-def test_config_sync_valid_system_subsection(version):
-    builder = ConfigSyncBatchBuilder(version=version)
-    builder.set_section_sub("system", "conntrack")
+BASE = ["service", "config-sync"]
 
-    assert builder.get_operations() == [
-        {
-            "op": "set",
-            "path": ["service", "config-sync", "section", "system", "conntrack"],
-        }
-    ]
+CASES = [
+    ("delete_config_sync", (), "delete", BASE),
+    ("set_mode", ("load",), "set", BASE + ["mode", "load"]),
+    ("delete_mode", (), "delete", BASE + ["mode"]),
+    ("set_secondary_address", ("192.0.2.1",), "set", BASE + ["secondary", "address", "192.0.2.1"]),
+    ("delete_secondary_address", (), "delete", BASE + ["secondary", "address"]),
+    ("set_secondary_key", ("secret",), "set", BASE + ["secondary", "key", "secret"]),
+    ("delete_secondary_key", (), "delete", BASE + ["secondary", "key"]),
+    ("set_secondary_port", ("443",), "set", BASE + ["secondary", "port", "443"]),
+    ("delete_secondary_port", (), "delete", BASE + ["secondary", "port"]),
+    ("set_secondary_timeout", ("30",), "set", BASE + ["secondary", "timeout", "30"]),
+    ("delete_secondary_timeout", (), "delete", BASE + ["secondary", "timeout"]),
+    ("set_section", ("firewall",), "set", BASE + ["section", "firewall"]),
+    ("delete_section", ("firewall",), "delete", BASE + ["section", "firewall"]),
+    ("set_section_sub", ("system", "conntrack"), "set", BASE + ["section", "system", "conntrack"]),
+    ("delete_section_sub", ("system", "conntrack"), "delete", BASE + ["section", "system", "conntrack"]),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_config_sync_builder_paths(method, args, op, expected_path, version):
+    builder = ConfigSyncBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]
 
 
 @pytest.mark.parametrize("version", ["1.4", "1.5"])

--- a/backend/tests/test_conntrack_sync_builder_paths.py
+++ b/backend/tests/test_conntrack_sync_builder_paths.py
@@ -1,0 +1,71 @@
+"""Golden (method, args, expected_path) cases for ConntrackSyncBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+"""
+
+import pytest
+
+from vyos_builders.conntrack_sync.conntrack_sync_batch_builder import (
+    ConntrackSyncBatchBuilder,
+)
+
+
+IFACE = "eth0"
+BASE = ["service", "conntrack-sync"]
+
+CASES = [
+    ("delete_conntrack_sync", (), "delete", BASE),
+    ("set_accept_protocol", ("tcp",), "set", BASE + ["accept-protocol", "tcp"]),
+    ("delete_accept_protocol", ("tcp",), "delete", BASE + ["accept-protocol", "tcp"]),
+    ("delete_accept_protocols", (), "delete", BASE + ["accept-protocol"]),
+    ("set_disable_external_cache", (), "set", BASE + ["disable-external-cache"]),
+    ("delete_disable_external_cache", (), "delete", BASE + ["disable-external-cache"]),
+    ("set_disable_syslog", (), "set", BASE + ["disable-syslog"]),
+    ("delete_disable_syslog", (), "delete", BASE + ["disable-syslog"]),
+    ("set_event_listen_queue_size", ("8",), "set", BASE + ["event-listen-queue-size", "8"]),
+    ("delete_event_listen_queue_size", (), "delete", BASE + ["event-listen-queue-size"]),
+    ("set_expect_sync", ("ftp",), "set", BASE + ["expect-sync", "ftp"]),
+    ("delete_expect_sync", ("ftp",), "delete", BASE + ["expect-sync", "ftp"]),
+    ("delete_expect_syncs", (), "delete", BASE + ["expect-sync"]),
+    (
+        "set_failover_vrrp_sync_group",
+        ("LAN",),
+        "set",
+        BASE + ["failover-mechanism", "vrrp", "sync-group", "LAN"],
+    ),
+    (
+        "delete_failover_vrrp_sync_group",
+        (),
+        "delete",
+        BASE + ["failover-mechanism", "vrrp", "sync-group"],
+    ),
+    ("delete_failover_mechanism", (), "delete", BASE + ["failover-mechanism"]),
+    ("set_ignore_address", ("192.0.2.1",), "set", BASE + ["ignore-address", "192.0.2.1"]),
+    ("delete_ignore_address", ("192.0.2.1",), "delete", BASE + ["ignore-address", "192.0.2.1"]),
+    ("delete_ignore_addresses", (), "delete", BASE + ["ignore-address"]),
+    ("set_interface", (IFACE,), "set", BASE + ["interface", IFACE]),
+    ("delete_interface", (IFACE,), "delete", BASE + ["interface", IFACE]),
+    ("delete_interfaces", (), "delete", BASE + ["interface"]),
+    ("set_interface_peer", (IFACE, "192.0.2.2"), "set", BASE + ["interface", IFACE, "peer", "192.0.2.2"]),
+    ("delete_interface_peer", (IFACE,), "delete", BASE + ["interface", IFACE, "peer"]),
+    ("set_interface_port", (IFACE, "3780"), "set", BASE + ["interface", IFACE, "port", "3780"]),
+    ("delete_interface_port", (IFACE,), "delete", BASE + ["interface", IFACE, "port"]),
+    ("set_listen_address", ("192.0.2.10",), "set", BASE + ["listen-address", "192.0.2.10"]),
+    ("delete_listen_address", ("192.0.2.10",), "delete", BASE + ["listen-address", "192.0.2.10"]),
+    ("delete_listen_addresses", (), "delete", BASE + ["listen-address"]),
+    ("set_mcast_group", ("225.0.0.50",), "set", BASE + ["mcast-group", "225.0.0.50"]),
+    ("delete_mcast_group", (), "delete", BASE + ["mcast-group"]),
+    ("set_startup_resync", (), "set", BASE + ["startup-resync"]),
+    ("delete_startup_resync", (), "delete", BASE + ["startup-resync"]),
+    ("set_sync_queue_size", ("1",), "set", BASE + ["sync-queue-size", "1"]),
+    ("delete_sync_queue_size", (), "delete", BASE + ["sync-queue-size"]),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_conntrack_sync_builder_paths(method, args, op, expected_path, version):
+    builder = ConntrackSyncBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]

--- a/backend/tests/test_console_server_builder_paths.py
+++ b/backend/tests/test_console_server_builder_paths.py
@@ -1,0 +1,46 @@
+"""Golden (method, args, expected_path) cases for ConsoleServerBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+"""
+
+import pytest
+
+from vyos_builders.console_server.console_server_batch_builder import (
+    ConsoleServerBatchBuilder,
+)
+
+
+DEVICE = "ttyS0"
+BASE = ["service", "console-server"]
+NODE = BASE + ["device", DEVICE]
+
+CASES = [
+    ("delete_console_server", (), "delete", BASE),
+    ("set_device", (DEVICE,), "set", NODE),
+    ("delete_device", (DEVICE,), "delete", NODE),
+    ("delete_devices", (), "delete", BASE + ["device"]),
+    ("set_device_alias", (DEVICE, "core-console"), "set", NODE + ["alias", "core-console"]),
+    ("delete_device_alias", (DEVICE,), "delete", NODE + ["alias"]),
+    ("set_device_data_bits", (DEVICE, "8"), "set", NODE + ["data-bits", "8"]),
+    ("delete_device_data_bits", (DEVICE,), "delete", NODE + ["data-bits"]),
+    ("set_device_description", (DEVICE, "serial"), "set", NODE + ["description", "serial"]),
+    ("delete_device_description", (DEVICE,), "delete", NODE + ["description"]),
+    ("set_device_parity", (DEVICE, "none"), "set", NODE + ["parity", "none"]),
+    ("delete_device_parity", (DEVICE,), "delete", NODE + ["parity"]),
+    ("set_device_speed", (DEVICE, "9600"), "set", NODE + ["speed", "9600"]),
+    ("delete_device_speed", (DEVICE,), "delete", NODE + ["speed"]),
+    ("set_device_ssh_port", (DEVICE, "2222"), "set", NODE + ["ssh", "port", "2222"]),
+    ("delete_device_ssh_port", (DEVICE,), "delete", NODE + ["ssh", "port"]),
+    ("delete_device_ssh", (DEVICE,), "delete", NODE + ["ssh"]),
+    ("set_device_stop_bits", (DEVICE, "1"), "set", NODE + ["stop-bits", "1"]),
+    ("delete_device_stop_bits", (DEVICE,), "delete", NODE + ["stop-bits"]),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_console_server_builder_paths(method, args, op, expected_path, version):
+    builder = ConsoleServerBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -25,17 +25,7 @@ export default function LoginPage() {
       try {
         // Use the frontend proxy instead of direct backend access
         // This works around Docker networking issues where browser can't access backend directly
-        const response = await fetch(`/api/session/onboarding-status`, {
-          method: "GET",
-        });
-
-        if (!response.ok) {
-          console.error("[LoginPage] Onboarding status check failed:", response.status);
-          setCheckingOnboarding(false);
-          return;
-        }
-
-        const data = await response.json();
+        const data = await sessionService.getOnboardingStatus();
 
         if (data.needs_onboarding) {
           console.log("[LoginPage] Onboarding needed - redirecting to /onboarding");

--- a/frontend/src/app/network/nat64/page.tsx
+++ b/frontend/src/app/network/nat64/page.tsx
@@ -28,7 +28,6 @@ import {
 import {
   nat64Service,
   type NAT64ConfigResponse,
-  type NAT64Capabilities,
   type NAT64SourceRule,
   type NAT64TranslationPool,
 } from "@/lib/api/nat64";
@@ -43,7 +42,6 @@ import { FeatureGroup } from "@/lib/api/user-management";
 export default function NAT64Page() {
   const { canRead, canWrite, isLoading: permissionsLoading } = usePermissions();
   const [config, setConfig] = useState<NAT64ConfigResponse | null>(null);
-  const [, setCapabilities] = useState<NAT64Capabilities | null>(null);
   const [selectedRule, setSelectedRule] = useState<NAT64SourceRule | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -82,7 +80,6 @@ export default function NAT64Page() {
 
   useEffect(() => {
     fetchConfig();
-    nat64Service.getCapabilities().then(setCapabilities).catch(console.error);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -37,17 +37,7 @@ export default function OnboardingPage() {
     const checkOnboardingAccess = async () => {
       try {
         console.log("[OnboardingPage] Checking if onboarding is needed...");
-        const response = await fetch("/api/session/onboarding-status", {
-          method: "GET",
-        });
-
-        if (!response.ok) {
-          console.error("[OnboardingPage] Failed to check onboarding status");
-          router.push("/login");
-          return;
-        }
-
-        const data = await response.json();
+        const data = await sessionService.getOnboardingStatus();
 
         if (!data.needs_onboarding) {
           // Users already exist - onboarding is not allowed
@@ -164,19 +154,13 @@ export default function OnboardingPage() {
       // SECURITY: Re-check onboarding status before creating account
       // Prevents race condition if someone else completed onboarding while form was open
       console.log("[Onboarding] Validating onboarding is still needed...");
-      const statusCheck = await fetch("/api/session/onboarding-status", {
-        method: "GET",
-      });
-
-      if (statusCheck.ok) {
-        const statusData = await statusCheck.json();
-        if (!statusData.needs_onboarding) {
-          setError("Onboarding has already been completed by another user. Please log in.");
-          setLoading(false);
-          setIsSubmitting(false);
-          setTimeout(() => router.push("/login"), 2000);
-          return;
-        }
+      const statusData = await sessionService.getOnboardingStatus();
+      if (!statusData.needs_onboarding) {
+        setError("Onboarding has already been completed by another user. Please log in.");
+        setLoading(false);
+        setIsSubmitting(false);
+        setTimeout(() => router.push("/login"), 2000);
+        return;
       }
 
       // Step 1: Create admin account

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -180,17 +180,7 @@ export default function Home() {
 
       if (!session?.user) {
         try {
-          const response = await fetch(`/api/session/onboarding-status`, {
-            method: "GET",
-          });
-
-          if (!response.ok) {
-            console.error("[RootPage] Onboarding status check failed:", response.status);
-            router.push("/login");
-            return;
-          }
-
-          const data = await response.json();
+          const data = await sessionService.getOnboardingStatus();
 
           if (data.needs_onboarding) {
             console.log("[RootPage] Onboarding needed - redirecting to /onboarding");

--- a/frontend/src/lib/api/session.ts
+++ b/frontend/src/lib/api/session.ts
@@ -131,6 +131,10 @@ export interface InstanceUpdateRequest {
   timeout?: number;
 }
 
+export interface OnboardingStatus {
+  needs_onboarding: boolean;
+}
+
 export interface AuthSessionInfo {
   token: string;
   created_at: string;
@@ -171,6 +175,10 @@ export interface RestoreSummary {
 // ============================================================================
 
 class SessionService {
+  async getOnboardingStatus(): Promise<OnboardingStatus> {
+    return apiClient.get<OnboardingStatus>("/session/onboarding-status");
+  }
+
   /**
    * Get the user's current active session
    * Returns null if no active session


### PR DESCRIPTION
NAT64 fetched capabilities and never used them. All advertised NAT64 features are always supported, so the dead fetch is gone.

Onboarding status used raw fetch on login, home, and onboarding. Those callers now go through sessionService.getOnboardingStatus.

Conntrack-sync and console-server had no golden path tables. config-sync only covered the login rejection. Added (method, args, expected_path) cases including matching delete for valueless set leaves. validateTmplPath on 1.4 and 1.5 accepted the emitted trees.

Tests: 108 passed (conntrack-sync, console-server path tests), 33 passed (config-sync with FastAPI). npx tsc --noEmit and npm run lint in frontend/.

Closes #620
Closes #621
Closes #625