### PR TITLE
refactor: batch builders share add_set plumbing

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -393,45 +393,22 @@ Bridge Interface Batch Builder
 Provides all bridge interface batch operations.
 """
 
-from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BridgeInterfaceBuilderMixin:
+class BridgeInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for bridge interface operations"""
 
     def __init__(self, version: str):
         """Initialize bridge interface batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_bridge"
         self.mappers = {
             self.interface_mapper_key: CommandMapperRegistry.get_mapper(
                 self.interface_mapper_key, version
             )
         }
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "BridgeInterfaceBuilderMixin":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BridgeInterfaceBuilderMixin":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Bridge Interface Operations

--- a/backend/tests/test_batch_builder.py
+++ b/backend/tests/test_batch_builder.py
@@ -1,0 +1,60 @@
+"""Shared BatchBuilder owns set/delete op list plumbing."""
+
+import ast
+from pathlib import Path
+
+from vyos_builders.base import BatchBuilder
+from vyos_builders.rip.rip_batch_builder import RipBatchBuilder
+
+CORE = frozenset({"add_set", "add_delete", "get_operations", "is_empty"})
+BUILDERS_ROOT = Path(__file__).resolve().parents[1] / "vyos_builders"
+
+
+def test_empty_path_is_not_recorded():
+    builder = BatchBuilder("1.5")
+    builder.add_set([]).add_delete([])
+    assert builder.is_empty()
+    assert builder.get_operations() == []
+
+
+def test_add_set_and_delete_copy_ops():
+    builder = BatchBuilder("1.4")
+    path = ["protocols", "ospf"]
+    assert builder.add_set(path) is builder
+    builder.add_delete(path)
+    ops = builder.get_operations()
+    assert ops == [
+        {"op": "set", "path": path},
+        {"op": "delete", "path": path},
+    ]
+    ops.append({"op": "set", "path": ["tamper"]})
+    assert builder.get_operations() == [
+        {"op": "set", "path": path},
+        {"op": "delete", "path": path},
+    ]
+
+
+def test_feature_builder_inherits_plumbing():
+    builder = RipBatchBuilder("1.5")
+    assert isinstance(builder, BatchBuilder)
+    assert builder.is_empty()
+    builder.set_network("10.0.0.0/8")
+    ops = builder.get_operations()
+    assert len(ops) == 1
+    assert ops[0]["op"] == "set"
+    assert "10.0.0.0/8" in ops[0]["path"]
+
+
+def test_feature_builders_do_not_redefine_ops_plumbing():
+    offenders = []
+    for path in BUILDERS_ROOT.rglob("*.py"):
+        if path.name == "base.py":
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name in CORE:
+                    offenders.append(f"{path.relative_to(BUILDERS_ROOT)}:{node.name}.{item.name}")
+    assert offenders == []

--- a/backend/vyos_builders/access_list/access_list.py
+++ b/backend/vyos_builders/access_list/access_list.py
@@ -5,17 +5,17 @@ Provides all batch operations for access-list configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class AccessListBatchBuilder:
+class AccessListBatchBuilder(BatchBuilder):
     """Complete batch builder for access-list operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "access_list"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class AccessListBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "AccessListBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "AccessListBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # IPv4 Access List Operations

--- a/backend/vyos_builders/as_path_list/as_path_list.py
+++ b/backend/vyos_builders/as_path_list/as_path_list.py
@@ -5,17 +5,17 @@ Provides all batch operations for AS path list configuration.
 Commands are identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class AsPathListBatchBuilder:
+class AsPathListBatchBuilder(BatchBuilder):
     """Complete batch builder for AS path list operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "as_path_list"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class AsPathListBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "AsPathListBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "AsPathListBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # AS Path List Operations

--- a/backend/vyos_builders/babel/babel_batch_builder.py
+++ b/backend/vyos_builders/babel/babel_batch_builder.py
@@ -5,38 +5,18 @@ Provides all batch operations for Babel routing protocol configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BabelBatchBuilder:
+class BabelBatchBuilder(BatchBuilder):
     """Complete batch builder for Babel protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "babel"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "BabelBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BabelBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Interface Operations

--- a/backend/vyos_builders/base.py
+++ b/backend/vyos_builders/base.py
@@ -1,0 +1,27 @@
+"""Shared set/delete operation list for feature batch builders."""
+
+from typing import Any, Dict, List, Self
+
+
+class BatchBuilder:
+    """Accumulate VyOS set/delete ops. Subclasses own mapper construction."""
+
+    def __init__(self, version: str) -> None:
+        self.version = version
+        self._operations: List[Dict[str, Any]] = []
+
+    def add_set(self, path: List[str]) -> Self:
+        if path:
+            self._operations.append({"op": "set", "path": path})
+        return self
+
+    def add_delete(self, path: List[str]) -> Self:
+        if path:
+            self._operations.append({"op": "delete", "path": path})
+        return self
+
+    def get_operations(self) -> List[Dict[str, Any]]:
+        return self._operations.copy()
+
+    def is_empty(self) -> bool:
+        return len(self._operations) == 0

--- a/backend/vyos_builders/bfd/bfd_batch_builder.py
+++ b/backend/vyos_builders/bfd/bfd_batch_builder.py
@@ -5,38 +5,18 @@ Provides all batch operations for BFD (Bidirectional Forwarding Detection) confi
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BfdBatchBuilder:
+class BfdBatchBuilder(BatchBuilder):
     """Complete batch builder for BFD protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "bfd"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "BfdBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BfdBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Peer Operations

--- a/backend/vyos_builders/bgp/bgp_batch_builder.py
+++ b/backend/vyos_builders/bgp/bgp_batch_builder.py
@@ -8,38 +8,18 @@ listen ranges, BMP, SID, SRv6, and interface MPLS settings.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BgpBatchBuilder:
+class BgpBatchBuilder(BatchBuilder):
     """Complete batch builder for BGP protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "bgp"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "BgpBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BgpBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/broadcast_relay/broadcast_relay_batch_builder.py
+++ b/backend/vyos_builders/broadcast_relay/broadcast_relay_batch_builder.py
@@ -20,35 +20,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BroadcastRelayBatchBuilder:
+class BroadcastRelayBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("broadcast_relay", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "BroadcastRelayBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BroadcastRelayBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/community_list/community_list.py
+++ b/backend/vyos_builders/community_list/community_list.py
@@ -5,50 +5,30 @@ Provides batch operations for community-list configuration.
 Commands are identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers.community_list import CommunityListMapper
+from vyos_builders.base import BatchBuilder
 
 
-class CommunityListBatchBuilder:
+class CommunityListBatchBuilder(BatchBuilder):
     """Complete batch builder for community-list operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper = CommunityListMapper(version)
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "CommunityListBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "CommunityListBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Community List Operations

--- a/backend/vyos_builders/config_sync/config_sync_batch_builder.py
+++ b/backend/vyos_builders/config_sync/config_sync_batch_builder.py
@@ -35,35 +35,15 @@ Structure:
 The template structure is identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class ConfigSyncBatchBuilder:
+class ConfigSyncBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("config_sync", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "ConfigSyncBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "ConfigSyncBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/conntrack_sync/conntrack_sync_batch_builder.py
+++ b/backend/vyos_builders/conntrack_sync/conntrack_sync_batch_builder.py
@@ -29,35 +29,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class ConntrackSyncBatchBuilder:
+class ConntrackSyncBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("conntrack_sync", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "ConntrackSyncBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "ConntrackSyncBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/console_server/console_server_batch_builder.py
+++ b/backend/vyos_builders/console_server/console_server_batch_builder.py
@@ -22,35 +22,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class ConsoleServerBatchBuilder:
+class ConsoleServerBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("console_server", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "ConsoleServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "ConsoleServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/container/container_batch_builder.py
+++ b/backend/vyos_builders/container/container_batch_builder.py
@@ -12,35 +12,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class ContainerBatchBuilder:
+class ContainerBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("container", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "ContainerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "ContainerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/dhcp/dhcp.py
+++ b/backend/vyos_builders/dhcp/dhcp.py
@@ -5,17 +5,17 @@ Provides all DHCP batch operations following the standard pattern.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DHCPBatchBuilder:
+class DHCPBatchBuilder(BatchBuilder):
     """Complete batch builder for DHCP server operations"""
 
     def __init__(self, version: str):
         """Initialize DHCP batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "dhcp"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class DHCPBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "DHCPBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty (for version-specific commands)
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DHCPBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:  # Only add if path is not empty (for version-specific commands)
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Global DHCP Server Operations

--- a/backend/vyos_builders/dhcp_relay/dhcp_relay_batch_builder.py
+++ b/backend/vyos_builders/dhcp_relay/dhcp_relay_batch_builder.py
@@ -22,35 +22,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DHCPRelayBatchBuilder:
+class DHCPRelayBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("dhcp_relay", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "DHCPRelayBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DHCPRelayBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/dhcpv6_relay/dhcpv6_relay_batch_builder.py
+++ b/backend/vyos_builders/dhcpv6_relay/dhcpv6_relay_batch_builder.py
@@ -20,35 +20,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DHCPv6RelayBatchBuilder:
+class DHCPv6RelayBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("dhcpv6_relay", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "DHCPv6RelayBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DHCPv6RelayBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/dhcpv6_server/dhcpv6_server_batch_builder.py
+++ b/backend/vyos_builders/dhcpv6_server/dhcpv6_server_batch_builder.py
@@ -9,35 +9,15 @@ Version differences handled transparently via the mapper:
   - 1.5: option/, range/<name>/..., pd/prefix/<p>/..., 'duid' + 'mac' fields,
           listen-interface, disable-route-autoinstall, subnet-id
 """
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DHCPv6ServerBatchBuilder:
+class DHCPv6ServerBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("dhcpv6_server", version)
-
-    # -------------------------------------------------------------------------
-    # Core helpers
-    # -------------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "DHCPv6ServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DHCPv6ServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -------------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/dns_dynamic/dns_dynamic_batch_builder.py
+++ b/backend/vyos_builders/dns_dynamic/dns_dynamic_batch_builder.py
@@ -30,35 +30,15 @@ Structure:
 The template structure is identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DNSDynamicBatchBuilder:
+class DNSDynamicBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("dns_dynamic", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "DNSDynamicBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DNSDynamicBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
+++ b/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
@@ -16,35 +16,15 @@ Version differences:
   - zone-cache and options (ECS) subtrees are only available on VyOS 1.5
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DNSForwardingBatchBuilder:
+class DNSForwardingBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("dns_forwarding", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "DNSForwardingBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DNSForwardingBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/event_handler/event_handler_batch_builder.py
+++ b/backend/vyos_builders/event_handler/event_handler_batch_builder.py
@@ -12,35 +12,15 @@ Version differences:
   - Schema is identical on VyOS 1.4 and 1.5
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class EventHandlerBatchBuilder:
+class EventHandlerBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("event_handler", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "EventHandlerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "EventHandlerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/extcommunity_list/extcommunity_list.py
+++ b/backend/vyos_builders/extcommunity_list/extcommunity_list.py
@@ -5,50 +5,30 @@ Provides batch operations for extcommunity-list configuration.
 Commands are identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers.extcommunity_list import ExtCommunityListMapper
+from vyos_builders.base import BatchBuilder
 
 
-class ExtCommunityListBatchBuilder:
+class ExtCommunityListBatchBuilder(BatchBuilder):
     """Complete batch builder for extcommunity-list operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper = ExtCommunityListMapper(version)
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "ExtCommunityListBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "ExtCommunityListBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # ExtCommunity List Operations

--- a/backend/vyos_builders/failover/failover_batch_builder.py
+++ b/backend/vyos_builders/failover/failover_batch_builder.py
@@ -5,38 +5,18 @@ Provides all batch operations for failover route configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class FailoverBatchBuilder:
+class FailoverBatchBuilder(BatchBuilder):
     """Complete batch builder for failover routing operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "failover"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "FailoverBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FailoverBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Route Operations

--- a/backend/vyos_builders/firewall/bridge.py
+++ b/backend/vyos_builders/firewall/bridge.py
@@ -5,17 +5,17 @@ Provides batch operations for bridge (layer 2) firewall configuration.
 Version-aware for VyOS 1.4 and 1.5 differences.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BridgeFirewallBatchBuilder:
+class BridgeFirewallBatchBuilder(BatchBuilder):
     """Batch builder for bridge firewall operations"""
 
     def __init__(self, version: str):
         """Initialize bridge firewall batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "firewall_bridge"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,31 +24,13 @@ class BridgeFirewallBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "BridgeFirewallBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BridgeFirewallBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Chain Operations

--- a/backend/vyos_builders/firewall/flowtables.py
+++ b/backend/vyos_builders/firewall/flowtables.py
@@ -4,17 +4,17 @@ Flowtables Batch Builder
 Provides batch operations for firewall flowtables.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class FlowtablesBatchBuilder:
+class FlowtablesBatchBuilder(BatchBuilder):
     """Batch builder for flowtable operations."""
 
     def __init__(self, version: str):
         """Initialize flowtables batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "firewall_flowtables"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -22,31 +22,13 @@ class FlowtablesBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "FlowtablesBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FlowtablesBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Flowtable Operations

--- a/backend/vyos_builders/firewall/groups.py
+++ b/backend/vyos_builders/firewall/groups.py
@@ -4,8 +4,9 @@ Firewall Groups Batch Builder
 Provides all firewall group batch operations following the standard pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
 def _version_to_float(version: str) -> float:
@@ -22,13 +23,12 @@ def _version_to_float(version: str) -> float:
         return 0.0
 
 
-class FirewallGroupsBatchBuilder:
+class FirewallGroupsBatchBuilder(BatchBuilder):
     """Complete batch builder for firewall group operations"""
 
     def __init__(self, version: str):
         """Initialize firewall groups batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "firewall_groups"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -37,31 +37,13 @@ class FirewallGroupsBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "FirewallGroupsBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FirewallGroupsBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Address Group Operations (IPv4)

--- a/backend/vyos_builders/firewall/ipv4.py
+++ b/backend/vyos_builders/firewall/ipv4.py
@@ -5,17 +5,17 @@ Provides all batch operations for IPv4 firewall rules.
 Handles both base chains (forward, input, output) and custom named chains.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class FirewallIPv4BatchBuilder:
+class FirewallIPv4BatchBuilder(BatchBuilder):
     """Complete batch builder for IPv4 firewall operations"""
 
     def __init__(self, version: str):
         """Initialize firewall IPv4 batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "firewall_ipv4"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class FirewallIPv4BatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "FirewallIPv4BatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FirewallIPv4BatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Base Chain Rule Operations

--- a/backend/vyos_builders/firewall/ipv6.py
+++ b/backend/vyos_builders/firewall/ipv6.py
@@ -5,17 +5,17 @@ Provides all batch operations for IPv6 firewall rules.
 Handles both base chains (forward, input, output) and custom named chains.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class FirewallIPv6BatchBuilder:
+class FirewallIPv6BatchBuilder(BatchBuilder):
     """Complete batch builder for IPv6 firewall operations"""
 
     def __init__(self, version: str):
         """Initialize firewall IPv6 batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "firewall_ipv6"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class FirewallIPv6BatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "FirewallIPv6BatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FirewallIPv6BatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Base Chain Rule Operations

--- a/backend/vyos_builders/firewall/zones.py
+++ b/backend/vyos_builders/firewall/zones.py
@@ -8,17 +8,17 @@ Handles version differences transparently:
 - VyOS 1.5: interfaces under `member interface/vrf`, plus `default-firewall`
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class FirewallZonesBatchBuilder:
+class FirewallZonesBatchBuilder(BatchBuilder):
     """Complete batch builder for firewall zone operations."""
 
     def __init__(self, version: str):
         """Initialize firewall zones batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "firewall_zones"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -26,31 +26,13 @@ class FirewallZonesBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "FirewallZonesBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FirewallZonesBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Zone Create / Delete

--- a/backend/vyos_builders/firewall_global_options/firewall_global_options.py
+++ b/backend/vyos_builders/firewall_global_options/firewall_global_options.py
@@ -5,17 +5,17 @@ Provides all firewall global-options batch operations following the standard pat
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class FirewallGlobalOptionsBatchBuilder:
+class FirewallGlobalOptionsBatchBuilder(BatchBuilder):
     """Complete batch builder for firewall global-options operations"""
 
     def __init__(self, version: str):
         """Initialize firewall global-options batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "firewall_global_options"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class FirewallGlobalOptionsBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "FirewallGlobalOptionsBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "FirewallGlobalOptionsBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Basic Options

--- a/backend/vyos_builders/high_availability/high_availability.py
+++ b/backend/vyos_builders/high_availability/high_availability.py
@@ -1,8 +1,9 @@
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class HighAvailabilityBatchBuilder:
+class HighAvailabilityBatchBuilder(BatchBuilder):
     """
     Batch builder for high-availability configuration.
 
@@ -18,26 +19,9 @@ class HighAvailabilityBatchBuilder:
     """
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "high_availability"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    def add_set(self, path: List[str]) -> "HighAvailabilityBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "HighAvailabilityBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # =========================================================================
     # HA Global

--- a/backend/vyos_builders/https/https_batch_builder.py
+++ b/backend/vyos_builders/https/https_batch_builder.py
@@ -16,35 +16,15 @@ Version differences:
   - 1.5: api/rest/debug, api/rest/strict, api/graphql/cors/allow-origin
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class HTTPSBatchBuilder:
+class HTTPSBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("https", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "HTTPSBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "HTTPSBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/igmp_proxy/igmp_proxy_batch_builder.py
+++ b/backend/vyos_builders/igmp_proxy/igmp_proxy_batch_builder.py
@@ -5,38 +5,18 @@ Provides all batch operations for IGMP proxy configuration.
 No version differences between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class IgmpProxyBatchBuilder:
+class IgmpProxyBatchBuilder(BatchBuilder):
     """Complete batch builder for IGMP proxy operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "igmp_proxy"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "IgmpProxyBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "IgmpProxyBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Global Operations

--- a/backend/vyos_builders/interfaces/bonding.py
+++ b/backend/vyos_builders/interfaces/bonding.py
@@ -6,9 +6,10 @@ Provides all bonding interface batch operations.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BondingInterfaceBuilderMixin:
+class BondingInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for bonding interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -17,22 +18,13 @@ class BondingInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_bonding"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "BondingInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BondingInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "BondingInterfaceBuilderMixin":
         for path in paths:
@@ -42,14 +34,8 @@ class BondingInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Basic Interface Operations

--- a/backend/vyos_builders/interfaces/bridge.py
+++ b/backend/vyos_builders/interfaces/bridge.py
@@ -6,9 +6,10 @@ Provides all bridge interface batch operations.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class BridgeInterfaceBuilderMixin:
+class BridgeInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for bridge interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -17,22 +18,13 @@ class BridgeInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_bridge"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "BridgeInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "BridgeInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "BridgeInterfaceBuilderMixin":
         for path in paths:
@@ -42,14 +34,8 @@ class BridgeInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Basic Interface Operations

--- a/backend/vyos_builders/interfaces/dummy.py
+++ b/backend/vyos_builders/interfaces/dummy.py
@@ -7,9 +7,10 @@ Dummy interfaces do not support physical properties like speed/duplex.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class DummyInterfaceBuilderMixin:
+class DummyInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for dummy interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -18,22 +19,13 @@ class DummyInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_dummy"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "DummyInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "DummyInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "DummyInterfaceBuilderMixin":
         for path in paths:
@@ -43,14 +35,8 @@ class DummyInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/ethernet.py
+++ b/backend/vyos_builders/interfaces/ethernet.py
@@ -4,17 +4,17 @@ Ethernet Interface Batch Builder
 Provides all ethernet interface batch operations.
 """
 
-from typing import List, Dict, Any
+from typing import List
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class EthernetInterfaceBuilderMixin:
+class EthernetInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for ethernet interface operations"""
 
     def __init__(self, version: str):
         """Initialize ethernet interface batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.interface_mapper_key = "interface_ethernet"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
@@ -22,16 +22,6 @@ class EthernetInterfaceBuilderMixin:
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "EthernetInterfaceBuilderMixin":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "EthernetInterfaceBuilderMixin":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "EthernetInterfaceBuilderMixin":
         """Add multiple 'set' operations to the batch."""
@@ -43,17 +33,9 @@ class EthernetInterfaceBuilderMixin:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Common Interface Operations

--- a/backend/vyos_builders/interfaces/geneve.py
+++ b/backend/vyos_builders/interfaces/geneve.py
@@ -6,9 +6,10 @@ Provides all GENEVE (Generic Network Virtualization Encapsulation) interface bat
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class GeneveInterfaceBuilderMixin:
+class GeneveInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for geneve interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -17,22 +18,13 @@ class GeneveInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_geneve"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "GeneveInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "GeneveInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "GeneveInterfaceBuilderMixin":
         for path in paths:
@@ -42,14 +34,8 @@ class GeneveInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/input.py
+++ b/backend/vyos_builders/interfaces/input.py
@@ -7,9 +7,10 @@ Input interfaces support description, disable, and redirect.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class InputInterfaceBuilderMixin:
+class InputInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for input (IFB) interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -18,22 +19,13 @@ class InputInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_input"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "InputInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "InputInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "InputInterfaceBuilderMixin":
         for path in paths:
@@ -43,14 +35,8 @@ class InputInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/l2tpv3.py
+++ b/backend/vyos_builders/interfaces/l2tpv3.py
@@ -6,9 +6,10 @@ Provides all L2TPv3 interface batch operations.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class L2TPv3InterfaceBuilderMixin:
+class L2TPv3InterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for L2TPv3 interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -17,22 +18,13 @@ class L2TPv3InterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_l2tpv3"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "L2TPv3InterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "L2TPv3InterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "L2TPv3InterfaceBuilderMixin":
         for path in paths:
@@ -42,14 +34,8 @@ class L2TPv3InterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/loopback.py
+++ b/backend/vyos_builders/interfaces/loopback.py
@@ -7,9 +7,10 @@ Loopback supports: address, description, ip source-validation, mirror, redirect.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class LoopbackInterfaceBuilderMixin:
+class LoopbackInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for loopback interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -18,22 +19,13 @@ class LoopbackInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_loopback"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "LoopbackInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "LoopbackInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "LoopbackInterfaceBuilderMixin":
         for path in paths:
@@ -43,14 +35,8 @@ class LoopbackInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/macsec.py
+++ b/backend/vyos_builders/interfaces/macsec.py
@@ -9,9 +9,10 @@ dhcp-options, dhcpv6-options, mirror, redirect.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class MacsecInterfaceBuilderMixin:
+class MacsecInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for MACsec interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -20,22 +21,13 @@ class MacsecInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_macsec"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "MacsecInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "MacsecInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "MacsecInterfaceBuilderMixin":
         for path in paths:
@@ -45,14 +37,8 @@ class MacsecInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/openvpn.py
+++ b/backend/vyos_builders/interfaces/openvpn.py
@@ -12,9 +12,10 @@ Version-aware where the underlying command tree differs (1.4 uses
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class OpenvpnInterfaceBuilderMixin:
+class OpenvpnInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for OpenVPN interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -23,22 +24,13 @@ class OpenvpnInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_openvpn"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "OpenvpnInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "OpenvpnInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "OpenvpnInterfaceBuilderMixin":
         for path in paths:
@@ -48,14 +40,8 @@ class OpenvpnInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.interface_mapper_key]

--- a/backend/vyos_builders/interfaces/pppoe.py
+++ b/backend/vyos_builders/interfaces/pppoe.py
@@ -12,9 +12,10 @@ and `ipv6 address interface-identifier`).
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class PppoeInterfaceBuilderMixin:
+class PppoeInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for PPPoE interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -23,22 +24,13 @@ class PppoeInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_pppoe"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "PppoeInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "PppoeInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "PppoeInterfaceBuilderMixin":
         for path in paths:
@@ -48,14 +40,8 @@ class PppoeInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.interface_mapper_key]

--- a/backend/vyos_builders/interfaces/pseudo_ethernet.py
+++ b/backend/vyos_builders/interfaces/pseudo_ethernet.py
@@ -9,11 +9,12 @@ Version-aware: 1.5 adds `dhcpv6-options no-request-dns/no-request-domain-name`
 and `ipv6 address interface-identifier` at all sub-levels.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class PseudoEthernetInterfaceBuilderMixin:
+class PseudoEthernetInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for pseudo-ethernet interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -22,8 +23,7 @@ class PseudoEthernetInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_pseudo_ethernet"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
@@ -31,25 +31,11 @@ class PseudoEthernetInterfaceBuilderMixin:
     # Core batch helpers
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "PseudoEthernetInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "PseudoEthernetInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.interface_mapper_key]

--- a/backend/vyos_builders/interfaces/sstpc.py
+++ b/backend/vyos_builders/interfaces/sstpc.py
@@ -10,9 +10,10 @@ No version differences exist between VyOS 1.4 and 1.5 for SSTPC.
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SstpcInterfaceBuilderMixin:
+class SstpcInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for SSTPC interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -21,22 +22,13 @@ class SstpcInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_sstpc"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "SstpcInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SstpcInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "SstpcInterfaceBuilderMixin":
         for path in paths:
@@ -46,14 +38,8 @@ class SstpcInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.interface_mapper_key]

--- a/backend/vyos_builders/interfaces/virtual_ethernet.py
+++ b/backend/vyos_builders/interfaces/virtual_ethernet.py
@@ -11,11 +11,12 @@ Version-aware:
 - 1.5 adds `ipv6 address interface-identifier` at all sub-levels
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class VirtualEthernetInterfaceBuilderMixin:
+class VirtualEthernetInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for virtual-ethernet interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -24,8 +25,7 @@ class VirtualEthernetInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_virtual_ethernet"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
@@ -33,25 +33,11 @@ class VirtualEthernetInterfaceBuilderMixin:
     # Core batch helpers
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "VirtualEthernetInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "VirtualEthernetInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.interface_mapper_key]

--- a/backend/vyos_builders/interfaces/vpp.py
+++ b/backend/vyos_builders/interfaces/vpp.py
@@ -6,11 +6,12 @@ VPP is a VyOS 1.5+ only feature supporting:
   bonding, bridge, gre, ipip, loopback, vxlan, xconnect
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class VppInterfaceBuilderMixin:
+class VppInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for all VPP interface types."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -19,8 +20,7 @@ class VppInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "interface_vpp"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -28,25 +28,11 @@ class VppInterfaceBuilderMixin:
     # Core batch helpers
     # =========================================================================
 
-    def add_set(self, path: List[str]) -> "VppInterfaceBuilderMixin":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "VppInterfaceBuilderMixin":
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.mapper_key]

--- a/backend/vyos_builders/interfaces/vti.py
+++ b/backend/vyos_builders/interfaces/vti.py
@@ -6,11 +6,12 @@ VTI interfaces are XFRM-based tunnel interfaces typically used with IPsec.
 Supported on both VyOS 1.4 and 1.5 with identical feature sets.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class VtiInterfaceBuilderMixin:
+class VtiInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for VTI interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -19,8 +20,7 @@ class VtiInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.interface_mapper_key = "interface_vti"
         self.mappers = {self.interface_mapper_key: CommandMapperRegistry.get_mapper(self.interface_mapper_key, version)}
 
@@ -28,27 +28,11 @@ class VtiInterfaceBuilderMixin:
     # Core batch helpers
     # =========================================================================
 
-    def add_set(self, path: List[str]) -> "VtiInterfaceBuilderMixin":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "VtiInterfaceBuilderMixin":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def _mapper(self):
         return self.mappers[self.interface_mapper_key]

--- a/backend/vyos_builders/interfaces/wireless.py
+++ b/backend/vyos_builders/interfaces/wireless.py
@@ -12,9 +12,10 @@ Provides all wireless interface batch operations covering:
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class WirelessInterfaceBuilderMixin:
+class WirelessInterfaceBuilderMixin(BatchBuilder):
     """Complete batch builder for wireless interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -23,24 +24,13 @@ class WirelessInterfaceBuilderMixin:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "interface_wireless"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "WirelessInterfaceBuilderMixin":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "WirelessInterfaceBuilderMixin":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "WirelessInterfaceBuilderMixin":
         for path in paths:
@@ -50,14 +40,8 @@ class WirelessInterfaceBuilderMixin:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/interfaces/wwan.py
+++ b/backend/vyos_builders/interfaces/wwan.py
@@ -12,9 +12,10 @@ Provides all WWAN interface batch operations covering:
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class WwanInterfaceBatchBuilder:
+class WwanInterfaceBatchBuilder(BatchBuilder):
     """Complete batch builder for WWAN interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -23,24 +24,13 @@ class WwanInterfaceBatchBuilder:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "interface_wwan"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
-
-    def add_set(self, path: List[str]) -> "WwanInterfaceBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "WwanInterfaceBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
 
     def add_multiple_sets(self, paths: List[List[str]]) -> "WwanInterfaceBatchBuilder":
         for path in paths:
@@ -50,14 +40,8 @@ class WwanInterfaceBatchBuilder:
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Capabilities

--- a/backend/vyos_builders/ipoe_server/ipoe_server_batch_builder.py
+++ b/backend/vyos_builders/ipoe_server/ipoe_server_batch_builder.py
@@ -1,15 +1,15 @@
 """IPoE Server Batch Builder."""
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class IPoEServerBatchBuilder:
+class IPoEServerBatchBuilder(BatchBuilder):
     """Batch builder for all IPoE server configuration operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "ipoe_server"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -17,27 +17,11 @@ class IPoEServerBatchBuilder:
     # Core infrastructure
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "IPoEServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "IPoEServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def get_capabilities(self) -> Dict[str, Any]:
         is_1_4 = "1.4" in self.version

--- a/backend/vyos_builders/ipsec/ipsec.py
+++ b/backend/vyos_builders/ipsec/ipsec.py
@@ -5,16 +5,16 @@ Provides all batch operations for IPSec VPN configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class IPSecBatchBuilder:
+class IPSecBatchBuilder(BatchBuilder):
     """Complete batch builder for IPSec VPN operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "ipsec"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -22,27 +22,11 @@ class IPSecBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "IPSecBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "IPSecBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Global Settings

--- a/backend/vyos_builders/isis/isis_batch_builder.py
+++ b/backend/vyos_builders/isis/isis_batch_builder.py
@@ -8,35 +8,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the Babel/OSPF batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class IsisBatchBuilder:
+class IsisBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("isis", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "IsisBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "IsisBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/l2tp/l2tp.py
+++ b/backend/vyos_builders/l2tp/l2tp.py
@@ -5,16 +5,16 @@ Provides all batch operations for L2TP remote-access VPN configuration.
 The L2TP command tree is identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class L2TPBatchBuilder:
+class L2TPBatchBuilder(BatchBuilder):
     """Complete batch builder for L2TP VPN operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "l2tp"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -22,27 +22,11 @@ class L2TPBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "L2TPBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "L2TPBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # General Settings

--- a/backend/vyos_builders/large_community_list/large_community_list.py
+++ b/backend/vyos_builders/large_community_list/large_community_list.py
@@ -5,50 +5,30 @@ Provides batch operations for large-community-list configuration.
 Commands are identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers.large_community_list import LargeCommunityListMapper
+from vyos_builders.base import BatchBuilder
 
 
-class LargeCommunityListBatchBuilder:
+class LargeCommunityListBatchBuilder(BatchBuilder):
     """Complete batch builder for large-community-list operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper = LargeCommunityListMapper(version)
 
     # ========================================================================
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "LargeCommunityListBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "LargeCommunityListBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # LargeCommunity List Operations

--- a/backend/vyos_builders/lldp/lldp_batch_builder.py
+++ b/backend/vyos_builders/lldp/lldp_batch_builder.py
@@ -30,35 +30,15 @@ Version differences:
   1.5 — per-interface mode supports: disable, rx-tx (default), rx, tx
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class LLDPBatchBuilder:
+class LLDPBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("lldp", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "LLDPBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "LLDPBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/load_balancing/load_balancing.py
+++ b/backend/vyos_builders/load_balancing/load_balancing.py
@@ -1,8 +1,9 @@
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class LoadBalancingBatchBuilder:
+class LoadBalancingBatchBuilder(BatchBuilder):
     """
     Batch builder for load-balancing configuration.
 
@@ -21,29 +22,12 @@ class LoadBalancingBatchBuilder:
     """
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "load_balancing"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
     def _m(self):
         return self.mappers[self.mapper_key]
-
-    def add_set(self, path: List[str]) -> "LoadBalancingBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "LoadBalancingBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # =========================================================================
     # Reverse Proxy — Global Parameters  (item_name ignored)

--- a/backend/vyos_builders/local_route/local_route.py
+++ b/backend/vyos_builders/local_route/local_route.py
@@ -5,17 +5,17 @@ Provides all batch operations for VyOS local route policy configuration.
 Handles both IPv4 (local-route) and IPv6 (local-route6) rules.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class LocalRouteBatchBuilder:
+class LocalRouteBatchBuilder(BatchBuilder):
     """Complete batch builder for local route policy operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "local_route"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class LocalRouteBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "LocalRouteBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "LocalRouteBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # IPv4 Local Route - Rule Operations

--- a/backend/vyos_builders/mpls/mpls_batch_builder.py
+++ b/backend/vyos_builders/mpls/mpls_batch_builder.py
@@ -11,35 +11,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class MplsBatchBuilder:
+class MplsBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("mpls", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "MplsBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "MplsBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/nat/nat.py
+++ b/backend/vyos_builders/nat/nat.py
@@ -4,17 +4,17 @@ NAT Batch Builder
 Provides all NAT batch operations following the standard pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class NATBatchBuilder:
+class NATBatchBuilder(BatchBuilder):
     """Complete batch builder for NAT operations"""
 
     def __init__(self, version: str):
         """Initialize NAT batch builder."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "nat"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -23,31 +23,13 @@ class NATBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "NATBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "NATBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Source NAT Rule Operations

--- a/backend/vyos_builders/nat64/nat64.py
+++ b/backend/vyos_builders/nat64/nat64.py
@@ -1,9 +1,10 @@
 """NAT64 batch builder for generating VyOS nat64 commands."""
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class NAT64BatchBuilder:
+class NAT64BatchBuilder(BatchBuilder):
     """Builder for NAT64 batch operations.
 
     Generates VyOS set/delete commands for nat64 source rules
@@ -11,26 +12,9 @@ class NAT64BatchBuilder:
     """
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "nat64"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    def add_set(self, path: List[str]) -> "NAT64BatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "NAT64BatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ==================== Rule operations ====================
 

--- a/backend/vyos_builders/nat66/nat66.py
+++ b/backend/vyos_builders/nat66/nat66.py
@@ -1,9 +1,10 @@
 """NAT66 batch builder for generating VyOS nat66 commands."""
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class NAT66BatchBuilder:
+class NAT66BatchBuilder(BatchBuilder):
     """Builder for NAT66 batch operations.
 
     Generates VyOS set/delete commands for nat66 source and destination rules.
@@ -13,26 +14,9 @@ class NAT66BatchBuilder:
     """
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "nat66"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    def add_set(self, path: List[str]) -> "NAT66BatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "NAT66BatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ==================== Source Rule operations ====================
 

--- a/backend/vyos_builders/ndp_proxy/ndp_proxy_batch_builder.py
+++ b/backend/vyos_builders/ndp_proxy/ndp_proxy_batch_builder.py
@@ -18,37 +18,17 @@ Config tree:
         interface          (iface name, required for interface mode)
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class NdpProxyBatchBuilder:
+class NdpProxyBatchBuilder(BatchBuilder):
     """Complete batch builder for NDP proxy operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("ndp_proxy", version)
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "NdpProxyBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "NdpProxyBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Global Operations

--- a/backend/vyos_builders/nhrp/nhrp_batch_builder.py
+++ b/backend/vyos_builders/nhrp/nhrp_batch_builder.py
@@ -14,35 +14,15 @@ Multi-argument batch operations encode compound values as "arg1,arg2"
 (comma-separated), matching the project's standard batch dispatch pattern.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class NhrpBatchBuilder:
+class NhrpBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("nhrp", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "NhrpBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "NhrpBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/ntp/ntp_batch_builder.py
+++ b/backend/vyos_builders/ntp/ntp_batch_builder.py
@@ -22,35 +22,15 @@ Version differences:
   1.4 and 1.5 share identical NTP config paths — no version-specific overrides.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class NTPBatchBuilder:
+class NTPBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("ntp", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "NTPBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "NTPBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/openfabric/openfabric_batch_builder.py
+++ b/backend/vyos_builders/openfabric/openfabric_batch_builder.py
@@ -1,32 +1,14 @@
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class OpenfabricBatchBuilder:
+class OpenfabricBatchBuilder(BatchBuilder):
     """Batch builder for OpenFabric protocol configuration."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("openfabric", version)
-
-    # ── Internals ─────────────────────────────────────────────────────────
-
-    def add_set(self, path: List[str]) -> "OpenfabricBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "OpenfabricBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ── Capabilities ──────────────────────────────────────────────────────
 

--- a/backend/vyos_builders/ospf/ospf_batch_builder.py
+++ b/backend/vyos_builders/ospf/ospf_batch_builder.py
@@ -10,38 +10,18 @@ ldp-sync, mpls-te, summary-address, segment-routing, aggregation, capability.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class OspfBatchBuilder:
+class OspfBatchBuilder(BatchBuilder):
     """Complete batch builder for OSPF protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "ospf"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "OspfBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "OspfBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/ospfv3/ospfv3_batch_builder.py
+++ b/backend/vyos_builders/ospfv3/ospfv3_batch_builder.py
@@ -8,38 +8,18 @@ distance, auto-cost, log-adjacency-changes, graceful-restart.
 No version-specific differences between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class Ospfv3BatchBuilder:
+class Ospfv3BatchBuilder(BatchBuilder):
     """Complete batch builder for OSPFv3 protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "ospfv3"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "Ospfv3BatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "Ospfv3BatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/pim/pim_batch_builder.py
+++ b/backend/vyos_builders/pim/pim_batch_builder.py
@@ -5,8 +5,9 @@ Provides all batch operations for PIM (Protocol Independent Multicast) configura
 No version differences between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 _INTERNAL_BUILDER_METHODS = frozenset({
     "add_set", "add_delete", "get_operations", "is_empty",
@@ -14,34 +15,13 @@ _INTERNAL_BUILDER_METHODS = frozenset({
 })
 
 
-class PimBatchBuilder:
+class PimBatchBuilder(BatchBuilder):
     """Complete batch builder for PIM operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "pim"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "PimBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "PimBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/pim6/pim6_batch_builder.py
+++ b/backend/vyos_builders/pim6/pim6_batch_builder.py
@@ -7,38 +7,18 @@ configuration.
 No version differences between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class Pim6BatchBuilder:
+class Pim6BatchBuilder(BatchBuilder):
     """Complete batch builder for PIMv6 operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "pim6"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "Pim6BatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "Pim6BatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/pki/pki.py
+++ b/backend/vyos_builders/pki/pki.py
@@ -11,16 +11,16 @@ Provides all batch operations for PKI configuration including:
 - X509 defaults
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class PKIBatchBuilder:
+class PKIBatchBuilder(BatchBuilder):
     """Complete batch builder for PKI operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "pki"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -28,27 +28,11 @@ class PKIBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "PKIBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "PKIBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Certificate Authority (CA)

--- a/backend/vyos_builders/pppoe_server/pppoe_server_batch_builder.py
+++ b/backend/vyos_builders/pppoe_server/pppoe_server_batch_builder.py
@@ -1,15 +1,15 @@
 """PPPoE Server Batch Builder."""
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class PPPoEServerBatchBuilder:
+class PPPoEServerBatchBuilder(BatchBuilder):
     """Batch builder for all PPPoE server configuration operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "pppoe_server"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
 
@@ -17,27 +17,11 @@ class PPPoEServerBatchBuilder:
     # Core infrastructure
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "PPPoEServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "PPPoEServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def get_capabilities(self) -> Dict[str, Any]:
         is_1_4 = "1.4" in self.version

--- a/backend/vyos_builders/prefix_list/prefix_list.py
+++ b/backend/vyos_builders/prefix_list/prefix_list.py
@@ -5,17 +5,17 @@ Provides all batch operations following the standard pattern.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class PrefixListBatchBuilder:
+class PrefixListBatchBuilder(BatchBuilder):
     """Complete batch builder for prefix-list operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "prefix_list"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class PrefixListBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "PrefixListBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "PrefixListBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # IPv4 Prefix List Operations

--- a/backend/vyos_builders/qos/qos_batch_builder.py
+++ b/backend/vyos_builders/qos/qos_batch_builder.py
@@ -21,6 +21,7 @@ Version differences (surfaced via capabilities):
 
 from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 # ---------------------------------------------------------------------------
 # Shared option lists (sourced from the VyOS templates)
@@ -56,31 +57,10 @@ def _segs(field: str) -> List[str]:
     return [s for s in field.split("/") if s != ""]
 
 
-class QoSBatchBuilder:
+class QoSBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("qos", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "QoSBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "QoSBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/rip/rip_batch_builder.py
+++ b/backend/vyos_builders/rip/rip_batch_builder.py
@@ -5,38 +5,18 @@ Covers: global settings, networks, neighbors, static routes, passive interfaces,
 distribute lists, interface settings, network distance, redistribute, and timers.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class RipBatchBuilder:
+class RipBatchBuilder(BatchBuilder):
     """Complete batch builder for RIP protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "rip"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "RipBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "RipBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/ripng/ripng_batch_builder.py
+++ b/backend/vyos_builders/ripng/ripng_batch_builder.py
@@ -5,38 +5,18 @@ configuration. Covers: global settings, aggregate addresses, networks, static ro
 passive interfaces, distribute lists, interface split-horizon, redistribute, and timers.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class RipNgBatchBuilder:
+class RipNgBatchBuilder(BatchBuilder):
     """Complete batch builder for RIPng protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "ripng"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "RipNgBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "RipNgBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/route/route_batch_builder.py
+++ b/backend/vyos_builders/route/route_batch_builder.py
@@ -5,17 +5,17 @@ Provides all batch operations for policy route and route6 configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class RouteBatchBuilder:
+class RouteBatchBuilder(BatchBuilder):
     """Complete batch builder for route policy operations."""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "route"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class RouteBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "RouteBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "RouteBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Policy Management

--- a/backend/vyos_builders/route_map/route_map_batch_builder.py
+++ b/backend/vyos_builders/route_map/route_map_batch_builder.py
@@ -5,17 +5,17 @@ Provides all batch operations for route-map configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class RouteMapBatchBuilder:
+class RouteMapBatchBuilder(BatchBuilder):
     """Complete batch builder for route-map operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "route_map"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class RouteMapBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "RouteMapBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:  # Only add if path is not empty
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "RouteMapBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Route Map Operations

--- a/backend/vyos_builders/router_advert/router_advert_batch_builder.py
+++ b/backend/vyos_builders/router_advert/router_advert_batch_builder.py
@@ -6,35 +6,15 @@ VyOS 1.5 adds:
   - base-interface per RA prefix (DHCPv6-PD support)
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class RouterAdvertBatchBuilder:
+class RouterAdvertBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("router_advert", version)
-
-    # ========================================================================
-    # Core helpers
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "RouterAdvertBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "RouterAdvertBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Interface lifecycle

--- a/backend/vyos_builders/rpki/rpki_batch_builder.py
+++ b/backend/vyos_builders/rpki/rpki_batch_builder.py
@@ -4,38 +4,18 @@ Provides all batch operations for RPKI (Resource Public Key Infrastructure)
 configuration. Covers: cache server management and global interval settings.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class RpkiBatchBuilder:
+class RpkiBatchBuilder(BatchBuilder):
     """Complete batch builder for RPKI protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "rpki"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "RpkiBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "RpkiBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/salt_minion/salt_minion_batch_builder.py
+++ b/backend/vyos_builders/salt_minion/salt_minion_batch_builder.py
@@ -18,35 +18,15 @@ Version differences:
   1.4 and 1.5 share identical Salt Minion config paths — no version-specific overrides.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SaltMinionBatchBuilder:
+class SaltMinionBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("salt_minion", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "SaltMinionBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SaltMinionBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/segment_routing/segment_routing_batch_builder.py
+++ b/backend/vyos_builders/segment_routing/segment_routing_batch_builder.py
@@ -4,38 +4,18 @@ Provides all batch operations for Segment Routing (SRv6) configuration.
 Covers: SRv6 locator management and per-interface SRv6 HMAC policy.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SegmentRoutingBatchBuilder:
+class SegmentRoutingBatchBuilder(BatchBuilder):
     """Complete batch builder for Segment Routing protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "segment_routing"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "SegmentRoutingBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SegmentRoutingBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/service_monitoring/service_monitoring_batch_builder.py
+++ b/backend/vyos_builders/service_monitoring/service_monitoring_batch_builder.py
@@ -22,35 +22,15 @@ Sub-sections:
   network-event     — kernel netlink event logger (1.5 only)
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class ServiceMonitoringBatchBuilder:
+class ServiceMonitoringBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("service_monitoring", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "ServiceMonitoringBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "ServiceMonitoringBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/sla/sla_batch_builder.py
+++ b/backend/vyos_builders/sla/sla_batch_builder.py
@@ -16,35 +16,15 @@ Version differences:
   1.4 and 1.5 share identical SLA config paths — no version-specific overrides.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SLABatchBuilder:
+class SLABatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("sla", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "SLABatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SLABatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/snmp/snmp_batch_builder.py
+++ b/backend/vyos_builders/snmp/snmp_batch_builder.py
@@ -14,35 +14,15 @@ absorbs any extra commas (router uses maxsplit), so trailing free-text values
 such as passwords are preserved intact.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SNMPBatchBuilder:
+class SNMPBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("snmp", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "SNMPBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SNMPBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/ssh/ssh_batch_builder.py
+++ b/backend/vyos_builders/ssh/ssh_batch_builder.py
@@ -11,8 +11,9 @@ Version differences (reflected in capabilities + mapper):
   - "fido" (pin-required / touch-required) and "trusted-user-ca" are 1.5 only.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 # Algorithm option lists sourced from the VyOS templates.
 _CIPHERS_1_5 = [
@@ -72,31 +73,10 @@ _PUBKEY_ALGORITHMS = [
 _LOGLEVELS = ["quiet", "fatal", "error", "info", "verbose"]
 
 
-class SSHBatchBuilder:
+class SSHBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("ssh", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "SSHBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SSHBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/static_routes/static_routes_batch_builder.py
+++ b/backend/vyos_builders/static_routes/static_routes_batch_builder.py
@@ -5,17 +5,17 @@ Provides all batch operations for static route configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class StaticRoutesBatchBuilder:
+class StaticRoutesBatchBuilder(BatchBuilder):
     """Complete batch builder for static routes operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "static_routes"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class StaticRoutesBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "StaticRoutesBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "StaticRoutesBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # IPv4 Route Operations

--- a/backend/vyos_builders/system/performance.py
+++ b/backend/vyos_builders/system/performance.py
@@ -4,31 +4,16 @@ System Option Performance Batch Builder
 Builds batch operations for set/delete system option performance.
 """
 
-from typing import List, Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SystemPerformanceBatchBuilder:
+class SystemPerformanceBatchBuilder(BatchBuilder):
     """Batch builder for system option performance (single set or delete)."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper = CommandMapperRegistry.get_mapper("system_performance", version)
-
-    def add_set(self, path: List[str]) -> "SystemPerformanceBatchBuilder":
-        self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SystemPerformanceBatchBuilder":
-        self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def set_performance(self, value: str) -> "SystemPerformanceBatchBuilder":
         """Add set system option performance <value>."""

--- a/backend/vyos_builders/system/system_batch_builder.py
+++ b/backend/vyos_builders/system/system_batch_builder.py
@@ -24,37 +24,21 @@ Builds VyOS batch operations for all system configuration subsections:
   - Sysctl parameters
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class SystemBatchBuilder:
+class SystemBatchBuilder(BatchBuilder):
     """Batch builder for system configuration operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper = CommandMapperRegistry.get_mapper("system", version)
 
     # =========================================================================
     # Core helpers
     # =========================================================================
-
-    def add_set(self, path: List[str]) -> "SystemBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "SystemBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     def clear(self) -> "SystemBatchBuilder":
         self._operations.clear()

--- a/backend/vyos_builders/tftp_server/tftp_server_batch_builder.py
+++ b/backend/vyos_builders/tftp_server/tftp_server_batch_builder.py
@@ -9,35 +9,15 @@ Version differences:
   1.4 and 1.5 share identical TFTP server config paths — no version-specific overrides.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class TFTPServerBatchBuilder:
+class TFTPServerBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("tftp_server", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "TFTPServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "TFTPServerBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Capabilities

--- a/backend/vyos_builders/traffic_engineering/traffic_engineering_batch_builder.py
+++ b/backend/vyos_builders/traffic_engineering/traffic_engineering_batch_builder.py
@@ -6,38 +6,18 @@ Covers: admin group management and per-interface TE parameter settings.
 Note: Traffic Engineering is only supported on VyOS 1.5+.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class TrafficEngineeringBatchBuilder:
+class TrafficEngineeringBatchBuilder(BatchBuilder):
     """Complete batch builder for Traffic Engineering protocol operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "traffic_engineering"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "TrafficEngineeringBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "TrafficEngineeringBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     @property
     def m(self):

--- a/backend/vyos_builders/tunnel/tunnel_batch_builder.py
+++ b/backend/vyos_builders/tunnel/tunnel_batch_builder.py
@@ -5,11 +5,12 @@ Provides all batch operations for tunnel interface configuration.
 Tunnel commands are identical between VyOS 1.4 and 1.5.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class TunnelBatchBuilder:
+class TunnelBatchBuilder(BatchBuilder):
     """Complete batch builder for tunnel interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -19,30 +20,9 @@ class TunnelBatchBuilder:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "tunnel"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "TunnelBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "TunnelBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Interface-level Operations

--- a/backend/vyos_builders/vrf/vrf_batch_builder.py
+++ b/backend/vyos_builders/vrf/vrf_batch_builder.py
@@ -8,7 +8,7 @@ Inherits from service mixins and prefixes global protocol builders for
 OSPF, OSPFv3, ISIS, and BGP (vrf name <vrf> + the global protocol tree).
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
 from .vrf_static_mixin import VrfStaticMixin
 from .vrf_rpki_mixin import VrfRpkiMixin
@@ -16,6 +16,7 @@ from .vrf_failover_mixin import VrfFailoverMixin
 from .vrf_dhcp_mixin import VrfDhcpMixin
 from .vrf_dhcpv6_mixin import VrfDhcpv6Mixin
 from .vrf_protocol import parse_vrf_protocol_op, run_vrf_protocol_op, vrf_protocol_op_exists
+from vyos_builders.base import BatchBuilder
 
 
 class VrfBatchBuilder(
@@ -24,12 +25,12 @@ class VrfBatchBuilder(
     VrfFailoverMixin,
     VrfDhcpMixin,
     VrfDhcpv6Mixin,
+    BatchBuilder,
 ):
     """Complete batch builder for VRF operations."""
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "vrf"
         self.mappers = CommandMapperRegistry.get_mappers(
             (
@@ -59,26 +60,6 @@ class VrfBatchBuilder(
             return run_vrf_protocol_op(self, verb, proto, suffix, vrf_name, value)
 
         return _op
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "VrfBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "VrfBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Global VRF Operations

--- a/backend/vyos_builders/vxlan/vxlan_batch_builder.py
+++ b/backend/vyos_builders/vxlan/vxlan_batch_builder.py
@@ -5,11 +5,12 @@ Provides all batch operations for VXLAN interface configuration.
 Version-aware: VyOS 1.5 adds ipv6 address interface-identifier and vlan-to-vni description.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class VxlanBatchBuilder:
+class VxlanBatchBuilder(BatchBuilder):
     """Complete batch builder for VXLAN interface operations."""
 
     _INTERNAL_BUILDER_METHODS = frozenset({
@@ -19,30 +20,9 @@ class VxlanBatchBuilder:
     })
 
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.mapper_key = "vxlan"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
-
-    # ========================================================================
-    # Core Batch Operations
-    # ========================================================================
-
-    def add_set(self, path: List[str]) -> "VxlanBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "VxlanBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # ========================================================================
     # Interface-level Operations

--- a/backend/vyos_builders/webproxy/webproxy_batch_builder.py
+++ b/backend/vyos_builders/webproxy/webproxy_batch_builder.py
@@ -20,35 +20,15 @@ Multi-value lists follow a delete-all-then-add pattern: callers delete the
 whole list then re-add each desired value.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class WebProxyBatchBuilder:
+class WebProxyBatchBuilder(BatchBuilder):
     def __init__(self, version: str):
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
         self.m = CommandMapperRegistry.get_mapper("webproxy", version)
-
-    # -----------------------------------------------------------------------
-    # Core helpers
-    # -----------------------------------------------------------------------
-
-    def add_set(self, path: List[str]) -> "WebProxyBatchBuilder":
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "WebProxyBatchBuilder":
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
-    def get_operations(self) -> List[Dict[str, Any]]:
-        return self._operations.copy()
-
-    def is_empty(self) -> bool:
-        return len(self._operations) == 0
 
     # -----------------------------------------------------------------------
     # Top-level

--- a/backend/vyos_builders/wireguard/wireguard.py
+++ b/backend/vyos_builders/wireguard/wireguard.py
@@ -5,17 +5,17 @@ Provides all batch operations for WireGuard VPN configuration.
 Handles version-specific differences through the mapper layer.
 """
 
-from typing import List, Dict, Any
+from typing import Dict, Any
 from vyos_mappers import CommandMapperRegistry
+from vyos_builders.base import BatchBuilder
 
 
-class WireGuardBatchBuilder:
+class WireGuardBatchBuilder(BatchBuilder):
     """Complete batch builder for WireGuard operations"""
 
     def __init__(self, version: str):
         """Initialize builder with VyOS version."""
-        self.version = version
-        self._operations: List[Dict[str, Any]] = []
+        super().__init__(version)
 
         self.mapper_key = "wireguard"
         self.mappers = {self.mapper_key: CommandMapperRegistry.get_mapper(self.mapper_key, version)}
@@ -24,33 +24,13 @@ class WireGuardBatchBuilder:
     # Core Batch Operations
     # ========================================================================
 
-    def add_set(self, path: List[str]) -> "WireGuardBatchBuilder":
-        """Add a 'set' operation to the batch."""
-        if path:
-            self._operations.append({"op": "set", "path": path})
-        return self
-
-    def add_delete(self, path: List[str]) -> "WireGuardBatchBuilder":
-        """Add a 'delete' operation to the batch."""
-        if path:
-            self._operations.append({"op": "delete", "path": path})
-        return self
-
     def clear(self) -> None:
         """Clear all operations from the batch."""
         self._operations = []
 
-    def get_operations(self) -> List[Dict[str, Any]]:
-        """Get the list of operations."""
-        return self._operations.copy()
-
     def operation_count(self) -> int:
         """Get the number of operations in the batch."""
         return len(self._operations)
-
-    def is_empty(self) -> bool:
-        """Check if the batch is empty."""
-        return len(self._operations) == 0
 
     # ========================================================================
     # Interface Operations


### PR DESCRIPTION
Dozens of *BatchBuilder classes each copied add_set, add_delete, get_operations, and is_empty. Feature files now inherit BatchBuilder for that list; they keep mapper construction and set_/delete_ methods.

Empty paths are skipped on the shared add_set/add_delete (the majority behavior). README builder sample matches.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_batch_builder.py tests/test_batch_builder_mappers.py tests/test_*builder*.py tests/test_*paths*.py (excluding FastAPI-importing files). 333 passed including the new regression that feature builders must not redefine the four methods.

Closes #632