### PR TITLE
fix: migrate before backend health and pin Prisma 6.19.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ services:
       retries: 5
       start_period: 10s
 
+  migrate:
+    image: ghcr.io/community-vyprojects/vymanager-frontend:beta
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    env_file:
+      - .env
+    restart: "no"
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     image: ghcr.io/community-vyprojects/vymanager-backend:beta
     container_name: vymanager-backend
@@ -199,6 +212,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
       interval: 30s
@@ -214,10 +229,10 @@ services:
     env_file:
       - .env
     depends_on:
-      backend:
-        condition: service_healthy
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     restart: unless-stopped
     networks:
       - vymanager-network

--- a/backend/tests/test_published_compose.py
+++ b/backend/tests/test_published_compose.py
@@ -1,0 +1,35 @@
+"""Published compose must migrate before backend health, and Prisma pins must match."""
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+PUBLISHED = [
+    ROOT / "install.sh",
+    ROOT / "README.md",
+    ROOT / "docs-site/docs/getting-started/install-docker.md",
+]
+
+
+def test_published_compose_has_one_shot_migrate_before_backend():
+    for path in PUBLISHED:
+        text = path.read_text()
+        assert "npx prisma migrate deploy" in text, path
+        assert re.search(r"^  migrate:$", text, re.M), path
+        assert text.count("service_completed_successfully") >= 2, path
+        assert "backend:\n        condition: service_healthy" not in text, path
+
+
+def test_prisma_client_and_cli_pins_match():
+    pkg = json.loads((ROOT / "frontend/package.json").read_text())
+    client = pkg["dependencies"]["@prisma/client"]
+    cli = pkg["devDependencies"]["prisma"]
+    assert client == cli
+    lock = json.loads((ROOT / "frontend/package-lock.json").read_text())
+    assert lock["packages"][""]["dependencies"]["@prisma/client"] == client
+    assert lock["packages"][""]["devDependencies"]["prisma"] == cli
+    assert lock["packages"]["node_modules/@prisma/client"]["version"] == client
+    assert lock["packages"]["node_modules/prisma"]["version"] == cli

--- a/docs-site/docs/getting-started/install-docker.md
+++ b/docs-site/docs/getting-started/install-docker.md
@@ -57,6 +57,19 @@ services:
       retries: 5
       start_period: 10s
 
+  migrate:
+    image: ghcr.io/community-vyprojects/vymanager-frontend:beta
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    env_file:
+      - .env
+    restart: "no"
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     image: ghcr.io/community-vyprojects/vymanager-backend:beta
     container_name: vymanager-backend
@@ -72,6 +85,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
       interval: 30s
@@ -87,10 +102,10 @@ services:
     env_file:
       - .env
     depends_on:
-      backend:
-        condition: service_healthy
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     restart: unless-stopped
     networks:
       - vymanager-network

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@prisma/client": "6.19.1",
+        "@prisma/client": "6.19.3",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.1.tgz",
-      "integrity": "sha512-4SXj4Oo6HyQkLUWT8Ke5R0PTAfVOKip5Roo+6+b2EDTkFg5be0FnBWiuRJc0BC0sRQIWGMLKW1XguhVfW/z3/A==",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@prisma/client": "6.19.1",
+    "@prisma/client": "6.19.3",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/install.sh
+++ b/install.sh
@@ -273,6 +273,19 @@ services:
       retries: 5
       start_period: 10s
 
+  migrate:
+    image: ${REGISTRY}-frontend:beta
+    container_name: vymanager-migrate
+    entrypoint: ["sh", "-c", "npx prisma generate && npx prisma migrate deploy"]
+    env_file:
+      - .env
+    restart: "no"
+    networks:
+      - vymanager
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   backend:
     image: ${REGISTRY}-backend:beta
     container_name: vymanager-backend
@@ -286,6 +299,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]
       interval: 30s
@@ -304,10 +319,10 @@ services:
     networks:
       - vymanager
     depends_on:
-      backend:
-        condition: service_healthy
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
 networks:
   vymanager:


### PR DESCRIPTION
Published compose waited for a healthy backend before starting frontend. Backend lifespan needs tables that prisma migrate deploy in the frontend image creates, so first boot and old volumes never migrate. README, install.sh, and the docker install page now run a one-shot migrate service before backend and frontend, matching container/vymanager-prod.

@prisma/client was 6.19.1 while prisma was 6.19.3. Both pins and the lockfile are 6.19.3.

Tests: PYTHONPATH=backend uv run --with pytest pytest backend/tests/test_published_compose.py (2 passed).

Closes #645
Closes #657