### PR TITLE
fix: drop bogus DHCPv6 subnet disable and raise on version-wrong paths

### DIFF
--- a/backend/routers/dhcpv6_server/dhcpv6_server.py
+++ b/backend/routers/dhcpv6_server/dhcpv6_server.py
@@ -76,7 +76,6 @@ class DHCPv6SubnetOptions(BaseModel):
 
 class DHCPv6Subnet(BaseModel):
     subnet: str
-    disabled: bool = False
     subnet_id: Optional[int] = None       # 1.5 only
     lease_default: Optional[int] = None
     lease_minimum: Optional[int] = None
@@ -304,7 +303,6 @@ async def get_dhcpv6_server_config(http_request: Request, refresh: bool = False)
 
                 subnets.append(DHCPv6Subnet(
                     subnet=subnet_cidr,
-                    disabled="disable" in subnet_data,
                     subnet_id=_parse_int(subnet_data.get("subnet-id")),
                     lease_default=lease_default,
                     lease_minimum=lease_minimum,
@@ -384,6 +382,12 @@ async def dhcpv6_server_batch_configure(
         )
     except HTTPException:
         raise
+    except NotImplementedError as e:
+        logger.info("Unsupported DHCPv6 operation for this VyOS version: %s", e)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Operation is not supported on this VyOS version: {e}",
+        )
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {e}")
     except Exception:

--- a/backend/tests/test_container_builder_paths.py
+++ b/backend/tests/test_container_builder_paths.py
@@ -1,0 +1,35 @@
+"""Golden (method, args, expected_path) cases for ContainerBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+1.5-only nodes are covered in test_container_version_gates.py.
+"""
+
+import pytest
+
+from vyos_builders.container.container_batch_builder import ContainerBatchBuilder
+
+NODE = ["container", "name", "web"]
+
+CASES = [
+    ("set_name", ("web",), "set", NODE),
+    ("delete_name", ("web",), "delete", NODE),
+    ("set_name_image", ("web", "nginx"), "set", NODE + ["image", "nginx"]),
+    ("delete_name_image", ("web",), "delete", NODE + ["image"]),
+    ("set_name_description", ("web", "test"), "set", NODE + ["description", "test"]),
+    ("delete_name_description", ("web",), "delete", NODE + ["description"]),
+    ("set_name_disable", ("web",), "set", NODE + ["disable"]),
+    ("delete_name_disable", ("web",), "delete", NODE + ["disable"]),
+    ("set_name_allow_host_networks", ("web",), "set", NODE + ["allow-host-networks"]),
+    ("delete_name_allow_host_networks", ("web",), "delete", NODE + ["allow-host-networks"]),
+    ("set_name_privileged", ("web",), "set", NODE + ["privileged"]),
+    ("delete_name_privileged", ("web",), "delete", NODE + ["privileged"]),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_container_builder_paths(method, args, op, expected_path, version):
+    builder = ContainerBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]

--- a/backend/tests/test_container_builder_paths.py
+++ b/backend/tests/test_container_builder_paths.py
@@ -1,6 +1,7 @@
 """Golden (method, args, expected_path) cases for ContainerBatchBuilder.
 
 Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+Every version-agnostic valueless set_* leaf has a matching delete_*.
 1.5-only nodes are covered in test_container_version_gates.py.
 """
 
@@ -9,6 +10,8 @@ import pytest
 from vyos_builders.container.container_batch_builder import ContainerBatchBuilder
 
 NODE = ["container", "name", "web"]
+NET = ["container", "network", "lan"]
+REG = ["container", "registry", "ghcr.io"]
 
 CASES = [
     ("set_name", ("web",), "set", NODE),
@@ -21,8 +24,18 @@ CASES = [
     ("delete_name_disable", ("web",), "delete", NODE + ["disable"]),
     ("set_name_allow_host_networks", ("web",), "set", NODE + ["allow-host-networks"]),
     ("delete_name_allow_host_networks", ("web",), "delete", NODE + ["allow-host-networks"]),
+    ("set_name_allow_host_pid", ("web",), "set", NODE + ["allow-host-pid"]),
+    ("delete_name_allow_host_pid", ("web",), "delete", NODE + ["allow-host-pid"]),
     ("set_name_privileged", ("web",), "set", NODE + ["privileged"]),
     ("delete_name_privileged", ("web",), "delete", NODE + ["privileged"]),
+    ("set_network", ("lan",), "set", NET),
+    ("delete_network", ("lan",), "delete", NET),
+    ("set_network_no_name_server", ("lan",), "set", NET + ["no-name-server"]),
+    ("delete_network_no_name_server", ("lan",), "delete", NET + ["no-name-server"]),
+    ("set_registry", ("ghcr.io",), "set", REG),
+    ("delete_registry", ("ghcr.io",), "delete", REG),
+    ("set_registry_disable", ("ghcr.io",), "set", REG + ["disable"]),
+    ("delete_registry_disable", ("ghcr.io",), "delete", REG + ["disable"]),
 ]
 
 

--- a/backend/tests/test_dhcp_builder_paths.py
+++ b/backend/tests/test_dhcp_builder_paths.py
@@ -1,0 +1,32 @@
+"""Golden (method, args, expected_path) cases for DHCPBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+host-decl-name is 1.4-only and is covered in test_dhcp_version_gates.py.
+"""
+
+import pytest
+
+from vyos_builders.dhcp.dhcp import DHCPBatchBuilder
+
+BASE = ["service", "dhcp-server"]
+LAN = BASE + ["shared-network-name", "LAN"]
+
+CASES = [
+    ("set_global_disable", (), "set", BASE + ["disable"]),
+    ("delete_global_disable", (), "delete", BASE + ["disable"]),
+    ("set_listen_address", ("192.0.2.1",), "set", BASE + ["listen-address", "192.0.2.1"]),
+    ("delete_listen_address", ("192.0.2.1",), "delete", BASE + ["listen-address", "192.0.2.1"]),
+    ("set_hostfile_update", (), "set", BASE + ["hostfile-update"]),
+    ("delete_hostfile_update", (), "delete", BASE + ["hostfile-update"]),
+    ("set_shared_network", ("LAN",), "set", LAN),
+    ("delete_shared_network", ("LAN",), "delete", LAN),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_dhcp_builder_paths(method, args, op, expected_path, version):
+    builder = DHCPBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]

--- a/backend/tests/test_dhcp_builder_paths.py
+++ b/backend/tests/test_dhcp_builder_paths.py
@@ -1,7 +1,9 @@
 """Golden (method, args, expected_path) cases for DHCPBatchBuilder.
 
 Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
-host-decl-name is 1.4-only and is covered in test_dhcp_version_gates.py.
+Every version-agnostic valueless set_* leaf has a matching delete_*.
+host-decl-name, subnet disable, and enable-failover are version-gated
+in test_dhcp_version_gates.py.
 """
 
 import pytest
@@ -10,6 +12,8 @@ from vyos_builders.dhcp.dhcp import DHCPBatchBuilder
 
 BASE = ["service", "dhcp-server"]
 LAN = BASE + ["shared-network-name", "LAN"]
+SUB = LAN + ["subnet", "192.168.1.0/24"]
+MAP = SUB + ["static-mapping", "host1"]
 
 CASES = [
     ("set_global_disable", (), "set", BASE + ["disable"]),
@@ -20,6 +24,18 @@ CASES = [
     ("delete_hostfile_update", (), "delete", BASE + ["hostfile-update"]),
     ("set_shared_network", ("LAN",), "set", LAN),
     ("delete_shared_network", ("LAN",), "delete", LAN),
+    ("set_shared_network_authoritative", ("LAN",), "set", LAN + ["authoritative"]),
+    ("delete_shared_network_authoritative", ("LAN",), "delete", LAN + ["authoritative"]),
+    ("set_shared_network_disable", ("LAN",), "set", LAN + ["disable"]),
+    ("delete_shared_network_disable", ("LAN",), "delete", LAN + ["disable"]),
+    ("set_shared_network_ping_check", ("LAN",), "set", LAN + ["ping-check"]),
+    ("delete_shared_network_ping_check", ("LAN",), "delete", LAN + ["ping-check"]),
+    ("set_subnet", ("LAN", "192.168.1.0/24"), "set", SUB),
+    ("delete_subnet", ("LAN", "192.168.1.0/24"), "delete", SUB),
+    ("set_subnet_ping_check", ("LAN", "192.168.1.0/24"), "set", SUB + ["ping-check"]),
+    ("delete_subnet_ping_check", ("LAN", "192.168.1.0/24"), "delete", SUB + ["ping-check"]),
+    ("set_static_mapping_disable", ("LAN", "192.168.1.0/24", "host1"), "set", MAP + ["disable"]),
+    ("delete_static_mapping_disable", ("LAN", "192.168.1.0/24", "host1"), "delete", MAP + ["disable"]),
 ]
 
 

--- a/backend/tests/test_dhcp_relay_builder_paths.py
+++ b/backend/tests/test_dhcp_relay_builder_paths.py
@@ -1,0 +1,43 @@
+"""Golden (method, args, expected_path) cases for DHCPRelayBatchBuilder.
+
+Paths checked with validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5).
+"""
+
+import pytest
+
+from vyos_builders.dhcp_relay.dhcp_relay_batch_builder import DHCPRelayBatchBuilder
+
+BASE = ["service", "dhcp-relay"]
+
+CASES = [
+    ("set_disable", (), "set", BASE + ["disable"]),
+    ("delete_disable", (), "delete", BASE + ["disable"]),
+    ("delete_dhcp_relay", (), "delete", BASE),
+    ("set_interface", ("eth0",), "set", BASE + ["interface", "eth0"]),
+    ("delete_interface", ("eth0",), "delete", BASE + ["interface", "eth0"]),
+    ("delete_interfaces", (), "delete", BASE + ["interface"]),
+    ("set_listen_interface", ("eth0",), "set", BASE + ["listen-interface", "eth0"]),
+    ("delete_listen_interface", ("eth0",), "delete", BASE + ["listen-interface", "eth0"]),
+    ("delete_listen_interfaces", (), "delete", BASE + ["listen-interface"]),
+    ("set_upstream_interface", ("eth0",), "set", BASE + ["upstream-interface", "eth0"]),
+    ("delete_upstream_interface", ("eth0",), "delete", BASE + ["upstream-interface", "eth0"]),
+    ("delete_upstream_interfaces", (), "delete", BASE + ["upstream-interface"]),
+    ("set_server", ("192.0.2.1",), "set", BASE + ["server", "192.0.2.1"]),
+    ("delete_server", ("192.0.2.1",), "delete", BASE + ["server", "192.0.2.1"]),
+    ("delete_servers", (), "delete", BASE + ["server"]),
+    ("set_hop_count", ("10",), "set", BASE + ["relay-options", "hop-count", "10"]),
+    ("delete_hop_count", (), "delete", BASE + ["relay-options", "hop-count"]),
+    ("set_max_size", ("576",), "set", BASE + ["relay-options", "max-size", "576"]),
+    ("delete_max_size", (), "delete", BASE + ["relay-options", "max-size"]),
+    ("set_relay_agents_packets", ("forward",), "set", BASE + ["relay-options", "relay-agents-packets", "forward"]),
+    ("delete_relay_agents_packets", (), "delete", BASE + ["relay-options", "relay-agents-packets"]),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_dhcp_relay_builder_paths(method, args, op, expected_path, version):
+    builder = DHCPRelayBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]

--- a/backend/tests/test_dhcpv6_version_gates.py
+++ b/backend/tests/test_dhcpv6_version_gates.py
@@ -1,0 +1,43 @@
+"""DHCPv6 mapper raises on version-wrong paths and has no subnet disable node."""
+
+import pytest
+
+from vyos_builders.dhcpv6_server.dhcpv6_server_batch_builder import (
+    DHCPv6ServerBatchBuilder,
+)
+from vyos_mappers.dhcpv6_server.dhcpv6_server_versions import get_dhcpv6_server_mapper
+
+
+def test_v14_listen_interface_raises():
+    mapper = get_dhcpv6_server_mapper("1.4")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        mapper.get_listen_interface("eth0")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        mapper.get_disable_route_autoinstall()
+
+
+def test_v15_listen_interface_emits():
+    mapper = get_dhcpv6_server_mapper("1.5")
+    assert mapper.get_listen_interface("eth0") == [
+        "service", "dhcpv6-server", "listen-interface", "eth0",
+    ]
+
+
+def test_v14_builder_listen_interface_raises():
+    builder = DHCPv6ServerBatchBuilder(version="1.4")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        builder.set_listen_interface("eth0")
+
+
+def test_subnet_disable_is_gone():
+    mapper = get_dhcpv6_server_mapper("1.5")
+    assert not hasattr(mapper, "get_subnet_disable")
+    builder = DHCPv6ServerBatchBuilder(version="1.5")
+    assert not hasattr(builder, "set_subnet_disable")
+    assert not hasattr(builder, "delete_subnet_disable")
+
+
+def test_v15_rejects_14_only_range():
+    mapper = get_dhcpv6_server_mapper("1.5")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        mapper.get_subnet_addr_range_start("LAN", "2001:db8::/64", "2001:db8::10")

--- a/backend/vyos_builders/dhcpv6_server/dhcpv6_server_batch_builder.py
+++ b/backend/vyos_builders/dhcpv6_server/dhcpv6_server_batch_builder.py
@@ -170,12 +170,6 @@ class DHCPv6ServerBatchBuilder(BatchBuilder):
     def delete_subnet(self, name: str, subnet: str) -> "DHCPv6ServerBatchBuilder":
         return self.add_delete(self.m.get_subnet_delete(name, subnet))
 
-    def set_subnet_disable(self, name: str, subnet: str) -> "DHCPv6ServerBatchBuilder":
-        return self.add_set(self.m.get_subnet_disable(name, subnet))
-
-    def delete_subnet_disable(self, name: str, subnet: str) -> "DHCPv6ServerBatchBuilder":
-        return self.add_delete(self.m.get_subnet_disable(name, subnet))
-
     # Lease times
     def set_subnet_lease_default(self, name: str, subnet: str, value: str) -> "DHCPv6ServerBatchBuilder":
         return self.add_set(self.m.get_subnet_lease_default(name, subnet, value))

--- a/backend/vyos_builders/vrf/vrf_dhcpv6_mixin.py
+++ b/backend/vyos_builders/vrf/vrf_dhcpv6_mixin.py
@@ -384,30 +384,6 @@ class VrfDhcpv6Mixin:
             return self.add_delete(path)
         return self
 
-    def set_vrf_dhcpv6_subnet_disable(
-        self, name: str, value: str
-    ) -> "VrfDhcpv6Mixin":
-        """Value format: 'network,prefix'."""
-        parts = value.split(",", 1)
-        if len(parts) == 2:
-            path = self.mappers["vrf_dhcpv6"].get_dhcpv6_subnet_disable(
-                name, parts[0], parts[1]
-            )
-            return self.add_set(path)
-        return self
-
-    def delete_vrf_dhcpv6_subnet_disable(
-        self, name: str, value: str
-    ) -> "VrfDhcpv6Mixin":
-        """Value format: 'network,prefix'."""
-        parts = value.split(",", 1)
-        if len(parts) == 2:
-            path = self.mappers["vrf_dhcpv6"].get_dhcpv6_subnet_disable(
-                name, parts[0], parts[1]
-            )
-            return self.add_delete(path)
-        return self
-
     def set_vrf_dhcpv6_subnet_domain_search(
         self, name: str, value: str
     ) -> "VrfDhcpv6Mixin":

--- a/backend/vyos_mappers/dhcpv6_server/dhcpv6_server.py
+++ b/backend/vyos_mappers/dhcpv6_server/dhcpv6_server.py
@@ -32,15 +32,15 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
     def get_global_name_server_delete(self, ns: str) -> List[str]:
         return BASE + ["global-parameters", "name-server", ns]
 
-    # 1.5-only — version mapper overrides return [] on 1.4
+    # 1.5-only — version mapper overrides; base raises on 1.4
     def get_disable_route_autoinstall(self) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_listen_interface(self, iface: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_listen_interface_delete(self, iface: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # =========================================================================
     # Shared network
@@ -63,22 +63,22 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
 
     # Network-level options — version-specific (overridden in v1_4/v1_5)
     def get_network_option_name_server(self, name: str, ns: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_network_option_name_server_delete(self, name: str, ns: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_network_option_domain_search(self, name: str, domain: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_network_option_domain_search_delete(self, name: str, domain: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_network_option_info_refresh_time(self, name: str, value: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_network_option_info_refresh_time_delete(self, name: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # =========================================================================
     # Subnet
@@ -89,9 +89,6 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
 
     def get_subnet_delete(self, name: str, subnet: str) -> List[str]:
         return SNN + [name, "subnet", subnet]
-
-    def get_subnet_disable(self, name: str, subnet: str) -> List[str]:
-        return SNN + [name, "subnet", subnet, "disable"]
 
     # Subnet lease times
     def get_subnet_lease_default(self, name: str, subnet: str, value: str) -> List[str]:
@@ -114,71 +111,71 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
 
     # Subnet-level options — version-specific (overridden in v1_4/v1_5)
     def get_subnet_option_name_server(self, name: str, subnet: str, ns: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_name_server_delete(self, name: str, subnet: str, ns: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_domain_search(self, name: str, subnet: str, domain: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_domain_search_delete(self, name: str, subnet: str, domain: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_info_refresh_time(self, name: str, subnet: str, value: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_info_refresh_time_delete(self, name: str, subnet: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nis_domain(self, name: str, subnet: str, domain: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nis_domain_delete(self, name: str, subnet: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nisplus_domain(self, name: str, subnet: str, domain: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nisplus_domain_delete(self, name: str, subnet: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nis_server(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nis_server_delete(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nisplus_server(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_nisplus_server_delete(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_sip_server(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_sip_server_delete(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_sntp_server(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_option_sntp_server_delete(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_cisco_tftp_server(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_cisco_tftp_server_delete(self, name: str, subnet: str, server: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # 1.5-only
     def get_subnet_id(self, name: str, subnet: str, sid: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_id_delete(self, name: str, subnet: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # =========================================================================
     # Address ranges — version-specific
@@ -186,39 +183,39 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
 
     # 1.5: named range
     def get_subnet_range(self, name: str, subnet: str, range_id: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_range_delete(self, name: str, subnet: str, range_id: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_range_start(self, name: str, subnet: str, range_id: str, start: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_range_stop(self, name: str, subnet: str, range_id: str, stop: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_range_prefix(self, name: str, subnet: str, range_id: str, prefix: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # 1.4: address-range start/stop
     def get_subnet_addr_range_start(self, name: str, subnet: str, start: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_addr_range_start_stop(self, name: str, subnet: str, start: str, stop: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_addr_range_start_delete(self, name: str, subnet: str, start: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # 1.4: address-range prefix
     def get_subnet_addr_range_prefix(self, name: str, subnet: str, prefix: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_addr_range_prefix_temporary(self, name: str, subnet: str, prefix: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_addr_range_prefix_delete(self, name: str, subnet: str, prefix: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # =========================================================================
     # Prefix delegation — version-specific
@@ -226,35 +223,35 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
 
     # 1.5: prefix-delegation prefix/<prefix>/...
     def get_subnet_pd_prefix(self, name: str, subnet: str, prefix: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_prefix_delete(self, name: str, subnet: str, prefix: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_prefix_delegated_length(self, name: str, subnet: str, prefix: str, length: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_prefix_length(self, name: str, subnet: str, prefix: str, length: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_prefix_excluded_prefix(self, name: str, subnet: str, prefix: str, excl: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_prefix_excluded_prefix_length(self, name: str, subnet: str, prefix: str, length: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # 1.4: prefix-delegation start/<start>/...
     def get_subnet_pd_start(self, name: str, subnet: str, start: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_start_stop(self, name: str, subnet: str, start: str, stop: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_start_prefix_length(self, name: str, subnet: str, start: str, length: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_subnet_pd_start_delete(self, name: str, subnet: str, start: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # =========================================================================
     # Static mappings
@@ -283,14 +280,14 @@ class DHCPv6ServerMapper(BaseFeatureMapper):
 
     # DUID field differs: 1.4 = identifier, 1.5 = duid — overridden in version mappers
     def get_static_mapping_duid(self, name: str, subnet: str, mapping: str, duid: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_static_mapping_duid_delete(self, name: str, subnet: str, mapping: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     # MAC address — 1.5 only
     def get_static_mapping_mac(self, name: str, subnet: str, mapping: str, mac: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")
 
     def get_static_mapping_mac_delete(self, name: str, subnet: str, mapping: str) -> List[str]:
-        return []
+        raise NotImplementedError("not supported on this VyOS version")

--- a/backend/vyos_mappers/vrf/vrf_dhcpv6.py
+++ b/backend/vyos_mappers/vrf/vrf_dhcpv6.py
@@ -171,13 +171,6 @@ class VrfDhcpv6Mapper:
             "shared-network-name", network, "subnet", prefix, "description", value,
         ]
 
-    def get_dhcpv6_subnet_disable(
-        self, name: str, network: str, prefix: str
-    ) -> List[str]:
-        return self._base(name) + [
-            "shared-network-name", network, "subnet", prefix, "disable",
-        ]
-
     def get_dhcpv6_subnet_domain_search(
         self, name: str, network: str, prefix: str, value: str
     ) -> List[str]:

--- a/frontend/src/components/dhcpv6-server/DHCPv6ServerContent.tsx
+++ b/frontend/src/components/dhcpv6-server/DHCPv6ServerContent.tsx
@@ -601,7 +601,6 @@ export function DHCPv6ServerContent() {
                             <TableRow className="hover:bg-transparent">
                               <TableHead>Subnet</TableHead>
                               {caps?.features.subnet_id.supported && <TableHead>ID</TableHead>}
-                              <TableHead>Status</TableHead>
                               <TableHead>Lease Default</TableHead>
                               <TableHead>Ranges</TableHead>
                               <TableHead>PD</TableHead>
@@ -621,18 +620,6 @@ export function DHCPv6ServerContent() {
                                       : <span className="text-muted-foreground">—</span>}
                                   </TableCell>
                                 )}
-                                <TableCell>
-                                  <Badge
-                                    variant="outline"
-                                    className={cn(
-                                      subnet.disabled
-                                        ? "bg-red-500/10 text-red-500 border-red-500/20"
-                                        : "bg-green-500/10 text-green-500 border-green-500/20"
-                                    )}
-                                  >
-                                    {subnet.disabled ? "Disabled" : "Active"}
-                                  </Badge>
-                                </TableCell>
                                 <TableCell>
                                   {subnet.lease_default != null
                                     ? `${subnet.lease_default}s`

--- a/frontend/src/components/dhcpv6-server/DHCPv6ServerNetworkModal.tsx
+++ b/frontend/src/components/dhcpv6-server/DHCPv6ServerNetworkModal.tsx
@@ -100,7 +100,6 @@ export function DHCPv6ServerNetworkModal({ open, network, caps, onClose, onSucce
 
   // ── Subnet fields (create only) ──
   const [subnetCidr, setSubnetCidr] = useState("");
-  const [subnetDisabled, setSubnetDisabled] = useState(false);
   const [leaseDefault, setLeaseDefault] = useState("");
   const [leaseMinimum, setLeaseMinimum] = useState("");
   const [leaseMaximum, setLeaseMaximum] = useState("");
@@ -140,7 +139,7 @@ export function DHCPv6ServerNetworkModal({ open, network, caps, onClose, onSucce
     setError(null);
     setActiveTab("network");
 
-    setSubnetCidr(""); setSubnetDisabled(false);
+    setSubnetCidr("");
     setLeaseDefault(""); setLeaseMinimum(""); setLeaseMaximum("");
     setSubNsServers([]); setSubNsInput("");
     setSubDomainSearch([]); setSubDsInput("");
@@ -206,7 +205,6 @@ export function DHCPv6ServerNetworkModal({ open, network, caps, onClose, onSucce
       const subIrt = subInfoRefreshTime.trim() !== "" ? parseInt(subInfoRefreshTime.trim(), 10) : null;
       const subnet = {
         subnet: subnetCidr.trim(),
-        disabled: subnetDisabled,
         subnet_id: caps.features.subnet_id.supported ? 1 : null,
         lease_default: leaseDefault.trim() !== "" ? parseInt(leaseDefault.trim(), 10) : null,
         lease_minimum: leaseMinimum.trim() !== "" ? parseInt(leaseMinimum.trim(), 10) : null,
@@ -331,15 +329,6 @@ export function DHCPv6ServerNetworkModal({ open, network, caps, onClose, onSucce
                         value={subnetCidr}
                         onChange={(e) => setSubnetCidr(e.target.value)}
                       />
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                      <Checkbox
-                        id="sub-disabled"
-                        checked={subnetDisabled}
-                        onCheckedChange={(v) => setSubnetDisabled(Boolean(v))}
-                      />
-                      <Label htmlFor="sub-disabled" className="cursor-pointer">Disable this subnet</Label>
                     </div>
 
                     <div className="grid grid-cols-3 gap-2">

--- a/frontend/src/components/dhcpv6-server/DHCPv6ServerSubnetModal.tsx
+++ b/frontend/src/components/dhcpv6-server/DHCPv6ServerSubnetModal.tsx
@@ -11,7 +11,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -99,7 +98,6 @@ export function DHCPv6ServerSubnetModal({
 
   // Basic
   const [subnetCidr, setSubnetCidr] = useState("");
-  const [disabled, setDisabled] = useState(false);
   const [leaseDefault, setLeaseDefault] = useState("");
   const [leaseMinimum, setLeaseMinimum] = useState("");
   const [leaseMaximum, setLeaseMaximum] = useState("");
@@ -133,7 +131,6 @@ export function DHCPv6ServerSubnetModal({
 
     if (subnet) {
       setSubnetCidr(subnet.subnet);
-      setDisabled(subnet.disabled);
       setLeaseDefault(subnet.lease_default != null ? String(subnet.lease_default) : "");
       setLeaseMinimum(subnet.lease_minimum != null ? String(subnet.lease_minimum) : "");
       setLeaseMaximum(subnet.lease_maximum != null ? String(subnet.lease_maximum) : "");
@@ -149,7 +146,6 @@ export function DHCPv6ServerSubnetModal({
       setCiscoTftpServers([...subnet.options.cisco_tftp_servers]);
     } else {
       setSubnetCidr("");
-      setDisabled(false);
       setLeaseDefault("");
       setLeaseMinimum("");
       setLeaseMaximum("");
@@ -206,7 +202,6 @@ export function DHCPv6ServerSubnetModal({
 
     const updated: DHCPv6Subnet = {
       subnet: subnetCidr.trim(),
-      disabled,
       subnet_id: computedSubnetId,
       lease_default: leaseDefault.trim() !== "" ? parseInt(leaseDefault.trim(), 10) : null,
       lease_minimum: leaseMinimum.trim() !== "" ? parseInt(leaseMinimum.trim(), 10) : null,
@@ -279,15 +274,6 @@ export function DHCPv6ServerSubnetModal({
                   onChange={(e) => setSubnetCidr(e.target.value)}
                   disabled={isEditing}
                 />
-              </div>
-
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="subnet-disabled"
-                  checked={disabled}
-                  onCheckedChange={(v) => setDisabled(Boolean(v))}
-                />
-                <Label htmlFor="subnet-disabled" className="cursor-pointer">Disable this subnet</Label>
               </div>
 
               <div className="grid grid-cols-3 gap-3">

--- a/frontend/src/components/vrf/schema/dhcpv6Entities.ts
+++ b/frontend/src/components/vrf/schema/dhcpv6Entities.ts
@@ -89,7 +89,6 @@ const SUBNET_GROUP: EntityGroupSpec = {
       title: "Subnet",
       fields: [
         { op: "vrf_dhcpv6_subnet_description", label: "Description", type: "text", path: ["description"] },
-        { op: "vrf_dhcpv6_subnet_disable", label: "Disable", type: "toggle", path: ["disable"] },
         { op: "vrf_dhcpv6_subnet_interface", label: "Interface", type: "text", path: ["interface"] },
         { op: "vrf_dhcpv6_subnet_id", label: "Subnet ID", type: "number", path: ["subnet-id"] },
       ],

--- a/frontend/src/lib/api/dhcpv6-server.ts
+++ b/frontend/src/lib/api/dhcpv6-server.ts
@@ -42,7 +42,6 @@ export interface DHCPv6StaticMapping {
 
 export interface DHCPv6Subnet {
   subnet: string;
-  disabled: boolean;
   subnet_id: number | null;
   lease_default: number | null;
   lease_minimum: number | null;
@@ -270,7 +269,6 @@ class DHCPv6ServerService {
 
     // Subnet
     ops.push({ op: "set_subnet", value: base });
-    if (subnet.disabled) ops.push({ op: "set_subnet_disable", value: base });
     if (subnet.subnet_id != null) ops.push({ op: "set_subnet_id", value: `${base},${subnet.subnet_id}` });
     if (subnet.lease_default != null) ops.push({ op: "set_subnet_lease_default", value: `${base},${subnet.lease_default}` });
     if (subnet.lease_minimum != null) ops.push({ op: "set_subnet_lease_minimum", value: `${base},${subnet.lease_minimum}` });
@@ -320,7 +318,6 @@ class DHCPv6ServerService {
 
     if (original === null) {
       ops.push({ op: "set_subnet", value: base });
-      if (updated.disabled) ops.push({ op: "set_subnet_disable", value: base });
       if (updated.subnet_id != null) ops.push({ op: "set_subnet_id", value: `${base},${updated.subnet_id}` });
       if (updated.lease_default != null) ops.push({ op: "set_subnet_lease_default", value: `${base},${updated.lease_default}` });
       if (updated.lease_minimum != null) ops.push({ op: "set_subnet_lease_minimum", value: `${base},${updated.lease_minimum}` });
@@ -336,9 +333,6 @@ class DHCPv6ServerService {
       for (const s of updated.options.sntp_servers) ops.push({ op: "set_subnet_sntp_server", value: `${base},${s}` });
       for (const s of updated.options.cisco_tftp_servers) ops.push({ op: "set_subnet_cisco_tftp_server", value: `${base},${s}` });
     } else {
-      if (updated.disabled !== original.disabled) {
-        ops.push({ op: updated.disabled ? "set_subnet_disable" : "delete_subnet_disable", value: base });
-      }
       if (updated.subnet_id !== original.subnet_id) {
         if (updated.subnet_id != null) ops.push({ op: "set_subnet_id", value: `${base},${updated.subnet_id}` });
         else ops.push({ op: "delete_subnet_id", value: base });


### PR DESCRIPTION
Both lab builds reject set service dhcpv6-server shared-network-name LAN subnet 2001:db8::/64 disable. The mapper still emitted that path and the subnet modal had a Disable this subnet control. Removed the node from the DHCPv6 mapper and builder, VRF DHCPv6 mixin, frontend types, both subnet modals, and the subnet status column.

Version-wrong DHCPv6 methods returned an empty path so BatchBuilder.add_set skipped them and the batch reported success. Base mapper stubs now raise NotImplementedError, matching PPPoE. The DHCPv6 batch endpoint maps that to HTTP 400. 1.4 listen-interface is INVALID; 1.5 is VALID.

Added golden (method, args, expected_path) tables for ContainerBatchBuilder, DHCPBatchBuilder, and DHCPRelayBatchBuilder, including delete counterparts for the valueless set leaves. Paths were checked with validateTmplPath on 1.4 and 1.5.

Tests run: PYTHONPATH=. uv run --with pytest pytest tests/test_dhcpv6_version_gates.py tests/test_dhcp_relay_builder_paths.py tests/test_dhcp_builder_paths.py tests/test_container_builder_paths.py tests/test_dhcp_version_gates.py tests/test_container_version_gates.py (117 passed). frontend npx tsc --noEmit (clean), npm run lint (0 errors).

Closes #653
Closes #659
Closes #660