### PR TITLE
fix: drop VyOS version labels from VLAN and VIF dialogs

### DIFF
--- a/frontend/src/components/network/ComprehensiveVIFCModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVIFCModal.tsx
@@ -725,7 +725,6 @@ export function ComprehensiveVIFCModal({
                       <div className="space-y-2">
                         <Label htmlFor="ipv6-interface-id">Interface Identifier</Label>
                         <Input id="ipv6-interface-id" placeholder="::1" value={ipv6InterfaceIdentifier} onChange={(e) => setIpv6InterfaceIdentifier(e.target.value)} />
-                        <p className="text-xs text-muted-foreground">VyOS 1.5+ only</p>
                       </div>
                     )}
                   </div>
@@ -837,13 +836,13 @@ export function ComprehensiveVIFCModal({
                     {feat?.vif_dhcpv6_options_no_request_dns && (
                       <div className="flex items-center space-x-2">
                         <Checkbox id="dhcpv6-no-request-dns" checked={dhcpv6NoRequestDns} onCheckedChange={(c) => setDhcpv6NoRequestDns(c as boolean)} />
-                        <Label htmlFor="dhcpv6-no-request-dns" className="cursor-pointer text-sm">No Request DNS (1.5+)</Label>
+                        <Label htmlFor="dhcpv6-no-request-dns" className="cursor-pointer text-sm">No Request DNS</Label>
                       </div>
                     )}
                     {feat?.vif_dhcpv6_options_no_request_domain_name && (
                       <div className="flex items-center space-x-2">
                         <Checkbox id="dhcpv6-no-request-domain-name" checked={dhcpv6NoRequestDomainName} onCheckedChange={(c) => setDhcpv6NoRequestDomainName(c as boolean)} />
-                        <Label htmlFor="dhcpv6-no-request-domain-name" className="cursor-pointer text-sm">No Request Domain (1.5+)</Label>
+                        <Label htmlFor="dhcpv6-no-request-domain-name" className="cursor-pointer text-sm">No Request Domain</Label>
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/network/ComprehensiveVIFSModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVIFSModal.tsx
@@ -719,7 +719,6 @@ export function ComprehensiveVIFSModal({
                       <div className="space-y-2">
                         <Label htmlFor="ipv6-interface-id">Interface Identifier</Label>
                         <Input id="ipv6-interface-id" placeholder="::1" value={ipv6InterfaceIdentifier} onChange={(e) => setIpv6InterfaceIdentifier(e.target.value)} />
-                        <p className="text-xs text-muted-foreground">VyOS 1.5+ only</p>
                       </div>
                     )}
                   </div>
@@ -831,13 +830,13 @@ export function ComprehensiveVIFSModal({
                     {feat?.vif_dhcpv6_options_no_request_dns && (
                       <div className="flex items-center space-x-2">
                         <Checkbox id="dhcpv6-no-request-dns" checked={dhcpv6NoRequestDns} onCheckedChange={(c) => setDhcpv6NoRequestDns(c as boolean)} />
-                        <Label htmlFor="dhcpv6-no-request-dns" className="cursor-pointer text-sm">No Request DNS (1.5+)</Label>
+                        <Label htmlFor="dhcpv6-no-request-dns" className="cursor-pointer text-sm">No Request DNS</Label>
                       </div>
                     )}
                     {feat?.vif_dhcpv6_options_no_request_domain_name && (
                       <div className="flex items-center space-x-2">
                         <Checkbox id="dhcpv6-no-request-domain-name" checked={dhcpv6NoRequestDomainName} onCheckedChange={(c) => setDhcpv6NoRequestDomainName(c as boolean)} />
-                        <Label htmlFor="dhcpv6-no-request-domain-name" className="cursor-pointer text-sm">No Request Domain (1.5+)</Label>
+                        <Label htmlFor="dhcpv6-no-request-domain-name" className="cursor-pointer text-sm">No Request Domain</Label>
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/network/ComprehensiveVLANModal.tsx
+++ b/frontend/src/components/network/ComprehensiveVLANModal.tsx
@@ -957,7 +957,6 @@ export function ComprehensiveVLANModal({
                           value={ipv6InterfaceIdentifier}
                           onChange={(e) => setIpv6InterfaceIdentifier(e.target.value)}
                         />
-                        <p className="text-xs text-muted-foreground">VyOS 1.5+ only</p>
                       </div>
                     )}
                   </div>
@@ -1123,13 +1122,13 @@ export function ComprehensiveVLANModal({
                     {feat?.vif_dhcpv6_options_no_request_dns && (
                       <div className="flex items-center space-x-2">
                         <Checkbox id="dhcpv6-no-request-dns" checked={dhcpv6NoRequestDns} onCheckedChange={(c) => setDhcpv6NoRequestDns(c as boolean)} />
-                        <Label htmlFor="dhcpv6-no-request-dns" className="cursor-pointer text-sm">No Request DNS (1.5+)</Label>
+                        <Label htmlFor="dhcpv6-no-request-dns" className="cursor-pointer text-sm">No Request DNS</Label>
                       </div>
                     )}
                     {feat?.vif_dhcpv6_options_no_request_domain_name && (
                       <div className="flex items-center space-x-2">
                         <Checkbox id="dhcpv6-no-request-domain-name" checked={dhcpv6NoRequestDomainName} onCheckedChange={(c) => setDhcpv6NoRequestDomainName(c as boolean)} />
-                        <Label htmlFor="dhcpv6-no-request-domain-name" className="cursor-pointer text-sm">No Request Domain (1.5+)</Label>
+                        <Label htmlFor="dhcpv6-no-request-domain-name" className="cursor-pointer text-sm">No Request Domain</Label>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
VLAN, VIF-S, and VIF-C dialogs printed "VyOS 1.5+ only" and "(1.5+)" on controls that are already shown or hidden by capabilities. Config UI must not display version numbers.

Removed the "VyOS 1.5+ only" helper under the IPv6 Interface Identifier input and the "(1.5+)" suffix on the DHCPv6 No Request DNS and No Request Domain checkbox labels in ComprehensiveVLANModal, ComprehensiveVIFSModal, and ComprehensiveVIFCModal. Each control stays capability-gated (feat?.vif_ipv6_address_interface_identifier, feat?.vif_dhcpv6_options_no_request_dns, feat?.vif_dhcpv6_options_no_request_domain_name), so nothing changes about when they render.

Tests run: cd frontend && npx tsc --noEmit (clean), npm run lint (0 errors).

Closes #627