### PR TITLE
fix: override prisma deepmerge-ts to 8.0.2

### DIFF
--- a/backend/tests/test_frontend_deepmerge_ts_lock.py
+++ b/backend/tests/test_frontend_deepmerge_ts_lock.py
@@ -1,0 +1,33 @@
+"""GHSA-ggr8-5vv4-36mx: frontend lock must not ship deepmerge-ts < 8."""
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+FRONTEND = REPO / "frontend"
+MIN = (8, 0, 0)
+
+
+def _tuple(version: str) -> tuple[int, ...]:
+    core = version.split("-", 1)[0]
+    return tuple(int(part) for part in core.split(".")[:3])
+
+
+def test_package_json_overrides_deepmerge_ts_to_v8():
+    pkg = json.loads((FRONTEND / "package.json").read_text())
+    pinned = pkg.get("overrides", {}).get("deepmerge-ts")
+    assert pinned, "frontend package.json must override deepmerge-ts"
+    assert _tuple(str(pinned)) >= MIN, pinned
+
+
+def test_lockfile_resolves_deepmerge_ts_v8():
+    lock = json.loads((FRONTEND / "package-lock.json").read_text())
+    found = []
+    for path, meta in lock["packages"].items():
+        name = meta.get("name") or path.rsplit("node_modules/", 1)[-1]
+        if name != "deepmerge-ts":
+            continue
+        version = meta["version"]
+        found.append((path, version))
+        assert _tuple(version) >= MIN, f"{path} resolved {version}"
+    assert found, "lockfile has no deepmerge-ts package"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5516,13 +5516,23 @@
       "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
       "devOptional": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/define-data-property": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,5 +63,8 @@
     "tsx": "^4.22.4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "deepmerge-ts": "8.0.2"
   }
 }


### PR DESCRIPTION
Prisma 6.19.3 and Prisma 7.10.0 both still depend on deepmerge-ts 7.1.5 (GHSA-ggr8-5vv4-36mx). Bumping prisma and @prisma/client cannot make the lock resolve 8.x.

frontend/package.json now overrides deepmerge-ts to 8.0.2, the same shape docs-site uses for transitive GHSA pins. The lockfile installs 8.0.2. prisma validate still succeeds with a dummy DATABASE_URL.

Tests: PYTHONPATH=. uv run --with pytest pytest tests/test_frontend_deepmerge_ts_lock.py
npx prisma validate (DATABASE_URL dummy)

Closes #629