### PR TITLE
fix: expose DHCP DDNS and HA peer settings

### DIFF
--- a/backend/routers/dhcp/dhcp.py
+++ b/backend/routers/dhcp/dhcp.py
@@ -24,6 +24,60 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/vyos/dhcp", tags=["dhcp"])
 
 
+def _parse_ddns_domains(raw: Any) -> List["DHCPDdnsDomain"]:
+    if not isinstance(raw, dict):
+        return []
+    domains: List[DHCPDdnsDomain] = []
+    for name, data in raw.items():
+        node = data if isinstance(data, dict) else {}
+        servers: List[DHCPDdnsDnsServer] = []
+        dns_raw = node.get("dns-server", {})
+        if isinstance(dns_raw, dict):
+            for sid, sdata in dns_raw.items():
+                snode = sdata if isinstance(sdata, dict) else {}
+                servers.append(
+                    DHCPDdnsDnsServer(
+                        id=str(sid),
+                        address=snode.get("address"),
+                        port=str(snode["port"]) if "port" in snode else None,
+                    )
+                )
+        domains.append(
+            DHCPDdnsDomain(
+                name=name,
+                key_name=node.get("key-name"),
+                dns_servers=servers,
+            )
+        )
+    return domains
+
+
+def _parse_dhcp_ddns(raw: Any) -> "DHCPDdnsConfig":
+    if raw is None:
+        return DHCPDdnsConfig(present=False)
+    if not isinstance(raw, dict):
+        return DHCPDdnsConfig(present=True)
+    keys: List[DHCPDdnsTsigKey] = []
+    tsig_raw = raw.get("tsig-key", {})
+    if isinstance(tsig_raw, dict):
+        for name, data in tsig_raw.items():
+            node = data if isinstance(data, dict) else {}
+            keys.append(
+                DHCPDdnsTsigKey(
+                    name=name,
+                    algorithm=node.get("algorithm"),
+                    secret=node.get("secret"),
+                )
+            )
+    return DHCPDdnsConfig(
+        present=True,
+        send_updates=raw.get("send-updates"),
+        tsig_keys=keys,
+        forward_domains=_parse_ddns_domains(raw.get("forward-domain")),
+        reverse_domains=_parse_ddns_domains(raw.get("reverse-domain")),
+    )
+
+
 # ============================================================================
 # Request/Response Models
 # ============================================================================
@@ -101,6 +155,34 @@ class DHCPFailoverConfig(BaseModel):
     source_address: Optional[str] = None
     remote: Optional[str] = None
     status: Optional[str] = None  # primary or secondary
+    certificate: Optional[str] = None
+    ca_certificate: Optional[str] = None
+
+
+class DHCPDdnsDnsServer(BaseModel):
+    id: str
+    address: Optional[str] = None
+    port: Optional[str] = None
+
+
+class DHCPDdnsDomain(BaseModel):
+    name: str
+    key_name: Optional[str] = None
+    dns_servers: List[DHCPDdnsDnsServer] = []
+
+
+class DHCPDdnsTsigKey(BaseModel):
+    name: str
+    algorithm: Optional[str] = None
+    secret: Optional[str] = None
+
+
+class DHCPDdnsConfig(BaseModel):
+    present: bool = False
+    send_updates: Optional[str] = None
+    tsig_keys: List[DHCPDdnsTsigKey] = []
+    forward_domains: List[DHCPDdnsDomain] = []
+    reverse_domains: List[DHCPDdnsDomain] = []
 
 
 class DHCPGlobalConfig(BaseModel):
@@ -118,6 +200,7 @@ class DHCPConfigResponse(BaseModel):
 
     shared_networks: List[DHCPSharedNetwork] = []
     failover: Optional[DHCPFailoverConfig] = None
+    ddns: DHCPDdnsConfig = DHCPDdnsConfig()
     global_config: DHCPGlobalConfig = DHCPGlobalConfig()
     total_subnets: int = 0
     total_static_mappings: int = 0
@@ -281,7 +364,11 @@ async def get_dhcp_config(http_request: Request, refresh: bool = False):
                 source_address=ha_config.get("source-address"),
                 remote=ha_config.get("remote"),
                 status=ha_config.get("status"),
+                certificate=ha_config.get("certificate"),
+                ca_certificate=ha_config.get("ca-certificate"),
             )
+
+        ddns = _parse_dhcp_ddns(dhcp_config.get("dynamic-dns-update"))
 
         # Parse shared networks
         if "shared-network-name" in dhcp_config:
@@ -565,6 +652,7 @@ async def get_dhcp_config(http_request: Request, refresh: bool = False):
         return DHCPConfigResponse(
             shared_networks=shared_networks,
             failover=failover,
+            ddns=ddns,
             global_config=global_config,
             total_subnets=total_subnets,
             total_static_mappings=total_static_mappings,

--- a/backend/tests/test_dhcp_builder_paths.py
+++ b/backend/tests/test_dhcp_builder_paths.py
@@ -36,6 +36,16 @@ CASES = [
     ("delete_subnet_ping_check", ("LAN", "192.168.1.0/24"), "delete", SUB + ["ping-check"]),
     ("set_static_mapping_disable", ("LAN", "192.168.1.0/24", "host1"), "set", MAP + ["disable"]),
     ("delete_static_mapping_disable", ("LAN", "192.168.1.0/24", "host1"), "delete", MAP + ["disable"]),
+    ("set_failover_mode", ("active-active",), "set", BASE + ["high-availability", "mode", "active-active"]),
+    ("delete_failover_mode", (), "delete", BASE + ["high-availability", "mode"]),
+    ("set_failover_name", ("peer1",), "set", BASE + ["high-availability", "name", "peer1"]),
+    ("delete_failover_name", (), "delete", BASE + ["high-availability", "name"]),
+    ("set_failover_remote", ("192.0.2.1",), "set", BASE + ["high-availability", "remote", "192.0.2.1"]),
+    ("delete_failover_remote", (), "delete", BASE + ["high-availability", "remote"]),
+    ("set_failover_source_address", ("192.0.2.2",), "set", BASE + ["high-availability", "source-address", "192.0.2.2"]),
+    ("delete_failover_source_address", (), "delete", BASE + ["high-availability", "source-address"]),
+    ("set_failover_status", ("primary",), "set", BASE + ["high-availability", "status", "primary"]),
+    ("delete_failover_status", (), "delete", BASE + ["high-availability", "status"]),
 ]
 
 

--- a/backend/tests/test_dhcp_version_gates.py
+++ b/backend/tests/test_dhcp_version_gates.py
@@ -12,6 +12,8 @@ def test_v15_rejects_14_only_sets():
         mapper.get_host_decl_name()
     with pytest.raises(ValueError, match="not supported"):
         mapper.get_subnet_enable_failover("LAN", "192.168.1.0/24")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_dynamic_dns_update()
 
 
 def test_v15_delete_helpers_stay_unguarded():
@@ -26,6 +28,12 @@ def test_v14_rejects_15_only_sets():
         mapper.get_listen_interface("eth0")
     with pytest.raises(ValueError, match="not supported"):
         mapper.get_static_mapping_duid("LAN", "192.168.1.0/24", "host1", "00:01:02")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_failover_certificate("FOO")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_ddns_send_updates("enable")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_ddns_domain("forward-domain", "example.com")
 
 
 def test_v15_emits_listen_interface_and_duid():
@@ -85,6 +93,14 @@ def test_capabilities_read_mapper_flags():
     assert f15["hostfile_update"]["supported"] is True
     assert f14["time_offset"]["supported"] is True
     assert f15["time_offset"]["supported"] is True
+    assert f14["dynamic_dns_update_leaf"]["supported"] is True
+    assert f15["dynamic_dns_update_leaf"]["supported"] is False
+    assert f14["dynamic_dns_update_kea"]["supported"] is False
+    assert f15["dynamic_dns_update_kea"]["supported"] is True
+    assert f14["failover"]["supported"] is True
+    assert f15["failover"]["supported"] is True
+    assert f14["failover_certificate"]["supported"] is False
+    assert f15["failover_certificate"]["supported"] is True
 
 
 def test_v15_builder_emits_listen_interface_and_duid():
@@ -102,3 +118,33 @@ def test_v14_builder_rejects_listen_interface_and_duid():
         builder.set_listen_interface("eth0")
     with pytest.raises(ValueError, match="not supported"):
         builder.set_static_mapping_duid("LAN", "192.168.1.0/24", "host1", "00:01:02")
+
+
+def test_v15_emits_ddns_kea_and_ha_certs():
+    mapper = DHCPMapper("1.5")
+    assert mapper.get_ddns_send_updates("enable")[-2:] == ["send-updates", "enable"]
+    assert mapper.get_ddns_tsig_key_algorithm("k1", "sha256")[-2:] == ["algorithm", "sha256"]
+    assert mapper.get_ddns_domain_dns_server_address(
+        "forward-domain", "example.com", "1", "192.0.2.53"
+    )[-2:] == ["address", "192.0.2.53"]
+    assert mapper.get_failover_certificate("FOO")[-1] == "FOO"
+    assert mapper.get_failover_ca_certificate("CA1")[-1] == "CA1"
+
+
+def test_v14_emits_ddns_leaf():
+    mapper = DHCPMapper("1.4")
+    assert mapper.get_dynamic_dns_update() == ["service", "dhcp-server", "dynamic-dns-update"]
+
+
+def test_v14_builder_rejects_ddns_kea_and_ha_certs():
+    builder = DHCPBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_ddns_send_updates("enable")
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_failover_certificate("FOO")
+
+
+def test_v15_builder_rejects_ddns_leaf():
+    builder = DHCPBatchBuilder(version="1.5")
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_dynamic_dns_update()

--- a/backend/vyos_builders/dhcp/dhcp.py
+++ b/backend/vyos_builders/dhcp/dhcp.py
@@ -806,6 +806,94 @@ class DHCPBatchBuilder(BatchBuilder):
         path = self.mappers[self.mapper_key].get_failover_status_path()
         return self.add_delete(path)
 
+    def set_failover_certificate(self, name: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_failover_certificate(name)
+        return self.add_set(path)
+
+    def delete_failover_certificate(self) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_failover_certificate_path()
+        return self.add_delete(path)
+
+    def set_failover_ca_certificate(self, name: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_failover_ca_certificate(name)
+        return self.add_set(path)
+
+    def delete_failover_ca_certificate(self) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_failover_ca_certificate_path()
+        return self.add_delete(path)
+
+    def set_dynamic_dns_update(self) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_dynamic_dns_update()
+        return self.add_set(path)
+
+    def delete_dynamic_dns_update(self) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_dynamic_dns_update_path()
+        return self.add_delete(path)
+
+    def set_ddns_send_updates(self, value: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_send_updates(value)
+        return self.add_set(path)
+
+    def delete_ddns_send_updates(self) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_send_updates_path()
+        return self.add_delete(path)
+
+    def set_ddns_tsig_key(self, name: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_tsig_key(name)
+        return self.add_set(path)
+
+    def delete_ddns_tsig_key(self, name: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_tsig_key_path(name)
+        return self.add_delete(path)
+
+    def set_ddns_tsig_key_algorithm(self, name: str, algorithm: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_tsig_key_algorithm(name, algorithm)
+        return self.add_set(path)
+
+    def set_ddns_tsig_key_secret(self, name: str, secret: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_tsig_key_secret(name, secret)
+        return self.add_set(path)
+
+    def set_ddns_domain(self, kind: str, domain: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain(kind, domain)
+        return self.add_set(path)
+
+    def delete_ddns_domain(self, kind: str, domain: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain_path(kind, domain)
+        return self.add_delete(path)
+
+    def set_ddns_domain_key_name(self, kind: str, domain: str, key_name: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain_key_name(kind, domain, key_name)
+        return self.add_set(path)
+
+    def delete_ddns_domain_key_name(self, kind: str, domain: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain_key_name_path(kind, domain)
+        return self.add_delete(path)
+
+    def set_ddns_domain_dns_server_address(
+        self, kind: str, domain: str, server_id: str, address: str
+    ) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain_dns_server_address(
+            kind, domain, server_id, address
+        )
+        return self.add_set(path)
+
+    def set_ddns_domain_dns_server_port(
+        self, kind: str, domain: str, server_id: str, port: str
+    ) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain_dns_server_port(
+            kind, domain, server_id, port
+        )
+        return self.add_set(path)
+
+    def delete_ddns_domain_dns_server(
+        self, kind: str, domain: str, server_id: str
+    ) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_domain_dns_server_path(
+            kind, domain, server_id
+        )
+        return self.add_delete(path)
+
     # ========================================================================
     # Capabilities
     # ========================================================================
@@ -871,6 +959,22 @@ class DHCPBatchBuilder(BatchBuilder):
                 "static_mapping_duid": {
                     "supported": mapper.has_static_mapping_duid(),
                     "description": "Identify a static mapping by DUID",
+                },
+                "failover": {
+                    "supported": True,
+                    "description": "DHCP high-availability peer",
+                },
+                "failover_certificate": {
+                    "supported": mapper.has_failover_certificate(),
+                    "description": "TLS certificate for DHCP high availability",
+                },
+                "dynamic_dns_update_leaf": {
+                    "supported": mapper.has_dynamic_dns_update_leaf(),
+                    "description": "Enable DHCP dynamic DNS updates",
+                },
+                "dynamic_dns_update_kea": {
+                    "supported": mapper.has_dynamic_dns_update_kea(),
+                    "description": "Kea dynamic DNS update settings",
                 },
                 "network_disable": {
                     "supported": True,

--- a/backend/vyos_mappers/dhcp/dhcp.py
+++ b/backend/vyos_mappers/dhcp/dhcp.py
@@ -63,6 +63,15 @@ class DHCPMapper(BaseFeatureMapper):
     def has_subnet_disable(self) -> bool:
         return "1.4" not in self.version
 
+    def has_dynamic_dns_update_leaf(self) -> bool:
+        return "1.4" in self.version
+
+    def has_dynamic_dns_update_kea(self) -> bool:
+        return "1.4" not in self.version
+
+    def has_failover_certificate(self) -> bool:
+        return "1.4" not in self.version
+
     def has_time_offset(self) -> bool:
         return True
 
@@ -781,6 +790,141 @@ class DHCPMapper(BaseFeatureMapper):
     def get_failover_status_path(self) -> List[str]:
         """Get command path for failover status deletion."""
         return ["service", "dhcp-server", "high-availability", "status"]
+
+    def get_failover_certificate(self, name: str) -> List[str]:
+        if not self.has_failover_certificate():
+            raise ValueError("high-availability certificate is not supported on this device")
+        return ["service", "dhcp-server", "high-availability", "certificate", name]
+
+    def get_failover_certificate_path(self) -> List[str]:
+        return ["service", "dhcp-server", "high-availability", "certificate"]
+
+    def get_failover_ca_certificate(self, name: str) -> List[str]:
+        if not self.has_failover_certificate():
+            raise ValueError("high-availability ca-certificate is not supported on this device")
+        return ["service", "dhcp-server", "high-availability", "ca-certificate", name]
+
+    def get_failover_ca_certificate_path(self) -> List[str]:
+        return ["service", "dhcp-server", "high-availability", "ca-certificate"]
+
+    def get_dynamic_dns_update(self) -> List[str]:
+        if not self.has_dynamic_dns_update_leaf():
+            raise ValueError("dynamic-dns-update leaf is not supported on this device")
+        return ["service", "dhcp-server", "dynamic-dns-update"]
+
+    def get_dynamic_dns_update_path(self) -> List[str]:
+        return ["service", "dhcp-server", "dynamic-dns-update"]
+
+    def _require_ddns_kea(self) -> None:
+        if not self.has_dynamic_dns_update_kea():
+            raise ValueError("Kea dynamic-dns-update is not supported on this device")
+
+    def get_ddns_send_updates(self, value: str) -> List[str]:
+        self._require_ddns_kea()
+        return ["service", "dhcp-server", "dynamic-dns-update", "send-updates", value]
+
+    def get_ddns_send_updates_path(self) -> List[str]:
+        return ["service", "dhcp-server", "dynamic-dns-update", "send-updates"]
+
+    def get_ddns_tsig_key(self, name: str) -> List[str]:
+        self._require_ddns_kea()
+        return ["service", "dhcp-server", "dynamic-dns-update", "tsig-key", name]
+
+    def get_ddns_tsig_key_path(self, name: str) -> List[str]:
+        return ["service", "dhcp-server", "dynamic-dns-update", "tsig-key", name]
+
+    def get_ddns_tsig_key_algorithm(self, name: str, algorithm: str) -> List[str]:
+        self._require_ddns_kea()
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", "tsig-key", name,
+            "algorithm", algorithm,
+        ]
+
+    def get_ddns_tsig_key_algorithm_path(self, name: str) -> List[str]:
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", "tsig-key", name, "algorithm",
+        ]
+
+    def get_ddns_tsig_key_secret(self, name: str, secret: str) -> List[str]:
+        self._require_ddns_kea()
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", "tsig-key", name,
+            "secret", secret,
+        ]
+
+    def get_ddns_tsig_key_secret_path(self, name: str) -> List[str]:
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", "tsig-key", name, "secret",
+        ]
+
+    def get_ddns_domain(self, kind: str, domain: str) -> List[str]:
+        self._require_ddns_kea()
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return ["service", "dhcp-server", "dynamic-dns-update", kind, domain]
+
+    def get_ddns_domain_path(self, kind: str, domain: str) -> List[str]:
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return ["service", "dhcp-server", "dynamic-dns-update", kind, domain]
+
+    def get_ddns_domain_key_name(self, kind: str, domain: str, key_name: str) -> List[str]:
+        self._require_ddns_kea()
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", kind, domain,
+            "key-name", key_name,
+        ]
+
+    def get_ddns_domain_key_name_path(self, kind: str, domain: str) -> List[str]:
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", kind, domain, "key-name",
+        ]
+
+    def get_ddns_domain_dns_server_address(
+        self, kind: str, domain: str, server_id: str, address: str
+    ) -> List[str]:
+        self._require_ddns_kea()
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", kind, domain,
+            "dns-server", server_id, "address", address,
+        ]
+
+    def get_ddns_domain_dns_server_address_path(
+        self, kind: str, domain: str, server_id: str
+    ) -> List[str]:
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", kind, domain,
+            "dns-server", server_id, "address",
+        ]
+
+    def get_ddns_domain_dns_server_port(
+        self, kind: str, domain: str, server_id: str, port: str
+    ) -> List[str]:
+        self._require_ddns_kea()
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", kind, domain,
+            "dns-server", server_id, "port", port,
+        ]
+
+    def get_ddns_domain_dns_server_path(
+        self, kind: str, domain: str, server_id: str
+    ) -> List[str]:
+        if kind not in ("forward-domain", "reverse-domain"):
+            raise ValueError("invalid DDNS domain kind")
+        return [
+            "service", "dhcp-server", "dynamic-dns-update", kind, domain,
+            "dns-server", server_id,
+        ]
 
     # ==================== Version-Specific Delegates ====================
 

--- a/frontend/src/app/network/dhcp/page.tsx
+++ b/frontend/src/app/network/dhcp/page.tsx
@@ -57,6 +57,8 @@ import { AddLeaseToStaticMappingModal } from "@/components/services/AddLeaseToSt
 import { AddRangeModal } from "@/components/services/AddRangeModal";
 import { AddStaticMappingModal } from "@/components/services/AddStaticMappingModal";
 import { DHCPServerSettingsModal } from "@/components/services/DHCPServerSettingsModal";
+import { DHCPFailoverModal } from "@/components/services/DHCPFailoverModal";
+import { DHCPDdnsModal } from "@/components/services/DHCPDdnsModal";
 import { EditRangeModal } from "@/components/services/EditRangeModal";
 import { ChevronRight } from "lucide-react";
 
@@ -113,6 +115,8 @@ function DHCPPageInner() {
   // Modal states
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
+  const [failoverModalOpen, setFailoverModalOpen] = useState(false);
+  const [ddnsModalOpen, setDdnsModalOpen] = useState(false);
   const [addingSubnetToNetwork, setAddingSubnetToNetwork] = useState<string | null>(null);
   const [editingSubnet, setEditingSubnet] = useState<{
     network: string;
@@ -444,6 +448,27 @@ function DHCPPageInner() {
               <Settings2 className="h-4 w-4 mr-2" />
               Server settings
             </Button>
+            <Button
+              className="w-full mt-2"
+              size="sm"
+              variant="outline"
+              onClick={() => setFailoverModalOpen(true)}
+              disabled={!config}
+            >
+              High availability
+            </Button>
+            {(capabilities?.fields.dynamic_dns_update_leaf?.supported ||
+              capabilities?.fields.dynamic_dns_update_kea?.supported) && (
+              <Button
+                className="w-full mt-2"
+                size="sm"
+                variant="outline"
+                onClick={() => setDdnsModalOpen(true)}
+                disabled={!config}
+              >
+                Dynamic DNS
+              </Button>
+            )}
           </div>
 
           {/* Network List */}
@@ -1313,6 +1338,30 @@ function DHCPPageInner() {
               fetchConfig(true);
             }}
             globalConfig={config.global_config}
+            capabilities={capabilities}
+          />
+        )}
+
+        {config && (
+          <DHCPFailoverModal
+            open={failoverModalOpen}
+            onOpenChange={setFailoverModalOpen}
+            onSuccess={() => {
+              fetchConfig(true);
+            }}
+            failover={config.failover}
+            capabilities={capabilities}
+          />
+        )}
+
+        {config && (
+          <DHCPDdnsModal
+            open={ddnsModalOpen}
+            onOpenChange={setDdnsModalOpen}
+            onSuccess={() => {
+              fetchConfig(true);
+            }}
+            ddns={config.ddns ?? { present: false, tsig_keys: [], forward_domains: [], reverse_domains: [] }}
             capabilities={capabilities}
           />
         )}

--- a/frontend/src/components/services/DHCPDdnsModal.tsx
+++ b/frontend/src/components/services/DHCPDdnsModal.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AlertCircle, Plus, X } from "lucide-react";
+import {
+  dhcpService,
+  type DHCPCapabilitiesResponse,
+  type DHCPDdnsConfig,
+  type DHCPDdnsDomain,
+  type DHCPDdnsTsigKey,
+} from "@/lib/api/dhcp";
+
+interface DHCPDdnsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  ddns: DHCPDdnsConfig;
+  capabilities: DHCPCapabilitiesResponse | null;
+}
+
+const emptyDdns = (): DHCPDdnsConfig => ({
+  present: false,
+  send_updates: "",
+  tsig_keys: [],
+  forward_domains: [],
+  reverse_domains: [],
+});
+
+const ALGOS = ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"];
+
+export function DHCPDdnsModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  ddns,
+  capabilities,
+}: DHCPDdnsModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<DHCPDdnsConfig>(emptyDdns());
+  const leaf = capabilities?.fields.dynamic_dns_update_leaf?.supported ?? false;
+  const kea = capabilities?.fields.dynamic_dns_update_kea?.supported ?? false;
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setForm({
+      present: ddns.present,
+      send_updates: ddns.send_updates ?? "",
+      tsig_keys: ddns.tsig_keys.map((k) => ({ ...k })),
+      forward_domains: ddns.forward_domains.map((d) => ({
+        ...d,
+        dns_servers: d.dns_servers.map((s) => ({ ...s })),
+      })),
+      reverse_domains: ddns.reverse_domains.map((d) => ({
+        ...d,
+        dns_servers: d.dns_servers.map((s) => ({ ...s })),
+      })),
+    });
+  }, [open, ddns]);
+
+  const addKey = () => {
+    setForm((prev) => ({
+      ...prev,
+      present: true,
+      tsig_keys: [...prev.tsig_keys, { name: "", algorithm: "sha256", secret: "" }],
+    }));
+  };
+
+  const updateKey = (index: number, patch: Partial<DHCPDdnsTsigKey>) => {
+    setForm((prev) => ({
+      ...prev,
+      tsig_keys: prev.tsig_keys.map((k, i) => (i === index ? { ...k, ...patch } : k)),
+    }));
+  };
+
+  const addDomain = (kind: "forward_domains" | "reverse_domains") => {
+    setForm((prev) => ({
+      ...prev,
+      present: true,
+      [kind]: [...prev[kind], { name: "", key_name: "", dns_servers: [] }],
+    }));
+  };
+
+  const updateDomain = (
+    kind: "forward_domains" | "reverse_domains",
+    index: number,
+    patch: Partial<DHCPDdnsDomain>
+  ) => {
+    setForm((prev) => ({
+      ...prev,
+      [kind]: prev[kind].map((d, i) => (i === index ? { ...d, ...patch } : d)),
+    }));
+  };
+
+  const addServer = (kind: "forward_domains" | "reverse_domains", index: number) => {
+    setForm((prev) => ({
+      ...prev,
+      [kind]: prev[kind].map((d, i) => {
+        if (i !== index) return d;
+        const nextId = String((d.dns_servers.length || 0) + 1);
+        return {
+          ...d,
+          dns_servers: [...d.dns_servers, { id: nextId, address: "", port: "" }],
+        };
+      }),
+    }));
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await dhcpService.saveDdns(ddns, form, leaf, kea);
+      if (!result.success) {
+        setError(result.error ?? "Failed to save dynamic DNS");
+        setLoading(false);
+        return;
+      }
+      onOpenChange(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save dynamic DNS");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const domainEditor = (title: string, kind: "forward_domains" | "reverse_domains") => (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>{title}</Label>
+        <Button type="button" variant="outline" size="sm" onClick={() => addDomain(kind)}>
+          <Plus className="h-3 w-3 mr-1" />
+          Add
+        </Button>
+      </div>
+      {form[kind].map((domain, index) => (
+        <div key={`${kind}-${index}`} className="border rounded-md p-3 space-y-2">
+          <div className="flex gap-2">
+            <Input
+              className="font-mono"
+              placeholder="example.com"
+              value={domain.name}
+              onChange={(e) => updateDomain(kind, index, { name: e.target.value })}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                setForm((prev) => ({
+                  ...prev,
+                  [kind]: prev[kind].filter((_, i) => i !== index),
+                }))
+              }
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <Input
+            placeholder="TSIG key name"
+            value={domain.key_name ?? ""}
+            onChange={(e) => updateDomain(kind, index, { key_name: e.target.value })}
+          />
+          {domain.dns_servers.map((server, sidx) => (
+            <div key={server.id} className="flex gap-2">
+              <Input
+                className="w-16 font-mono"
+                value={server.id}
+                onChange={(e) => {
+                  const dns_servers = domain.dns_servers.map((s, i) =>
+                    i === sidx ? { ...s, id: e.target.value } : s
+                  );
+                  updateDomain(kind, index, { dns_servers });
+                }}
+              />
+              <Input
+                className="font-mono"
+                placeholder="192.0.2.53"
+                value={server.address ?? ""}
+                onChange={(e) => {
+                  const dns_servers = domain.dns_servers.map((s, i) =>
+                    i === sidx ? { ...s, address: e.target.value } : s
+                  );
+                  updateDomain(kind, index, { dns_servers });
+                }}
+              />
+              <Input
+                className="w-20 font-mono"
+                placeholder="53"
+                value={server.port ?? ""}
+                onChange={(e) => {
+                  const dns_servers = domain.dns_servers.map((s, i) =>
+                    i === sidx ? { ...s, port: e.target.value } : s
+                  );
+                  updateDomain(kind, index, { dns_servers });
+                }}
+              />
+            </div>
+          ))}
+          <Button type="button" variant="ghost" size="sm" onClick={() => addServer(kind, index)}>
+            Add DNS server
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px] max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>DHCP dynamic DNS</DialogTitle>
+          <DialogDescription>Update DNS from DHCP leases</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          {leaf && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="ddns-leaf"
+                checked={form.present}
+                onCheckedChange={(v) => setForm((prev) => ({ ...prev, present: Boolean(v) }))}
+              />
+              <Label htmlFor="ddns-leaf" className="cursor-pointer">
+                Enable dynamic DNS updates
+              </Label>
+            </div>
+          )}
+          {kea && (
+            <>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="ddns-present"
+                  checked={form.present}
+                  onCheckedChange={(v) => setForm((prev) => ({ ...prev, present: Boolean(v) }))}
+                />
+                <Label htmlFor="ddns-present" className="cursor-pointer">
+                  Configure dynamic DNS
+                </Label>
+              </div>
+              {form.present && (
+                <>
+                  <div className="space-y-1">
+                    <Label>Send updates</Label>
+                    <Select
+                      value={form.send_updates || "__none__"}
+                      onValueChange={(v) =>
+                        setForm((prev) => ({
+                          ...prev,
+                          send_updates: v === "__none__" ? "" : v,
+                        }))
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Unset" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none__">Unset</SelectItem>
+                        <SelectItem value="enable">enable</SelectItem>
+                        <SelectItem value="disable">disable</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Label>TSIG keys</Label>
+                      <Button type="button" variant="outline" size="sm" onClick={addKey}>
+                        <Plus className="h-3 w-3 mr-1" />
+                        Add
+                      </Button>
+                    </div>
+                    {form.tsig_keys.map((key, index) => (
+                      <div key={index} className="border rounded-md p-3 space-y-2">
+                        <div className="flex gap-2">
+                          <Input
+                            placeholder="key name"
+                            value={key.name}
+                            onChange={(e) => updateKey(index, { name: e.target.value })}
+                          />
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() =>
+                              setForm((prev) => ({
+                                ...prev,
+                                tsig_keys: prev.tsig_keys.filter((_, i) => i !== index),
+                              }))
+                            }
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                        <Select
+                          value={key.algorithm || "sha256"}
+                          onValueChange={(v) => updateKey(index, { algorithm: v })}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {ALGOS.map((a) => (
+                              <SelectItem key={a} value={a}>
+                                {a}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Input
+                          className="font-mono"
+                          placeholder="base64 secret"
+                          value={key.secret ?? ""}
+                          onChange={(e) => updateKey(index, { secret: e.target.value })}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  {domainEditor("Forward domains", "forward_domains")}
+                  {domainEditor("Reverse domains", "reverse_domains")}
+                </>
+              )}
+            </>
+          )}
+          {error && (
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+              <AlertCircle className="h-4 w-4 text-destructive" />
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/services/DHCPFailoverModal.tsx
+++ b/frontend/src/components/services/DHCPFailoverModal.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AlertCircle } from "lucide-react";
+import { pkiService } from "@/lib/api/pki";
+import {
+  dhcpService,
+  type DHCPCapabilitiesResponse,
+  type DHCPFailoverConfig,
+} from "@/lib/api/dhcp";
+
+interface DHCPFailoverModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+  failover?: DHCPFailoverConfig;
+  capabilities: DHCPCapabilitiesResponse | null;
+}
+
+const empty: DHCPFailoverConfig = {
+  mode: "",
+  name: "",
+  remote: "",
+  source_address: "",
+  status: "",
+  certificate: "",
+  ca_certificate: "",
+};
+
+export function DHCPFailoverModal({
+  open,
+  onOpenChange,
+  onSuccess,
+  failover,
+  capabilities,
+}: DHCPFailoverModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<DHCPFailoverConfig>(empty);
+  const [certs, setCerts] = useState<string[]>([]);
+  const [cas, setCas] = useState<string[]>([]);
+  const canCert = capabilities?.fields.failover_certificate?.supported ?? false;
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setForm({
+      mode: failover?.mode ?? "",
+      name: failover?.name ?? "",
+      remote: failover?.remote ?? "",
+      source_address: failover?.source_address ?? "",
+      status: failover?.status ?? "",
+      certificate: failover?.certificate ?? "",
+      ca_certificate: failover?.ca_certificate ?? "",
+    });
+    if (canCert) {
+      pkiService
+        .getConfig()
+        .then((pki) => {
+          setCerts(pki.certificates.map((c) => c.name));
+          setCas(pki.ca.map((c) => c.name));
+        })
+        .catch(() => {
+          setCerts([]);
+          setCas([]);
+        });
+    }
+  }, [open, failover, canCert]);
+
+  const set = (field: keyof DHCPFailoverConfig, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value === "__none__" ? "" : value }));
+  };
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await dhcpService.saveFailover(failover, form, canCert);
+      if (!result.success) {
+        setError(result.error ?? "Failed to save high availability");
+        setLoading(false);
+        return;
+      }
+      onOpenChange(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save high availability");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>DHCP high availability</DialogTitle>
+          <DialogDescription>Peer settings for this DHCP server</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div className="space-y-1">
+            <Label>Mode</Label>
+            <Select value={form.mode || "__none__"} onValueChange={(v) => set("mode", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Unset" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">Unset</SelectItem>
+                <SelectItem value="active-active">active-active</SelectItem>
+                <SelectItem value="active-passive">active-passive</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label>Name</Label>
+            <Input value={form.name ?? ""} onChange={(e) => set("name", e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label>Remote</Label>
+            <Input
+              className="font-mono"
+              value={form.remote ?? ""}
+              onChange={(e) => set("remote", e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Source address</Label>
+            <Input
+              className="font-mono"
+              value={form.source_address ?? ""}
+              onChange={(e) => set("source_address", e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Status</Label>
+            <Select value={form.status || "__none__"} onValueChange={(v) => set("status", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Unset" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">Unset</SelectItem>
+                <SelectItem value="primary">primary</SelectItem>
+                <SelectItem value="secondary">secondary</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {canCert && (
+            <>
+              <div className="space-y-1">
+                <Label>Certificate</Label>
+                <Select
+                  value={form.certificate || "__none__"}
+                  onValueChange={(v) => set("certificate", v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="None" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">None</SelectItem>
+                    {certs.map((name) => (
+                      <SelectItem key={name} value={name}>
+                        {name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label>CA certificate</Label>
+                <Select
+                  value={form.ca_certificate || "__none__"}
+                  onValueChange={(v) => set("ca_certificate", v)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="None" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">None</SelectItem>
+                    {cas.map((name) => (
+                      <SelectItem key={name} value={name}>
+                        {name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </>
+          )}
+          {error && (
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+              <AlertCircle className="h-4 w-4 text-destructive" />
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={loading}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/lib/api/dhcp.ts
+++ b/frontend/src/lib/api/dhcp.ts
@@ -64,6 +64,34 @@ export interface DHCPFailoverConfig {
   source_address?: string;
   remote?: string;
   status?: string;
+  certificate?: string;
+  ca_certificate?: string;
+}
+
+export interface DHCPDdnsDnsServer {
+  id: string;
+  address?: string;
+  port?: string;
+}
+
+export interface DHCPDdnsDomain {
+  name: string;
+  key_name?: string;
+  dns_servers: DHCPDdnsDnsServer[];
+}
+
+export interface DHCPDdnsTsigKey {
+  name: string;
+  algorithm?: string;
+  secret?: string;
+}
+
+export interface DHCPDdnsConfig {
+  present: boolean;
+  send_updates?: string;
+  tsig_keys: DHCPDdnsTsigKey[];
+  forward_domains: DHCPDdnsDomain[];
+  reverse_domains: DHCPDdnsDomain[];
 }
 
 export interface DHCPGlobalConfig {
@@ -77,6 +105,7 @@ export interface DHCPGlobalConfig {
 export interface DHCPConfigResponse {
   shared_networks: DHCPSharedNetwork[];
   failover?: DHCPFailoverConfig;
+  ddns: DHCPDdnsConfig;
   global_config: DHCPGlobalConfig;
   total_subnets: number;
   total_static_mappings: number;
@@ -146,6 +175,10 @@ export interface DHCPCapabilitiesResponse {
     hostfile_update: DHCPFieldCapability;
     host_decl_name: DHCPFieldCapability;
     static_mapping_duid: DHCPFieldCapability;
+    failover: DHCPFieldCapability;
+    failover_certificate: DHCPFieldCapability;
+    dynamic_dns_update_leaf: DHCPFieldCapability;
+    dynamic_dns_update_kea: DHCPFieldCapability;
     network_disable: DHCPFieldCapability;
     subnet_disable: DHCPFieldCapability;
   };
@@ -949,6 +982,124 @@ class DHCPService {
       network_name: "_global",
       operations,
     });
+  }
+
+  async saveFailover(
+    original: DHCPFailoverConfig | undefined,
+    updated: DHCPFailoverConfig,
+    canCert: boolean
+  ): Promise<VyOSResponse> {
+    const operations: DHCPBatchOperation[] = [];
+    const orig = original ?? {};
+    const scalar = (
+      field: keyof DHCPFailoverConfig,
+      setOp: string,
+      deleteOp: string
+    ) => {
+      const next = (updated[field] ?? "").trim();
+      const prev = (orig[field] ?? "").trim();
+      if (next === prev) return;
+      if (next) operations.push({ op: setOp, value: next });
+      else operations.push({ op: deleteOp });
+    };
+    scalar("mode", "set_failover_mode", "delete_failover_mode");
+    scalar("name", "set_failover_name", "delete_failover_name");
+    scalar("remote", "set_failover_remote", "delete_failover_remote");
+    scalar("source_address", "set_failover_source_address", "delete_failover_source_address");
+    scalar("status", "set_failover_status", "delete_failover_status");
+    if (canCert) {
+      scalar("certificate", "set_failover_certificate", "delete_failover_certificate");
+      scalar("ca_certificate", "set_failover_ca_certificate", "delete_failover_ca_certificate");
+    }
+    if (operations.length === 0) return { success: true };
+    return this.batchConfigure({ network_name: "_global", operations });
+  }
+
+  async saveDdns(
+    original: DHCPDdnsConfig,
+    updated: DHCPDdnsConfig,
+    leaf: boolean,
+    kea: boolean
+  ): Promise<VyOSResponse> {
+    const operations: DHCPBatchOperation[] = [];
+    if (leaf) {
+      if (updated.present !== original.present) {
+        operations.push({
+          op: updated.present ? "set_dynamic_dns_update" : "delete_dynamic_dns_update",
+        });
+      }
+    }
+    if (kea) {
+      if (!updated.present && original.present) {
+        operations.push({ op: "delete_dynamic_dns_update" });
+      } else if (updated.present) {
+        const nextSend = updated.send_updates ?? "";
+        const prevSend = original.send_updates ?? "";
+        if (nextSend !== prevSend) {
+          if (nextSend) operations.push({ op: "set_ddns_send_updates", value: nextSend });
+          else operations.push({ op: "delete_ddns_send_updates" });
+        }
+        const origKeys = new Map(original.tsig_keys.map((k) => [k.name, k]));
+        const nextKeys = new Map(updated.tsig_keys.filter((k) => k.name.trim()).map((k) => [k.name, k]));
+        for (const name of origKeys.keys()) {
+          if (!nextKeys.has(name)) operations.push({ op: "delete_ddns_tsig_key", value: name });
+        }
+        for (const [name, key] of nextKeys) {
+          const prev = origKeys.get(name);
+          if (!prev) operations.push({ op: "set_ddns_tsig_key", value: name });
+          if ((key.algorithm ?? "") !== (prev?.algorithm ?? "") && key.algorithm) {
+            operations.push({ op: "set_ddns_tsig_key_algorithm", value: `${name}|${key.algorithm}` });
+          }
+          if ((key.secret ?? "") !== (prev?.secret ?? "") && key.secret) {
+            operations.push({ op: "set_ddns_tsig_key_secret", value: `${name}|${key.secret}` });
+          }
+        }
+        const diffDomains = (kind: "forward-domain" | "reverse-domain", origList: DHCPDdnsDomain[], nextList: DHCPDdnsDomain[]) => {
+          const origMap = new Map(origList.map((d) => [d.name, d]));
+          const nextMap = new Map(nextList.filter((d) => d.name.trim()).map((d) => [d.name, d]));
+          for (const name of origMap.keys()) {
+            if (!nextMap.has(name)) operations.push({ op: "delete_ddns_domain", value: `${kind}|${name}` });
+          }
+          for (const [name, domain] of nextMap) {
+            const prev = origMap.get(name);
+            if (!prev) operations.push({ op: "set_ddns_domain", value: `${kind}|${name}` });
+            if ((domain.key_name ?? "") !== (prev?.key_name ?? "")) {
+              if (domain.key_name) {
+                operations.push({ op: "set_ddns_domain_key_name", value: `${kind}|${name}|${domain.key_name}` });
+              } else if (prev?.key_name) {
+                operations.push({ op: "delete_ddns_domain_key_name", value: `${kind}|${name}` });
+              }
+            }
+            const origServers = new Map((prev?.dns_servers ?? []).map((s) => [s.id, s]));
+            const nextServers = new Map(domain.dns_servers.filter((s) => s.id.trim()).map((s) => [s.id, s]));
+            for (const id of origServers.keys()) {
+              if (!nextServers.has(id)) {
+                operations.push({ op: "delete_ddns_domain_dns_server", value: `${kind}|${name}|${id}` });
+              }
+            }
+            for (const [id, server] of nextServers) {
+              const prevS = origServers.get(id);
+              if ((server.address ?? "") !== (prevS?.address ?? "") && server.address) {
+                operations.push({
+                  op: "set_ddns_domain_dns_server_address",
+                  value: `${kind}|${name}|${id}|${server.address}`,
+                });
+              }
+              if ((server.port ?? "") !== (prevS?.port ?? "") && server.port) {
+                operations.push({
+                  op: "set_ddns_domain_dns_server_port",
+                  value: `${kind}|${name}|${id}|${server.port}`,
+                });
+              }
+            }
+          }
+        };
+        diffDomains("forward-domain", original.forward_domains, updated.forward_domains);
+        diffDomains("reverse-domain", original.reverse_domains, updated.reverse_domains);
+      }
+    }
+    if (operations.length === 0) return { success: true };
+    return this.batchConfigure({ network_name: "_global", operations });
   }
 
   // Shared network disable


### PR DESCRIPTION
DHCP dynamic-dns-update was not in the mapper. 1.4 is a leaf. 1.5 is a Kea subtree (send-updates, tsig-key, forward-domain, reverse-domain). HA peer fields already existed on the builder but dhcp.ts never called them, and 1.5 certificate/ca-certificate had no mapper methods.

Mapper owns existence and raises on the other version. Capabilities read those flags. UI adds High availability and Dynamic DNS dialogs with no version numbers in copy.

Tests: PYTHONPATH=backend pytest backend/tests/test_dhcp_version_gates.py backend/tests/test_dhcp_builder_paths.py (76 passed). frontend npx tsc --noEmit clean. npm run lint 0 errors. validate-path.sh: 1.4 DDNS leaf VALID, 1.5 Kea children VALID, HA certs VALID on 1.5 INVALID on 1.4.

Closes #650
Closes #651