### PR TITLE
fix: DHCP lease release gates on a capability flag

### DIFF
--- a/backend/tests/test_dhcp_lease_clear_capability.py
+++ b/backend/tests/test_dhcp_lease_clear_capability.py
@@ -1,0 +1,22 @@
+"""DHCP lease-clear capability comes from the mapper, not a version sniff in the UI."""
+
+from vyos_builders.dhcp.dhcp import DHCPBatchBuilder
+from vyos_mappers.dhcp.dhcp import DHCPMapper
+
+
+def test_mapper_1_4_cannot_clear_inactive():
+    assert DHCPMapper("1.4").can_clear_inactive_leases() is False
+
+
+def test_mapper_1_5_can_clear_inactive():
+    assert DHCPMapper("1.5").can_clear_inactive_leases() is True
+
+
+def test_capabilities_1_4_hides_inactive_clear():
+    fields = DHCPBatchBuilder(version="1.4").get_capabilities()["fields"]
+    assert fields["clear_inactive_lease"]["supported"] is False
+
+
+def test_capabilities_1_5_advertises_inactive_clear():
+    fields = DHCPBatchBuilder(version="1.5").get_capabilities()["fields"]
+    assert fields["clear_inactive_lease"]["supported"] is True

--- a/backend/vyos_builders/dhcp/dhcp.py
+++ b/backend/vyos_builders/dhcp/dhcp.py
@@ -808,7 +808,9 @@ class DHCPBatchBuilder:
 
     def get_capabilities(self) -> Dict[str, Any]:
         """Get capabilities for the current VyOS version."""
-        has_subnet_id = self.mappers[self.mapper_key].has_subnet_id()
+        mapper = self.mappers[self.mapper_key]
+        has_subnet_id = mapper.has_subnet_id()
+        can_clear_inactive_leases = mapper.can_clear_inactive_leases()
         is_v15_or_later = "1.5" in self.version or "latest" in self.version
         is_v14 = "1.4" in self.version
 
@@ -920,6 +922,10 @@ class DHCPBatchBuilder:
                 "enable_failover": {
                     "supported": is_v14,
                     "description": "High availability failover (VyOS 1.4 only)",
+                },
+                "clear_inactive_lease": {
+                    "supported": can_clear_inactive_leases,
+                    "description": "Clear leases that are not in the active state",
                 },
             },
             "version_notes": {

--- a/backend/vyos_mappers/dhcp/dhcp.py
+++ b/backend/vyos_mappers/dhcp/dhcp.py
@@ -801,3 +801,7 @@ class DHCPMapper(BaseFeatureMapper):
     def has_subnet_id(self) -> bool:
         """Check if this version supports subnet-id."""
         return self.version_mapper.has_subnet_id()
+
+    def can_clear_inactive_leases(self) -> bool:
+        """Whether operational lease clear works for non-active states."""
+        return self.version_mapper.can_clear_inactive_leases()

--- a/backend/vyos_mappers/dhcp/dhcp_versions/v1_4.py
+++ b/backend/vyos_mappers/dhcp/dhcp_versions/v1_4.py
@@ -91,3 +91,7 @@ class DHCPMapperV1_4:
     def has_subnet_id(self) -> bool:
         """Returns False - subnet-id does not exist in VyOS 1.4."""
         return False
+
+    def can_clear_inactive_leases(self) -> bool:
+        """1.4 GraphQL ClearReleaseLeaseDhcp only releases active leases."""
+        return False

--- a/backend/vyos_mappers/dhcp/dhcp_versions/v1_5.py
+++ b/backend/vyos_mappers/dhcp/dhcp_versions/v1_5.py
@@ -356,3 +356,7 @@ class DHCPMapperV1_5:
     def has_subnet_id(self) -> bool:
         """Returns True - subnet-id is required in VyOS 1.5."""
         return True
+
+    def can_clear_inactive_leases(self) -> bool:
+        """1.5 GraphQL ClearDhcpServerLeaseDhcp clears any lease state."""
+        return True

--- a/frontend/src/app/network/dhcp/page.tsx
+++ b/frontend/src/app/network/dhcp/page.tsx
@@ -1234,8 +1234,7 @@ function DHCPPageInner() {
                                           Add Static
                                         </Button>
                                       )}
-                                      {/* VyOS 1.4 can only release active leases; 1.5 can clear any state */}
-                                      {(!capabilities?.version?.includes("1.4") || lease.state === "active") && (
+                                      {(lease.state === "active" || capabilities?.fields.clear_inactive_lease?.supported) && (
                                         <Button
                                           variant="ghost"
                                           size="icon"

--- a/frontend/src/lib/api/dhcp.ts
+++ b/frontend/src/lib/api/dhcp.ts
@@ -134,6 +134,8 @@ export interface DHCPCapabilitiesResponse {
     // Options
     ping_check: DHCPFieldCapability;
     enable_failover: DHCPFieldCapability;
+    // Operational lease clear
+    clear_inactive_lease: DHCPFieldCapability;
     // Disable / description
     description: DHCPFieldCapability;
     global_disable: DHCPFieldCapability;


### PR DESCRIPTION
dhcp/page.tsx shows Release only when capabilities.version includes 1.4 or the lease is active. The page should not parse the version string. Put a capability flag next to the other DHCP field flags and gate the button on that.

The version-specific DHCP mappers now own can_clear_inactive_leases (False on 1.4, True on 1.5). get_capabilities() exposes it as fields.clear_inactive_lease. The page shows Release for active leases always, and for other states only when that flag is set.

Tests run from backend with PYTHONPATH=.:
pytest tests/test_dhcp_lease_clear_capability.py -q
4 passed

Frontend: npx tsc --noEmit (clean). npm run lint: no new issues in the changed files (pre-existing errors in HardwareSensorsCard).

Closes #628
