### PR TITLE
fix: routing search, unused caps, version labels, and interface pickers

### DIFF
--- a/frontend/src/app/policies/local-route/page.tsx
+++ b/frontend/src/app/policies/local-route/page.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Plus, Search, RefreshCw, Route, AlertCircle } from "lucide-react";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { localRouteService, type LocalRouteRule, type LocalRouteConfigResponse, type LocalRouteCapabilitiesResponse } from "@/lib/api/local-route";
+import { localRouteService, type LocalRouteRule, type LocalRouteConfigResponse } from "@/lib/api/local-route";
 import { CreateLocalRouteModal } from "@/components/policies/CreateLocalRouteModal";
 import { EditLocalRouteModal } from "@/components/policies/EditLocalRouteModal";
 import { DeleteLocalRouteModal } from "@/components/policies/DeleteLocalRouteModal";
@@ -27,7 +27,6 @@ function LocalRoutePageInner() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [config, setConfig] = useState<LocalRouteConfigResponse | null>(null);
-  const [, setCapabilities] = useState<LocalRouteCapabilitiesResponse | null>(null);
   const [selectedTab, setSelectedTab] = useState<"ipv4" | "ipv6">("ipv4");
   const [searchQuery, setSearchQuery] = useState("");
 
@@ -51,7 +50,6 @@ function LocalRoutePageInner() {
   );
 
   useEffect(() => {
-    fetchCapabilities();
     fetchConfig();
   }, []);
 
@@ -61,15 +59,6 @@ function LocalRoutePageInner() {
       setSelectedTab(section);
     }
   }, [searchParams]);
-
-  const fetchCapabilities = async () => {
-    try {
-      const data = await localRouteService.getCapabilities();
-      setCapabilities(data);
-    } catch (err) {
-      console.error("Error fetching capabilities:", err);
-    }
-  };
 
   const fetchConfig = async (refresh: boolean = false) => {
     try {

--- a/frontend/src/app/routing/static-failover/static-routes/page.tsx
+++ b/frontend/src/app/routing/static-failover/static-routes/page.tsx
@@ -38,7 +38,6 @@ import {
   staticRoutesService,
   type StaticRoute,
   type StaticRoutesConfig,
-  type StaticRoutesCapabilities,
   type ArpEntry,
   type MulticastRoute,
   type NeighborProxyArp,
@@ -62,7 +61,6 @@ import { RoutingTablesAccordion } from "@/components/routing/RoutingTablesAccord
 function StaticRoutesPageInner() {
   const searchParams = useSearchParams();
   const [config, setConfig] = useState<StaticRoutesConfig | null>(null);
-  const [, setCapabilities] = useState<StaticRoutesCapabilities | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -97,12 +95,8 @@ function StaticRoutesPageInner() {
     try {
       setLoading(true);
       setError(null);
-      const [configData, capsData] = await Promise.all([
-        staticRoutesService.getConfig(refresh),
-        staticRoutesService.getCapabilities(),
-      ]);
+      const configData = await staticRoutesService.getConfig(refresh);
       setConfig(configData);
-      setCapabilities(capsData);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to load static routes configuration"
@@ -118,9 +112,9 @@ function StaticRoutesPageInner() {
   }, []);
 
   useEffect(() => {
-    const tab = searchParams.get("tab");
-    if (tab === "routes" || tab === "arp" || tab === "mroute" || tab === "neighbor-proxy" || tab === "tables") {
-      setActiveTab(tab);
+    const section = searchParams.get("section") ?? searchParams.get("tab");
+    if (section === "routes" || section === "arp" || section === "mroute" || section === "neighbor-proxy" || section === "tables") {
+      setActiveTab(section);
     }
   }, [searchParams]);
 

--- a/frontend/src/app/routing/static-failover/static-routes/page.tsx
+++ b/frontend/src/app/routing/static-failover/static-routes/page.tsx
@@ -44,6 +44,7 @@ import {
   type NeighborProxyNd,
 } from "@/lib/api/static-routes";
 import { cn } from "@/lib/utils";
+import { staticRouteTabFromSearch } from "@/lib/query-tabs";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { CreateStaticRouteModal } from "@/components/routing/CreateStaticRouteModal";
 import { EditStaticRouteModal } from "@/components/routing/EditStaticRouteModal";
@@ -112,8 +113,8 @@ function StaticRoutesPageInner() {
   }, []);
 
   useEffect(() => {
-    const section = searchParams.get("section") ?? searchParams.get("tab");
-    if (section === "routes" || section === "arp" || section === "mroute" || section === "neighbor-proxy" || section === "tables") {
+    const section = staticRouteTabFromSearch((key) => searchParams.get(key));
+    if (section) {
       setActiveTab(section);
     }
   }, [searchParams]);

--- a/frontend/src/components/bgp/BgpContent.tsx
+++ b/frontend/src/components/bgp/BgpContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -59,6 +60,7 @@ export function BgpContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState("overview");
+  const searchParams = useSearchParams();
 
   // Neighbor modal state
   const [neighborModalOpen, setNeighborModalOpen] = useState(false);
@@ -142,6 +144,19 @@ export function BgpContent() {
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    if (
+      tab === "overview" ||
+      tab === "neighbors" ||
+      tab === "peer-groups" ||
+      tab === "address-families" ||
+      tab === "parameters"
+    ) {
+      setActiveTab(tab);
+    }
+  }, [searchParams]);
 
   // Stats
   const neighborCount = config?.neighbors.length ?? 0;

--- a/frontend/src/components/bgp/BgpContent.tsx
+++ b/frontend/src/components/bgp/BgpContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
+import { bgpTabFromSearch } from "@/lib/query-tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -146,14 +147,8 @@ export function BgpContent() {
   }, [loadData]);
 
   useEffect(() => {
-    const tab = searchParams.get("tab");
-    if (
-      tab === "overview" ||
-      tab === "neighbors" ||
-      tab === "peer-groups" ||
-      tab === "address-families" ||
-      tab === "parameters"
-    ) {
+    const tab = bgpTabFromSearch((key) => searchParams.get(key));
+    if (tab) {
       setActiveTab(tab);
     }
   }, [searchParams]);

--- a/frontend/src/components/isis/IsisContent.tsx
+++ b/frontend/src/components/isis/IsisContent.tsx
@@ -52,6 +52,11 @@ import {
 } from "lucide-react";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { isisService, IsisConfig, IsisCapabilities, IsisInterface, IsisRedistributeEntry } from "@/lib/api/isis";
+import {
+  isisLspRefreshMinSeconds,
+  isisSrv6Supported,
+  isisTeExportSupported,
+} from "@/lib/isis-feature-flags";
 import { routeMapService } from "@/lib/api/route-map";
 import { IsisInterfaceModal } from "./IsisInterfaceModal";
 import { IsisRedistributeModal } from "./IsisRedistributeModal";
@@ -959,7 +964,7 @@ export function IsisContent() {
                       {[
                         { label: "LSP MTU (bytes)", key: "lsp_mtu" as const, value: lspMtu, setter: setLspMtu, placeholder: "Default (1497)", min: 128, max: 4352, cur: g?.lsp_mtu },
                         { label: "LSP Generation Interval (s)", key: "lsp_gen_interval" as const, value: lspGenInterval, setter: setLspGenInterval, placeholder: "Default", min: 1, max: 120, cur: g?.lsp_gen_interval },
-                        { label: "LSP Refresh Interval (s)", key: "lsp_refresh_interval" as const, value: lspRefreshInterval, setter: setLspRefreshInterval, placeholder: "Default (900)", min: capabilities?.features.lsp_refresh_min_1.supported ? 1 : 2, max: 65235, cur: g?.lsp_refresh_interval },
+                        { label: "LSP Refresh Interval (s)", key: "lsp_refresh_interval" as const, value: lspRefreshInterval, setter: setLspRefreshInterval, placeholder: "Default (900)", min: isisLspRefreshMinSeconds(capabilities?.features), max: 65235, cur: g?.lsp_refresh_interval },
                         { label: "Max LSP Lifetime (s)", key: "max_lsp_lifetime" as const, value: maxLspLifetime, setter: setMaxLspLifetime, placeholder: "Default (1200)", min: 350, max: 65535, cur: g?.max_lsp_lifetime },
                         { label: "SPF Interval (ms)", key: "spf_interval" as const, value: spfInterval, setter: setSpfInterval, placeholder: "Default", min: 1, max: 120000, cur: g?.spf_interval },
                         { label: "LDP Sync Holddown (s)", key: "ldp_sync_holddown" as const, value: ldpSyncHolddown, setter: setLdpSyncHolddown, placeholder: "Disabled", min: 1, max: 10000, cur: g?.ldp_sync_holddown },
@@ -1068,7 +1073,7 @@ export function IsisContent() {
                           <p className="text-xs text-muted-foreground mb-1">Prefix SIDs</p>
                           <p className="text-sm">{config?.segment_routing.prefixes.length ?? 0} configured</p>
                         </div>
-                        {capabilities?.features.srv6.supported && config?.segment_routing.srv6_locator && (
+                        {isisSrv6Supported(capabilities?.features) && config?.segment_routing.srv6_locator && (
                           <div>
                             <p className="text-xs text-muted-foreground mb-1">SRv6 Locator</p>
                             <Badge variant="secondary" className="font-mono">{config.segment_routing.srv6_locator}</Badge>
@@ -1094,7 +1099,7 @@ export function IsisContent() {
                           <p className="font-mono">{config.traffic_engineering.address}</p>
                         </div>
                       )}
-                      {capabilities?.features.te_export.supported && (
+                      {isisTeExportSupported(capabilities?.features) && (
                         <div className="flex items-center gap-2">
                           <span className="text-muted-foreground">TED Export:</span>
                           <span>{config?.traffic_engineering.export ? "Yes" : "No"}</span>

--- a/frontend/src/components/isis/IsisContent.tsx
+++ b/frontend/src/components/isis/IsisContent.tsx
@@ -959,7 +959,7 @@ export function IsisContent() {
                       {[
                         { label: "LSP MTU (bytes)", key: "lsp_mtu" as const, value: lspMtu, setter: setLspMtu, placeholder: "Default (1497)", min: 128, max: 4352, cur: g?.lsp_mtu },
                         { label: "LSP Generation Interval (s)", key: "lsp_gen_interval" as const, value: lspGenInterval, setter: setLspGenInterval, placeholder: "Default", min: 1, max: 120, cur: g?.lsp_gen_interval },
-                        { label: "LSP Refresh Interval (s)", key: "lsp_refresh_interval" as const, value: lspRefreshInterval, setter: setLspRefreshInterval, placeholder: "Default (900)", min: capabilities?.version_info.is_1_5 ? 2 : 1, max: 65235, cur: g?.lsp_refresh_interval },
+                        { label: "LSP Refresh Interval (s)", key: "lsp_refresh_interval" as const, value: lspRefreshInterval, setter: setLspRefreshInterval, placeholder: "Default (900)", min: capabilities?.features.lsp_refresh_min_1.supported ? 1 : 2, max: 65235, cur: g?.lsp_refresh_interval },
                         { label: "Max LSP Lifetime (s)", key: "max_lsp_lifetime" as const, value: maxLspLifetime, setter: setMaxLspLifetime, placeholder: "Default (1200)", min: 350, max: 65535, cur: g?.max_lsp_lifetime },
                         { label: "SPF Interval (ms)", key: "spf_interval" as const, value: spfInterval, setter: setSpfInterval, placeholder: "Default", min: 1, max: 120000, cur: g?.spf_interval },
                         { label: "LDP Sync Holddown (s)", key: "ldp_sync_holddown" as const, value: ldpSyncHolddown, setter: setLdpSyncHolddown, placeholder: "Disabled", min: 1, max: 10000, cur: g?.ldp_sync_holddown },
@@ -1068,7 +1068,7 @@ export function IsisContent() {
                           <p className="text-xs text-muted-foreground mb-1">Prefix SIDs</p>
                           <p className="text-sm">{config?.segment_routing.prefixes.length ?? 0} configured</p>
                         </div>
-                        {capabilities.version_info.is_1_5 && config?.segment_routing.srv6_locator && (
+                        {capabilities?.features.srv6.supported && config?.segment_routing.srv6_locator && (
                           <div>
                             <p className="text-xs text-muted-foreground mb-1">SRv6 Locator</p>
                             <Badge variant="secondary" className="font-mono">{config.segment_routing.srv6_locator}</Badge>
@@ -1094,7 +1094,7 @@ export function IsisContent() {
                           <p className="font-mono">{config.traffic_engineering.address}</p>
                         </div>
                       )}
-                      {capabilities?.version_info.is_1_5 && (
+                      {capabilities?.features.te_export.supported && (
                         <div className="flex items-center gap-2">
                           <span className="text-muted-foreground">TED Export:</span>
                           <span>{config?.traffic_engineering.export ? "Yes" : "No"}</span>

--- a/frontend/src/components/isis/IsisInterfaceModal.tsx
+++ b/frontend/src/components/isis/IsisInterfaceModal.tsx
@@ -29,6 +29,10 @@ import {
 } from "@/lib/api/isis";
 import { showService, InterfaceName } from "@/lib/api/show";
 import { InterfaceSelect } from "@/components/ui/interface-select";
+import {
+  isisRemoteLfaSupported,
+  isisTiLfaSupported,
+} from "@/lib/isis-feature-flags";
 
 interface IsisInterfaceModalProps {
   open: boolean;
@@ -47,8 +51,8 @@ export function IsisInterfaceModal({
   capabilities,
 }: IsisInterfaceModalProps) {
   const isEdit = !!existingInterface;
-  const tiLfaSupported = capabilities?.features.ti_lfa.supported ?? false;
-  const remoteLfaSupported = capabilities?.features.remote_lfa.supported ?? false;
+  const tiLfaSupported = isisTiLfaSupported(capabilities?.features);
+  const remoteLfaSupported = isisRemoteLfaSupported(capabilities?.features);
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/isis/IsisInterfaceModal.tsx
+++ b/frontend/src/components/isis/IsisInterfaceModal.tsx
@@ -47,7 +47,8 @@ export function IsisInterfaceModal({
   capabilities,
 }: IsisInterfaceModalProps) {
   const isEdit = !!existingInterface;
-  const isV15 = capabilities?.version_info.is_1_5 ?? false;
+  const tiLfaSupported = capabilities?.features.ti_lfa.supported ?? false;
+  const remoteLfaSupported = capabilities?.features.remote_lfa.supported ?? false;
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -459,8 +460,8 @@ export function IsisInterfaceModal({
               </div>
             </div>
 
-            {/* TI-LFA (v1.5 only) */}
-            {isV15 && (
+            {/* TI-LFA */}
+            {tiLfaSupported && (
               <>
                 <Separator />
                 <div>
@@ -502,7 +503,11 @@ export function IsisInterfaceModal({
                     )}
                   </div>
                 </div>
+              </>
+            )}
 
+            {remoteLfaSupported && (
+              <>
                 <Separator />
 
                 {/* Remote LFA */}
@@ -562,7 +567,7 @@ export function IsisInterfaceModal({
               </>
             )}
 
-            {!isV15 && (
+            {!tiLfaSupported && !remoteLfaSupported && (
               <p className="text-sm text-muted-foreground">
                 TI-LFA and Remote LFA are not supported on this device.
               </p>

--- a/frontend/src/components/policies/AddRouteMapRuleModal.tsx
+++ b/frontend/src/components/policies/AddRouteMapRuleModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { VrfSelect } from "@/components/ui/vrf-select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1032,11 +1033,12 @@ export function AddRouteMapRuleModal({
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="matchInterface">Interface</Label>
-                      <Input
+                      <InterfaceSelect
                         id="matchInterface"
-                        placeholder="e.g., eth0"
-                        value={matchInterface}
-                        onChange={(e) => setMatchInterface(e.target.value)}
+                        value={matchInterface || "__none__"}
+                        onValueChange={(v) => setMatchInterface(v === "__none__" ? "" : v)}
+                        noneOption={{ label: "None", value: "__none__" }}
+                        placeholder="Select interface"
                       />
                     </div>
                     <div className="space-y-2">

--- a/frontend/src/components/policies/CreateLocalRouteModal.tsx
+++ b/frontend/src/components/policies/CreateLocalRouteModal.tsx
@@ -381,7 +381,7 @@ export function CreateLocalRouteModal({
                   extraOptions={[{ label: "Default", value: "default" }]}
                 />
                 <p className="text-xs text-muted-foreground">
-                  VRF instance to use for matched traffic (VyOS 1.5+)
+                  VRF instance to use for matched traffic
                 </p>
               </div>
             )}
@@ -397,9 +397,9 @@ export function CreateLocalRouteModal({
                   <li>• At least one matching criterion (source, destination, or interface) is required</li>
                   <li>• Choose either Routing Table OR VRF - you cannot specify both</li>
                   {capabilities?.features.vrf_support.supported ? (
-                    <li>• VRF option is available on VyOS 1.5+</li>
+                    <li>• VRF option is available on this device</li>
                   ) : (
-                    <li>• VRF requires VyOS 1.5+ (currently unavailable)</li>
+                    <li>• This device does not support VRF</li>
                   )}
                   <li>• Traffic matching all specified criteria will use the specified destination</li>
                   <li>• Rules are processed in numerical order</li>

--- a/frontend/src/components/policies/CreateRouteMapModal.tsx
+++ b/frontend/src/components/policies/CreateRouteMapModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { VrfSelect } from "@/components/ui/vrf-select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -13,7 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { AlertCircle } from "lucide-react";
 import { routeMapService } from "@/lib/api/route-map";
-import type { RouteMapCapabilities, MatchConditions, SetActions } from "@/lib/api/route-map";
+import type { MatchConditions, SetActions } from "@/lib/api/route-map";
 
 interface CreateRouteMapModalProps {
     open: boolean;
@@ -24,7 +25,6 @@ interface CreateRouteMapModalProps {
 export function CreateRouteMapModal({ open, onOpenChange, onSuccess }: CreateRouteMapModalProps) {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [, setCapabilities] = useState<RouteMapCapabilities | null>(null);
 
     // Basic fields
     const [name, setName] = useState("");
@@ -118,21 +118,6 @@ export function CreateRouteMapModal({ open, onOpenChange, onSuccess }: CreateRou
     const [setSrc, setSetSrc] = useState("");
     const [setTable, setSetTable] = useState("");
     const [setTag, setSetTag] = useState("");
-
-    useEffect(() => {
-        if (open) {
-            loadCapabilities();
-        }
-    }, [open]);
-
-    const loadCapabilities = async () => {
-        try {
-            const caps = await routeMapService.getCapabilities();
-            setCapabilities(caps);
-        } catch (err) {
-            console.error("Failed to load capabilities:", err);
-        }
-    };
 
     const resetForm = () => {
         setName("");
@@ -736,11 +721,12 @@ export function CreateRouteMapModal({ open, onOpenChange, onSuccess }: CreateRou
         </div>
         <div className="space-y-2">
         <Label htmlFor="matchInterface">Interface</Label>
-        <Input
+        <InterfaceSelect
         id="matchInterface"
-        placeholder="e.g., eth0"
-        value={matchInterface}
-        onChange={(e) => setMatchInterface(e.target.value)}
+        value={matchInterface || "__none__"}
+        onValueChange={(v) => setMatchInterface(v === "__none__" ? "" : v)}
+        noneOption={{ label: "None", value: "__none__" }}
+        placeholder="Select interface"
         />
         </div>
         <div className="space-y-2">

--- a/frontend/src/components/policies/CreateRouteRuleModal.tsx
+++ b/frontend/src/components/policies/CreateRouteRuleModal.tsx
@@ -1532,7 +1532,7 @@ export function CreateRouteRuleModal({
                       extraOptions={[{ label: "Default", value: "default" }]}
                     />
                     <p className="text-xs text-muted-foreground">
-                      VRF routing (VyOS 1.5+ only)
+                      VRF routing
                     </p>
                   </div>
                 )}

--- a/frontend/src/components/policies/EditLocalRouteModal.tsx
+++ b/frontend/src/components/policies/EditLocalRouteModal.tsx
@@ -371,7 +371,7 @@ export function EditLocalRouteModal({
                   extraOptions={[{ label: "Default", value: "default" }]}
                 />
                 <p className="text-xs text-muted-foreground">
-                  VRF instance to use for matched traffic (VyOS 1.5+)
+                  VRF instance to use for matched traffic
                 </p>
               </div>
             )}
@@ -388,9 +388,9 @@ export function EditLocalRouteModal({
                   <li>• Choose either Routing Table OR VRF - you cannot specify both</li>
                   <li>• Switching between Table and VRF will clear the other field</li>
                   {capabilities?.features.vrf_support.supported ? (
-                    <li>• VRF option is available on VyOS 1.5+</li>
+                    <li>• VRF option is available on this device</li>
                   ) : (
-                    <li>• VRF requires VyOS 1.5+ (currently unavailable)</li>
+                    <li>• This device does not support VRF</li>
                   )}
                 </ul>
               </div>

--- a/frontend/src/components/policies/EditRouteMapRuleModal.tsx
+++ b/frontend/src/components/policies/EditRouteMapRuleModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { VrfSelect } from "@/components/ui/vrf-select";
+import { InterfaceSelect } from "@/components/ui/interface-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -1069,11 +1070,12 @@ export function EditRouteMapRuleModal({
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="matchInterface">Interface</Label>
-                      <Input
+                      <InterfaceSelect
                         id="matchInterface"
-                        placeholder="e.g., eth0"
-                        value={matchInterface}
-                        onChange={(e) => setMatchInterface(e.target.value)}
+                        value={matchInterface || "__none__"}
+                        onValueChange={(v) => setMatchInterface(v === "__none__" ? "" : v)}
+                        noneOption={{ label: "None", value: "__none__" }}
+                        placeholder="Select interface"
                       />
                     </div>
                     <div className="space-y-2">

--- a/frontend/src/components/policies/EditRouteRuleModal.tsx
+++ b/frontend/src/components/policies/EditRouteRuleModal.tsx
@@ -1677,7 +1677,7 @@ export function EditRouteRuleModal({
                       extraOptions={[{ label: "Default", value: "default" }]}
                     />
                     <p className="text-xs text-muted-foreground">
-                      VRF routing (VyOS 1.5+ only)
+                      VRF routing
                     </p>
                   </div>
                 )}

--- a/frontend/src/components/routing/CreateStaticRouteModal.tsx
+++ b/frontend/src/components/routing/CreateStaticRouteModal.tsx
@@ -547,14 +547,16 @@ export function CreateStaticRouteModal({ open, onOpenChange, onSuccess, routeTyp
             {capabilities?.features.dhcp_interface.supported && (
               <div className="space-y-2">
                 <Label htmlFor="dhcp-interface">DHCP Interface</Label>
-                <Input
+                <InterfaceSelect
                   id="dhcp-interface"
-                  placeholder="e.g., eth0"
-                  value={dhcpInterface}
-                  onChange={(e) => setDhcpInterface(e.target.value)}
+                  value={dhcpInterface || "__none__"}
+                  onValueChange={(v) => setDhcpInterface(v === "__none__" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "__none__" }}
+                  placeholder="Select interface"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Use gateway from DHCP on this interface (VyOS 1.4 only)
+                  Use gateway from DHCP on this interface
                 </p>
               </div>
             )}
@@ -562,7 +564,7 @@ export function CreateStaticRouteModal({ open, onOpenChange, onSuccess, routeTyp
             {!capabilities?.features.dhcp_interface.supported && (
               <div className="bg-muted/50 border rounded-lg p-4">
                 <p className="text-sm text-muted-foreground">
-                  No advanced options available for this VyOS version.
+                  No advanced options available on this device.
                 </p>
               </div>
             )}

--- a/frontend/src/components/routing/EditStaticRouteModal.tsx
+++ b/frontend/src/components/routing/EditStaticRouteModal.tsx
@@ -588,14 +588,16 @@ export function EditStaticRouteModal({ open, onOpenChange, onSuccess, route }: E
             {capabilities?.features.dhcp_interface.supported && (
               <div className="space-y-2">
                 <Label htmlFor="dhcp-interface">DHCP Interface</Label>
-                <Input
+                <InterfaceSelect
                   id="dhcp-interface"
-                  placeholder="e.g., eth0"
-                  value={dhcpInterface}
-                  onChange={(e) => setDhcpInterface(e.target.value)}
+                  value={dhcpInterface || "__none__"}
+                  onValueChange={(v) => setDhcpInterface(v === "__none__" ? "" : v)}
+                  interfaces={availableInterfaces}
+                  noneOption={{ label: "None", value: "__none__" }}
+                  placeholder="Select interface"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Use gateway from DHCP on this interface (VyOS 1.4 only)
+                  Use gateway from DHCP on this interface
                 </p>
               </div>
             )}
@@ -603,7 +605,7 @@ export function EditStaticRouteModal({ open, onOpenChange, onSuccess, route }: E
             {!capabilities?.features.dhcp_interface.supported && (
               <div className="bg-muted/50 border rounded-lg p-4">
                 <p className="text-sm text-muted-foreground">
-                  No advanced options available for this VyOS version.
+                  No advanced options available on this device.
                 </p>
               </div>
             )}

--- a/frontend/src/lib/isis-feature-flags.test.ts
+++ b/frontend/src/lib/isis-feature-flags.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isisLspRefreshMinSeconds,
+  isisRemoteLfaSupported,
+  isisSrv6Supported,
+  isisTeExportSupported,
+  isisTiLfaSupported,
+  type IsisFeatureFlags,
+} from "./isis-feature-flags";
+
+function flags(overrides: Partial<Record<keyof IsisFeatureFlags, boolean>>): IsisFeatureFlags {
+  const leaf = (supported: boolean) => ({ supported });
+  return {
+    ti_lfa: leaf(overrides.ti_lfa ?? false),
+    remote_lfa: leaf(overrides.remote_lfa ?? false),
+    srv6: leaf(overrides.srv6 ?? false),
+    te_export: leaf(overrides.te_export ?? false),
+    lsp_refresh_min_1: leaf(overrides.lsp_refresh_min_1 ?? false),
+  };
+}
+
+describe("ISIS UI feature gates", () => {
+  it("does not enable TI-LFA from version_info; only features.ti_lfa", () => {
+    assert.equal(isisTiLfaSupported(flags({})), false);
+    assert.equal(isisTiLfaSupported(flags({ ti_lfa: true })), true);
+    assert.equal(isisTiLfaSupported(undefined), false);
+  });
+
+  it("gates Remote LFA separately from TI-LFA", () => {
+    assert.equal(isisRemoteLfaSupported(flags({ ti_lfa: true })), false);
+    assert.equal(isisRemoteLfaSupported(flags({ remote_lfa: true })), true);
+  });
+
+  it("gates SRv6 and TED export on their own flags", () => {
+    assert.equal(isisSrv6Supported(flags({})), false);
+    assert.equal(isisSrv6Supported(flags({ srv6: true })), true);
+    assert.equal(isisTeExportSupported(flags({ te_export: true })), true);
+    assert.equal(isisTeExportSupported(flags({ srv6: true })), false);
+  });
+
+  it("uses lsp_refresh_min_1 for the numeric min, not is_1_5", () => {
+    assert.equal(isisLspRefreshMinSeconds(flags({ lsp_refresh_min_1: true })), 1);
+    assert.equal(isisLspRefreshMinSeconds(flags({})), 2);
+    assert.equal(isisLspRefreshMinSeconds(undefined), 2);
+  });
+});

--- a/frontend/src/lib/isis-feature-flags.ts
+++ b/frontend/src/lib/isis-feature-flags.ts
@@ -1,0 +1,33 @@
+/** ISIS UI gates on capability feature flags, never version_info. */
+
+export interface IsisFeatureLeaf {
+  supported: boolean;
+}
+
+export interface IsisFeatureFlags {
+  ti_lfa: IsisFeatureLeaf;
+  remote_lfa: IsisFeatureLeaf;
+  srv6: IsisFeatureLeaf;
+  te_export: IsisFeatureLeaf;
+  lsp_refresh_min_1: IsisFeatureLeaf;
+}
+
+export function isisTiLfaSupported(features: IsisFeatureFlags | undefined): boolean {
+  return features?.ti_lfa.supported ?? false;
+}
+
+export function isisRemoteLfaSupported(features: IsisFeatureFlags | undefined): boolean {
+  return features?.remote_lfa.supported ?? false;
+}
+
+export function isisSrv6Supported(features: IsisFeatureFlags | undefined): boolean {
+  return features?.srv6.supported ?? false;
+}
+
+export function isisTeExportSupported(features: IsisFeatureFlags | undefined): boolean {
+  return features?.te_export.supported ?? false;
+}
+
+export function isisLspRefreshMinSeconds(features: IsisFeatureFlags | undefined): number {
+  return features?.lsp_refresh_min_1.supported ? 1 : 2;
+}

--- a/frontend/src/lib/query-tabs.test.ts
+++ b/frontend/src/lib/query-tabs.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  bgpTabFromSearch,
+  staticRouteTabFromSearch,
+} from "./query-tabs";
+
+function params(record: Record<string, string>): (key: string) => string | null {
+  return (key) => record[key] ?? null;
+}
+
+describe("staticRouteTabFromSearch", () => {
+  it("reads section as nav and search emit it", () => {
+    assert.equal(staticRouteTabFromSearch(params({ section: "arp" })), "arp");
+    assert.equal(staticRouteTabFromSearch(params({ section: "mroute" })), "mroute");
+    assert.equal(staticRouteTabFromSearch(params({ section: "tables" })), "tables");
+  });
+
+  it("falls back to tab when section is absent", () => {
+    assert.equal(staticRouteTabFromSearch(params({ tab: "neighbor-proxy" })), "neighbor-proxy");
+  });
+
+  it("prefers section over tab", () => {
+    assert.equal(
+      staticRouteTabFromSearch(params({ section: "arp", tab: "routes" })),
+      "arp",
+    );
+  });
+
+  it("ignores unknown values", () => {
+    assert.equal(staticRouteTabFromSearch(params({ section: "overview" })), null);
+    assert.equal(staticRouteTabFromSearch(params({})), null);
+  });
+});
+
+describe("bgpTabFromSearch", () => {
+  it("reads tab as nav emits it", () => {
+    assert.equal(bgpTabFromSearch(params({ tab: "neighbors" })), "neighbors");
+    assert.equal(bgpTabFromSearch(params({ tab: "peer-groups" })), "peer-groups");
+  });
+
+  it("does not treat section as a BGP tab", () => {
+    assert.equal(bgpTabFromSearch(params({ section: "neighbors" })), null);
+  });
+
+  it("ignores unknown tabs", () => {
+    assert.equal(bgpTabFromSearch(params({ tab: "arp" })), null);
+  });
+});

--- a/frontend/src/lib/query-tabs.ts
+++ b/frontend/src/lib/query-tabs.ts
@@ -1,0 +1,40 @@
+/** Query-param tab helpers for routing pages. Nav emits `section` for static
+ *  routes and `tab` for BGP; pages must consume the name nav actually sends. */
+
+export const STATIC_ROUTE_TABS = [
+  "routes",
+  "arp",
+  "mroute",
+  "neighbor-proxy",
+  "tables",
+] as const;
+
+export type StaticRouteTab = (typeof STATIC_ROUTE_TABS)[number];
+
+export function staticRouteTabFromSearch(
+  get: (key: string) => string | null,
+): StaticRouteTab | null {
+  const value = get("section") ?? get("tab");
+  return (STATIC_ROUTE_TABS as readonly string[]).includes(value ?? "")
+    ? (value as StaticRouteTab)
+    : null;
+}
+
+export const BGP_TABS = [
+  "overview",
+  "neighbors",
+  "peer-groups",
+  "address-families",
+  "parameters",
+] as const;
+
+export type BgpTab = (typeof BGP_TABS)[number];
+
+export function bgpTabFromSearch(
+  get: (key: string) => string | null,
+): BgpTab | null {
+  const value = get("tab");
+  return (BGP_TABS as readonly string[]).includes(value ?? "")
+    ? (value as BgpTab)
+    : null;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -38,6 +38,7 @@
     ".next/dev/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
Static-route search and nav emit section=arp (and the other static-route sections) but the page only read tab, so those hits opened Routes. BGP Neighbors sends tab=neighbors and BgpContent never consumed it. The page now reads section (still honors tab), and BgpContent reads tab.

policies/local-route, static-routes, and CreateRouteMapModal fetched capabilities and threw the result away. Dropped those unused fetches. Modals that actually gate still load capabilities themselves.

Local-route, route-rule, and static-route modals printed VyOS 1.5+ or 1.4 only on fields already hidden by capabilities. That copy is gone. Hidden DHCP advanced options now say this device does not support them.

Route-map match interface and static-route DHCP interface were free-text with placeholder eth0. They now use InterfaceSelect, same as next-hop.

IsisInterfaceModal gated TI-LFA and Remote LFA on version_info.is_1_5. IsisContent did the same for SRv6, TED export, and LSP refresh min. Those widgets now use features.ti_lfa, remote_lfa, srv6, te_export, and lsp_refresh_min_1.

Tests run: cd frontend && npx tsc --noEmit (clean), npm run lint (0 errors, 3 pre-existing warnings in unrelated files).

Closes #646
Closes #647
Closes #654
Closes #655
Closes #656