### PR TITLE
fix: expose DHCP listen settings and 1.5 DUID

### DIFF
--- a/backend/routers/dhcp/dhcp.py
+++ b/backend/routers/dhcp/dhcp.py
@@ -43,6 +43,7 @@ class DHCPStaticMapping(BaseModel):
     name: str = Field(..., description="Static mapping name")
     ip_address: Optional[str] = None
     mac_address: Optional[str] = None
+    duid: Optional[str] = None
     description: Optional[str] = None
     disable: bool = False
 
@@ -106,6 +107,7 @@ class DHCPGlobalConfig(BaseModel):
     """DHCP global configuration."""
 
     listen_addresses: List[str] = []
+    listen_interfaces: List[str] = []
     hostfile_update: bool = False
     host_decl_name: bool = False
     disable: bool = False
@@ -261,6 +263,9 @@ async def get_dhcp_config(http_request: Request, refresh: bool = False):
             listen_addresses=list(dhcp_config.get("listen-address", {}).keys())
             if isinstance(dhcp_config.get("listen-address"), dict)
             else [],
+            listen_interfaces=list(dhcp_config.get("listen-interface", {}).keys())
+            if isinstance(dhcp_config.get("listen-interface"), dict)
+            else [],
             hostfile_update="hostfile-update" in dhcp_config,
             host_decl_name="host-decl-name" in dhcp_config,
             disable="disable" in dhcp_config,
@@ -411,6 +416,7 @@ async def get_dhcp_config(http_request: Request, refresh: bool = False):
                                         name=mapping_name,
                                         ip_address=mapping_data.get("ip-address"),
                                         mac_address=mac_addr,
+                                        duid=mapping_data.get("duid"),
                                         description=mapping_data.get("description"),
                                         disable="disable" in mapping_data,
                                     )
@@ -929,6 +935,8 @@ async def dhcp_batch_configure(http_request: Request, request: DHCPBatchRequest)
 
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except KeyError:
         raise HTTPException(status_code=404, detail="Device not found in registry")
     except Exception as e:

--- a/backend/tests/test_dhcp_version_gates.py
+++ b/backend/tests/test_dhcp_version_gates.py
@@ -20,6 +20,30 @@ def test_v15_delete_helpers_stay_unguarded():
     assert mapper.get_subnet_enable_failover_path("LAN", "192.168.1.0/24")[-1] == "enable-failover"
 
 
+def test_v14_rejects_15_only_sets():
+    mapper = DHCPMapper("1.4")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_listen_interface("eth0")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_static_mapping_duid("LAN", "192.168.1.0/24", "host1", "00:01:02")
+
+
+def test_v15_emits_listen_interface_and_duid():
+    mapper = DHCPMapper("1.5")
+    assert mapper.get_listen_interface("eth0") == [
+        "service", "dhcp-server", "listen-interface", "eth0",
+    ]
+    assert mapper.get_static_mapping_duid("LAN", "192.168.1.0/24", "host1", "00:01:02")[-2:] == [
+        "duid", "00:01:02",
+    ]
+
+
+def test_v14_delete_helpers_stay_unguarded_for_15_nodes():
+    mapper = DHCPMapper("1.4")
+    assert mapper.get_listen_interface_path("eth0")[-1] == "eth0"
+    assert mapper.get_static_mapping_duid_path("LAN", "192.168.1.0/24", "host1")[-1] == "duid"
+
+
 def test_v14_rejects_subnet_disable_set():
     mapper = DHCPMapper("1.4")
     with pytest.raises(ValueError, match="not supported"):
@@ -51,5 +75,30 @@ def test_capabilities_read_mapper_flags():
     assert f15["enable_failover"]["supported"] is False
     assert f14["subnet_disable"]["supported"] is False
     assert f15["subnet_disable"]["supported"] is True
+    assert f14["listen_interface"]["supported"] is False
+    assert f15["listen_interface"]["supported"] is True
+    assert f14["static_mapping_duid"]["supported"] is False
+    assert f15["static_mapping_duid"]["supported"] is True
+    assert f14["host_decl_name"]["supported"] is True
+    assert f15["host_decl_name"]["supported"] is False
+    assert f14["listen_address"]["supported"] is True
+    assert f15["hostfile_update"]["supported"] is True
     assert f14["time_offset"]["supported"] is True
     assert f15["time_offset"]["supported"] is True
+
+
+def test_v15_builder_emits_listen_interface_and_duid():
+    builder = DHCPBatchBuilder(version="1.5")
+    builder.set_listen_interface("eth0")
+    builder.set_static_mapping_duid("LAN", "192.168.1.0/24", "host1", "00:01:02")
+    ops = builder.get_operations()
+    assert ops[0]["path"] == ["service", "dhcp-server", "listen-interface", "eth0"]
+    assert ops[1]["path"][-2:] == ["duid", "00:01:02"]
+
+
+def test_v14_builder_rejects_listen_interface_and_duid():
+    builder = DHCPBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_listen_interface("eth0")
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_static_mapping_duid("LAN", "192.168.1.0/24", "host1", "00:01:02")

--- a/backend/vyos_builders/dhcp/dhcp.py
+++ b/backend/vyos_builders/dhcp/dhcp.py
@@ -76,6 +76,14 @@ class DHCPBatchBuilder(BatchBuilder):
         path = self.mappers[self.mapper_key].get_host_decl_name_path()
         return self.add_delete(path)
 
+    def set_listen_interface(self, interface: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_listen_interface(interface)
+        return self.add_set(path)
+
+    def delete_listen_interface(self, interface: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_listen_interface_path(interface)
+        return self.add_delete(path)
+
     # ========================================================================
     # Shared Network Operations
     # ========================================================================
@@ -508,6 +516,22 @@ class DHCPBatchBuilder(BatchBuilder):
         )
         return self.add_delete(path)
 
+    def set_static_mapping_duid(
+        self, network_name: str, subnet: str, mapping_name: str, duid: str
+    ) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_static_mapping_duid(
+            network_name, subnet, mapping_name, duid
+        )
+        return self.add_set(path)
+
+    def delete_static_mapping_duid(
+        self, network_name: str, subnet: str, mapping_name: str
+    ) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_static_mapping_duid_path(
+            network_name, subnet, mapping_name
+        )
+        return self.add_delete(path)
+
     def set_static_mapping_disable(
         self, network_name: str, subnet: str, mapping_name: str
     ) -> "DHCPBatchBuilder":
@@ -827,6 +851,26 @@ class DHCPBatchBuilder(BatchBuilder):
                 "global_disable": {
                     "supported": True,
                     "description": "Disable the entire DHCP server",
+                },
+                "listen_address": {
+                    "supported": True,
+                    "description": "Addresses the DHCP server listens on",
+                },
+                "listen_interface": {
+                    "supported": mapper.has_listen_interface(),
+                    "description": "Interfaces the DHCP server listens on",
+                },
+                "hostfile_update": {
+                    "supported": True,
+                    "description": "Write DHCP hostnames into the hosts file",
+                },
+                "host_decl_name": {
+                    "supported": mapper.has_host_decl_name(),
+                    "description": "Use the host declaration name as the hostname",
+                },
+                "static_mapping_duid": {
+                    "supported": mapper.has_static_mapping_duid(),
+                    "description": "Identify a static mapping by DUID",
                 },
                 "network_disable": {
                     "supported": True,

--- a/backend/vyos_mappers/dhcp/dhcp.py
+++ b/backend/vyos_mappers/dhcp/dhcp.py
@@ -51,6 +51,12 @@ class DHCPMapper(BaseFeatureMapper):
     def has_host_decl_name(self) -> bool:
         return "1.4" in self.version
 
+    def has_listen_interface(self) -> bool:
+        return "1.4" not in self.version
+
+    def has_static_mapping_duid(self) -> bool:
+        return "1.4" not in self.version
+
     def has_enable_failover(self) -> bool:
         return "1.4" in self.version
 
@@ -69,6 +75,14 @@ class DHCPMapper(BaseFeatureMapper):
     def get_host_decl_name_path(self) -> List[str]:
         """Get command path for host-decl-name deletion."""
         return ["service", "dhcp-server", "host-decl-name"]
+
+    def get_listen_interface(self, interface: str) -> List[str]:
+        if not self.has_listen_interface():
+            raise ValueError("listen-interface is not supported on this device")
+        return ["service", "dhcp-server", "listen-interface", interface]
+
+    def get_listen_interface_path(self, interface: str) -> List[str]:
+        return ["service", "dhcp-server", "listen-interface", interface]
 
     # ==================== Shared Network Commands ====================
 
@@ -446,6 +460,24 @@ class DHCPMapper(BaseFeatureMapper):
         return [
             "service", "dhcp-server", "shared-network-name", network_name,
             "subnet", subnet, "static-mapping", mapping_name, "disable"
+        ]
+
+    def get_static_mapping_duid(
+        self, network_name: str, subnet: str, mapping_name: str, duid: str
+    ) -> List[str]:
+        if not self.has_static_mapping_duid():
+            raise ValueError("static-mapping duid is not supported on this device")
+        return [
+            "service", "dhcp-server", "shared-network-name", network_name,
+            "subnet", subnet, "static-mapping", mapping_name, "duid", duid
+        ]
+
+    def get_static_mapping_duid_path(
+        self, network_name: str, subnet: str, mapping_name: str
+    ) -> List[str]:
+        return [
+            "service", "dhcp-server", "shared-network-name", network_name,
+            "subnet", subnet, "static-mapping", mapping_name, "duid"
         ]
 
     # ==================== Subnet Options (Common) ====================

--- a/frontend/src/app/network/dhcp/page.tsx
+++ b/frontend/src/app/network/dhcp/page.tsx
@@ -56,6 +56,7 @@ import { DeleteStaticMappingModal } from "@/components/services/DeleteStaticMapp
 import { AddLeaseToStaticMappingModal } from "@/components/services/AddLeaseToStaticMappingModal";
 import { AddRangeModal } from "@/components/services/AddRangeModal";
 import { AddStaticMappingModal } from "@/components/services/AddStaticMappingModal";
+import { DHCPServerSettingsModal } from "@/components/services/DHCPServerSettingsModal";
 import { EditRangeModal } from "@/components/services/EditRangeModal";
 import { ChevronRight } from "lucide-react";
 
@@ -111,6 +112,7 @@ function DHCPPageInner() {
 
   // Modal states
   const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [addingSubnetToNetwork, setAddingSubnetToNetwork] = useState<string | null>(null);
   const [editingSubnet, setEditingSubnet] = useState<{
     network: string;
@@ -346,7 +348,8 @@ function DHCPPageInner() {
     const matchesSearch = searchQuery === "" ||
       mapping.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       mapping.ip_address?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      mapping.mac_address?.toLowerCase().includes(searchQuery.toLowerCase());
+      mapping.mac_address?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      mapping.duid?.toLowerCase().includes(searchQuery.toLowerCase());
     return matchesSubnet && matchesSearch;
   });
 
@@ -430,6 +433,16 @@ function DHCPPageInner() {
             >
               <Plus className="h-4 w-4 mr-2" />
               New Server
+            </Button>
+            <Button
+              className="w-full mt-2"
+              size="sm"
+              variant="outline"
+              onClick={() => setSettingsModalOpen(true)}
+              disabled={!config}
+            >
+              <Settings2 className="h-4 w-4 mr-2" />
+              Server settings
             </Button>
           </div>
 
@@ -1021,7 +1034,7 @@ function DHCPPageInner() {
                                     </div>
                                   </TableCell>
                                   <TableCell className="font-mono text-sm">
-                                    {mapping.mac_address || <span className="text-muted-foreground">—</span>}
+                                    {mapping.mac_address || mapping.duid || <span className="text-muted-foreground">—</span>}
                                   </TableCell>
                                   <TableCell className="font-mono">
                                     {mapping.ip_address || <span className="text-muted-foreground">—</span>}
@@ -1276,7 +1289,6 @@ function DHCPPageInner() {
           )}
         </div>
 
-        {/* Modals */}
         <CreateDHCPServerModal
           open={createModalOpen || !!addingSubnetToNetwork}
           onOpenChange={(open) => {
@@ -1292,6 +1304,18 @@ function DHCPPageInner() {
           capabilities={capabilities}
           existingNetwork={addingSubnetToNetwork || undefined}
         />
+
+        {config && (
+          <DHCPServerSettingsModal
+            open={settingsModalOpen}
+            onOpenChange={setSettingsModalOpen}
+            onSuccess={() => {
+              fetchConfig(true);
+            }}
+            globalConfig={config.global_config}
+            capabilities={capabilities}
+          />
+        )}
 
         {editingSubnet && (
           <EditDHCPServerModal
@@ -1342,6 +1366,7 @@ function DHCPPageInner() {
             networkName={editingStaticMapping.network}
             subnet={editingStaticMapping.subnet}
             mapping={editingStaticMapping.mapping}
+            capabilities={capabilities}
             onSuccess={() => {
               fetchConfig(true);
               fetchLeases();
@@ -1416,6 +1441,7 @@ function DHCPPageInner() {
               // Switch to Static Mappings tab to show the new mapping
               setActiveTab("static");
             }}
+            capabilities={capabilities}
           />
         )}
 

--- a/frontend/src/components/services/AddStaticMappingModal.tsx
+++ b/frontend/src/components/services/AddStaticMappingModal.tsx
@@ -20,13 +20,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { AlertCircle, Network, Plus } from "lucide-react";
-import { dhcpService, type DHCPSharedNetwork } from "@/lib/api/dhcp";
+import { dhcpService, type DHCPSharedNetwork, type DHCPCapabilitiesResponse } from "@/lib/api/dhcp";
 
 interface AddStaticMappingModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
   network: DHCPSharedNetwork;
+  capabilities?: DHCPCapabilitiesResponse | null;
 }
 
 export function AddStaticMappingModal({
@@ -34,6 +35,7 @@ export function AddStaticMappingModal({
   onOpenChange,
   onSuccess,
   network,
+  capabilities,
 }: AddStaticMappingModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,6 +45,7 @@ export function AddStaticMappingModal({
   const [mappingName, setMappingName] = useState("");
   const [ipAddress, setIpAddress] = useState("");
   const [macAddress, setMacAddress] = useState("");
+  const [duid, setDuid] = useState("");
   const [description, setDescription] = useState("");
 
   // Reset form when modal opens
@@ -52,6 +55,7 @@ export function AddStaticMappingModal({
       setMappingName("");
       setIpAddress("");
       setMacAddress("");
+      setDuid("");
       setDescription("");
       // Auto-select subnet if there's only one
       if (network.subnets.length === 1) {
@@ -102,15 +106,19 @@ export function AddStaticMappingModal({
       return false;
     }
 
-    // Validate MAC address
-    if (!macAddress.trim()) {
-      setError("MAC address is required");
+    const canDuid = capabilities?.fields.static_mapping_duid?.supported ?? false;
+
+    // Identify the host by MAC and/or DUID
+    if (!macAddress.trim() && !(canDuid && duid.trim())) {
+      setError(canDuid ? "MAC address or DUID is required" : "MAC address is required");
       return false;
     }
-    const macPattern = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
-    if (!macPattern.test(macAddress.trim())) {
-      setError("Invalid MAC address format (expected: XX:XX:XX:XX:XX:XX)");
-      return false;
+    if (macAddress.trim()) {
+      const macPattern = /^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/;
+      if (!macPattern.test(macAddress.trim())) {
+        setError("Invalid MAC address format (expected: XX:XX:XX:XX:XX:XX)");
+        return false;
+      }
     }
 
     return true;
@@ -129,7 +137,8 @@ export function AddStaticMappingModal({
         mappingName.trim(),
         ipAddress.trim(),
         macAddress.trim(),
-        description.trim() || undefined
+        description.trim() || undefined,
+        duid.trim() || undefined
       );
 
       handleClose();
@@ -226,6 +235,22 @@ export function AddStaticMappingModal({
               The hardware MAC address of the device
             </p>
           </div>
+
+          {capabilities?.fields.static_mapping_duid?.supported && (
+            <div className="space-y-2">
+              <Label htmlFor="duid">DUID</Label>
+              <Input
+                id="duid"
+                placeholder="e.g., 00:01:00:01:2a:3b:4c:5d:6e:7f"
+                value={duid}
+                onChange={(e) => setDuid(e.target.value)}
+                className="font-mono"
+              />
+              <p className="text-xs text-muted-foreground">
+                Client DUID. Use this instead of or with a MAC address.
+              </p>
+            </div>
+          )}
 
           {/* Description */}
           <div className="space-y-2">

--- a/frontend/src/components/services/DHCPServerSettingsModal.tsx
+++ b/frontend/src/components/services/DHCPServerSettingsModal.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { AlertCircle, Plus, Settings2, X } from "lucide-react";
+import { InterfaceSelect } from "@/components/ui/interface-select";
+import {
+  dhcpService,
+  type DHCPCapabilitiesResponse,
+  type DHCPGlobalConfig,
+} from "@/lib/api/dhcp";
+
+interface DHCPServerSettingsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  globalConfig: DHCPGlobalConfig;
+  capabilities: DHCPCapabilitiesResponse | null;
+}
+
+export function DHCPServerSettingsModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  globalConfig,
+  capabilities,
+}: DHCPServerSettingsModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [listenAddresses, setListenAddresses] = useState<string[]>([]);
+  const [listenInterfaces, setListenInterfaces] = useState<string[]>([]);
+  const [addressInput, setAddressInput] = useState("");
+  const [ifacePick, setIfacePick] = useState("__none__");
+  const [hostfileUpdate, setHostfileUpdate] = useState(false);
+  const [hostDeclName, setHostDeclName] = useState(false);
+
+  const canListenInterface = capabilities?.fields.listen_interface?.supported ?? false;
+  const canHostDeclName = capabilities?.fields.host_decl_name?.supported ?? false;
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setListenAddresses([...(globalConfig.listen_addresses ?? [])]);
+    setListenInterfaces([...(globalConfig.listen_interfaces ?? [])]);
+    setAddressInput("");
+    setIfacePick("__none__");
+    setHostfileUpdate(globalConfig.hostfile_update);
+    setHostDeclName(globalConfig.host_decl_name);
+  }, [open, globalConfig]);
+
+  const addAddress = () => {
+    const v = addressInput.trim();
+    if (!v) return;
+    if (!listenAddresses.includes(v)) setListenAddresses([...listenAddresses, v]);
+    setAddressInput("");
+  };
+
+  const addInterface = (value: string) => {
+    setIfacePick("__none__");
+    if (value === "__none__" || listenInterfaces.includes(value)) return;
+    setListenInterfaces([...listenInterfaces, value]);
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await dhcpService.saveGlobalSettings(globalConfig, {
+        ...globalConfig,
+        listen_addresses: listenAddresses,
+        listen_interfaces: canListenInterface ? listenInterfaces : (globalConfig.listen_interfaces ?? []),
+        hostfile_update: hostfileUpdate,
+        host_decl_name: canHostDeclName ? hostDeclName : globalConfig.host_decl_name,
+      });
+      if (!result.success) {
+        setError(result.error ?? "Failed to save server settings");
+        setLoading(false);
+        return;
+      }
+      onOpenChange(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save server settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Settings2 className="h-5 w-5" />
+            DHCP Server Settings
+          </DialogTitle>
+          <DialogDescription>
+            Bind the DHCP listener and toggle host-file options
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label>Listen addresses</Label>
+            <div className="flex gap-2">
+              <Input
+                placeholder="192.168.1.1"
+                value={addressInput}
+                onChange={(e) => setAddressInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    addAddress();
+                  }
+                }}
+                className="font-mono"
+              />
+              <Button type="button" variant="outline" size="icon" onClick={addAddress}>
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {listenAddresses.map((addr) => (
+                <Badge key={addr} variant="outline" className="font-mono gap-1">
+                  {addr}
+                  <button type="button" onClick={() => setListenAddresses(listenAddresses.filter((a) => a !== addr))}>
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          {canListenInterface && (
+            <div className="space-y-2">
+              <Label>Listen interfaces</Label>
+              <InterfaceSelect
+                value={ifacePick}
+                onValueChange={addInterface}
+                noneOption={{ label: "Add interface", value: "__none__" }}
+                placeholder="Select interface"
+              />
+              <div className="flex flex-wrap gap-1.5">
+                {listenInterfaces.map((iface) => (
+                  <Badge key={iface} variant="outline" className="font-mono gap-1">
+                    {iface}
+                    <button type="button" onClick={() => setListenInterfaces(listenInterfaces.filter((i) => i !== iface))}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="hostfile-update"
+              checked={hostfileUpdate}
+              onCheckedChange={(v) => setHostfileUpdate(Boolean(v))}
+            />
+            <Label htmlFor="hostfile-update" className="cursor-pointer">
+              Update hosts file from leases
+            </Label>
+          </div>
+
+          {canHostDeclName && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="host-decl-name"
+                checked={hostDeclName}
+                onCheckedChange={(v) => setHostDeclName(Boolean(v))}
+              />
+              <Label htmlFor="host-decl-name" className="cursor-pointer">
+                Use host declaration name
+              </Label>
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+              <AlertCircle className="h-4 w-4 text-destructive" />
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/services/EditStaticMappingModal.tsx
+++ b/frontend/src/components/services/EditStaticMappingModal.tsx
@@ -15,7 +15,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { AlertCircle, Monitor, Network } from "lucide-react";
-import { dhcpService, type DHCPStaticMapping } from "@/lib/api/dhcp";
+import { dhcpService, type DHCPStaticMapping, type DHCPCapabilitiesResponse } from "@/lib/api/dhcp";
 
 interface EditStaticMappingModalProps {
   open: boolean;
@@ -24,6 +24,7 @@ interface EditStaticMappingModalProps {
   networkName: string;
   subnet: string;
   mapping: DHCPStaticMapping;
+  capabilities?: DHCPCapabilitiesResponse | null;
 }
 
 export function EditStaticMappingModal({
@@ -33,6 +34,7 @@ export function EditStaticMappingModal({
   networkName,
   subnet,
   mapping,
+  capabilities,
 }: EditStaticMappingModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -40,6 +42,7 @@ export function EditStaticMappingModal({
   // Form fields
   const [ipAddress, setIpAddress] = useState("");
   const [macAddress, setMacAddress] = useState("");
+  const [duid, setDuid] = useState("");
   const [disabled, setDisabled] = useState(false);
   const [description, setDescription] = useState("");
 
@@ -48,6 +51,7 @@ export function EditStaticMappingModal({
     if (open && mapping) {
       setIpAddress(mapping.ip_address || "");
       setMacAddress(mapping.mac_address || "");
+      setDuid(mapping.duid || "");
       setDisabled(mapping.disable);
       setDescription(mapping.description ?? "");
       setError(null);
@@ -96,10 +100,12 @@ export function EditStaticMappingModal({
       const config: {
         ip_address?: string;
         mac_address?: string;
+        duid?: string;
         disable?: boolean;
         description?: string;
         delete_ip_address?: boolean;
         delete_mac_address?: boolean;
+        delete_duid?: boolean;
         delete_description?: boolean;
       } = {};
 
@@ -122,6 +128,16 @@ export function EditStaticMappingModal({
           config.mac_address = newMac;
         } else if (oldMac) {
           config.delete_mac_address = true;
+        }
+      }
+
+      const newDuid = duid.trim();
+      const oldDuid = mapping.duid || "";
+      if (newDuid !== oldDuid) {
+        if (newDuid) {
+          config.duid = newDuid;
+        } else if (oldDuid) {
+          config.delete_duid = true;
         }
       }
 
@@ -220,6 +236,19 @@ export function EditStaticMappingModal({
               The MAC address of the device (format: XX:XX:XX:XX:XX:XX)
             </p>
           </div>
+
+          {capabilities?.fields.static_mapping_duid?.supported && (
+            <div className="space-y-2">
+              <Label htmlFor="duid">DUID</Label>
+              <Input
+                id="duid"
+                placeholder="e.g., 00:01:00:01:2a:3b:4c:5d:6e:7f"
+                value={duid}
+                onChange={(e) => setDuid(e.target.value)}
+                className="font-mono"
+              />
+            </div>
+          )}
 
           {/* Disabled Toggle */}
           <div className="flex items-center gap-3 rounded-lg border p-4">

--- a/frontend/src/lib/api/dhcp.ts
+++ b/frontend/src/lib/api/dhcp.ts
@@ -15,6 +15,7 @@ export interface DHCPStaticMapping {
   name: string;
   ip_address?: string;
   mac_address?: string;
+  duid?: string;
   disable: boolean;
   description?: string;
 }
@@ -68,6 +69,7 @@ export interface DHCPFailoverConfig {
 export interface DHCPGlobalConfig {
   disable?: boolean;
   listen_addresses: string[];
+  listen_interfaces: string[];
   hostfile_update: boolean;
   host_decl_name: boolean;
 }
@@ -139,6 +141,11 @@ export interface DHCPCapabilitiesResponse {
     // Disable / description
     description: DHCPFieldCapability;
     global_disable: DHCPFieldCapability;
+    listen_address: DHCPFieldCapability;
+    listen_interface: DHCPFieldCapability;
+    hostfile_update: DHCPFieldCapability;
+    host_decl_name: DHCPFieldCapability;
+    static_mapping_duid: DHCPFieldCapability;
     network_disable: DHCPFieldCapability;
     subnet_disable: DHCPFieldCapability;
   };
@@ -747,18 +754,27 @@ class DHCPService {
     mapping_name: string,
     ip_address: string,
     mac_address: string,
-    description?: string
+    description?: string,
+    duid?: string
   ): Promise<VyOSResponse> {
     const operations: DHCPBatchOperation[] = [
       {
         op: "set_static_mapping_ip_address",
         value: `${mapping_name}|${ip_address}`,
       },
-      {
+    ];
+    if (mac_address.trim()) {
+      operations.push({
         op: "set_static_mapping_mac_address",
         value: `${mapping_name}|${mac_address}`,
-      },
-    ];
+      });
+    }
+    if (duid?.trim()) {
+      operations.push({
+        op: "set_static_mapping_duid",
+        value: `${mapping_name}|${duid.trim()}`,
+      });
+    }
     if (description?.trim()) {
       operations.push({
         op: "set_static_mapping_description",
@@ -783,10 +799,12 @@ class DHCPService {
     config: {
       ip_address?: string;
       mac_address?: string;
+      duid?: string;
       disable?: boolean;
       description?: string;
       delete_ip_address?: boolean;
       delete_mac_address?: boolean;
+      delete_duid?: boolean;
       delete_description?: boolean;
     }
   ): Promise<VyOSResponse> {
@@ -815,6 +833,18 @@ class DHCPService {
       operations.push({
         op: "set_static_mapping_mac_address",
         value: `${mapping_name}|${config.mac_address}`,
+      });
+    }
+
+    if (config.delete_duid) {
+      operations.push({
+        op: "delete_static_mapping_duid",
+        value: mapping_name,
+      });
+    } else if (config.duid) {
+      operations.push({
+        op: "set_static_mapping_duid",
+        value: `${mapping_name}|${config.duid}`,
       });
     }
 
@@ -882,6 +912,42 @@ class DHCPService {
     return this.batchConfigure({
       network_name: "_global",
       operations: [{ op: "delete_global_disable" }],
+    });
+  }
+
+  async saveGlobalSettings(
+    original: DHCPGlobalConfig,
+    updated: DHCPGlobalConfig
+  ): Promise<VyOSResponse> {
+    const operations: DHCPBatchOperation[] = [];
+    const addedAddr = updated.listen_addresses.filter((a) => !original.listen_addresses.includes(a));
+    const removedAddr = original.listen_addresses.filter((a) => !updated.listen_addresses.includes(a));
+    for (const a of removedAddr) operations.push({ op: "delete_listen_address", value: a });
+    for (const a of addedAddr) operations.push({ op: "set_listen_address", value: a });
+
+    const origIfaces = original.listen_interfaces ?? [];
+    const nextIfaces = updated.listen_interfaces ?? [];
+    const addedIface = nextIfaces.filter((i) => !origIfaces.includes(i));
+    const removedIface = origIfaces.filter((i) => !nextIfaces.includes(i));
+    for (const i of removedIface) operations.push({ op: "delete_listen_interface", value: i });
+    for (const i of addedIface) operations.push({ op: "set_listen_interface", value: i });
+
+    if (updated.hostfile_update !== original.hostfile_update) {
+      operations.push({
+        op: updated.hostfile_update ? "set_hostfile_update" : "delete_hostfile_update",
+      });
+    }
+    if (updated.host_decl_name !== original.host_decl_name) {
+      operations.push({
+        op: updated.host_decl_name ? "set_host_decl_name" : "delete_host_decl_name",
+      });
+    }
+    if (operations.length === 0) {
+      return { success: true };
+    }
+    return this.batchConfigure({
+      network_name: "_global",
+      operations,
     });
   }
 


### PR DESCRIPTION
The DHCP page never showed listen-address, hostfile-update, or host-decl-name even though the builder already knew those nodes. 1.5 listen-interface and static-mapping duid were missing from mapper, capabilities, and UI.

Adds mapper has_* plus raise on version-wrong sets, capabilities from those flags, a server settings dialog, and DUID on add/edit static mapping. Batch maps ValueError to HTTP 400.

Tests: PYTHONPATH=backend uv run --with pytest pytest backend/tests/test_dhcp_version_gates.py backend/tests/test_dhcp_builder_paths.py (52 passed). frontend npx tsc --noEmit clean. npm run lint 0 errors. validate-path.sh: listen-interface and duid INVALID on 1.4 VALID on 1.5; listen-address and hostfile-update VALID on both; host-decl-name VALID on 1.4 INVALID on 1.5.

Closes #648
Closes #649
Closes #652