### PR TITLE
fix: enforce dedicated RBAC groups on interface routers

### DIFF
--- a/backend/rbac_permissions.py
+++ b/backend/rbac_permissions.py
@@ -1070,10 +1070,10 @@ def _apply_parent_child_permissions(permissions: Dict[FeatureGroup, PermissionLe
                 permissions[child] = PermissionLevel.READ
 
     # INTERFACES grants permissions to all interface sub-types.
-    # Load-bearing fallback: the interface routers with dedicated groups
-    # (PSEUDO_ETHERNET, VIRTUAL_ETHERNET, VPP, VTI, WIRELESS, WWAN) enforce
-    # their own group, and this propagation is what keeps INTERFACES-only
-    # roles working on them. Removing a child here revokes that fallback.
+    # Load-bearing fallback: interface routers with dedicated groups
+    # enforce their own group, and this propagation is what keeps
+    # INTERFACES-only roles working on them. Removing a child here
+    # revokes that fallback.
     interfaces_perm = permissions.get(FeatureGroup.INTERFACES, PermissionLevel.NONE)
     if interfaces_perm != PermissionLevel.NONE:
         interface_children = [

--- a/backend/routers/interfaces/bonding.py
+++ b/backend/routers/interfaces/bonding.py
@@ -247,7 +247,7 @@ class BondingInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_bonding_capabilities(request: Request):
     """Get bonding feature capabilities based on device VyOS version."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.BONDING)
 
     try:
         service = get_session_vyos_service(request)
@@ -274,7 +274,7 @@ async def get_bonding_capabilities(request: Request):
 @router.get("/config", response_model=BondingInterfacesConfigResponse)
 async def get_bonding_config(http_request: Request) -> BondingInterfacesConfigResponse:
     """Get all bonding interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.BONDING)
 
     from vyos_mappers.interfaces.bonding_versions import get_bonding_mapper
 
@@ -372,7 +372,7 @@ async def configure_bonding_batch(http_request: Request, request: BondingBatchRe
 
     All operations are version-aware and sent to VyOS in a single batch.
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.BONDING)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/bridge.py
+++ b/backend/routers/interfaces/bridge.py
@@ -217,7 +217,7 @@ class BridgeInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_bridge_capabilities(request: Request):
     """Get bridge feature capabilities based on device VyOS version."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.BRIDGE)
 
     try:
         service = get_session_vyos_service(request)
@@ -244,7 +244,7 @@ async def get_bridge_capabilities(request: Request):
 @router.get("/config", response_model=BridgeInterfacesConfigResponse)
 async def get_bridge_config(http_request: Request) -> BridgeInterfacesConfigResponse:
     """Get all bridge interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.BRIDGE)
 
     from vyos_mappers.interfaces.bridge_versions import get_bridge_mapper
 
@@ -387,7 +387,7 @@ async def configure_bridge_batch(http_request: Request, request: BridgeBatchRequ
 
     All operations are version-aware and sent to VyOS in a single batch.
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.BRIDGE)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/dummy.py
+++ b/backend/routers/interfaces/dummy.py
@@ -69,7 +69,7 @@ class DummyInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for dummy interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.DUMMY)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.dummy import DummyInterfaceBuilderMixin
     builder = DummyInterfaceBuilderMixin(version=service.get_version())
@@ -79,7 +79,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=DummyInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> DummyInterfacesConfigResponse:
     """Get all dummy interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.DUMMY)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -136,7 +136,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `set_netns` | Yes | Assign to network namespace |
     | `delete_netns` | No | Remove network namespace |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.DUMMY)
 
     service = get_session_vyos_service(http_request)
     batch = service.create_dummy_batch()

--- a/backend/routers/interfaces/ethernet.py
+++ b/backend/routers/interfaces/ethernet.py
@@ -342,7 +342,7 @@ async def get_ethernet_capabilities(request: Request) -> Dict[str, Any]:
     ```
     """
     # Check RBAC permission
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.ETHERNET)
 
     try:
         service = get_session_vyos_service(request)
@@ -948,7 +948,7 @@ async def get_ethernet_config(http_request: Request) -> EthernetInterfacesConfig
     Returns configuration details including addresses, description, speed, duplex, hw_id, etc.
     """
     # Check RBAC permission
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.ETHERNET)
 
     from vyos_mappers.interfaces import EthernetInterfaceMapper
 
@@ -977,7 +977,7 @@ async def get_ethernet_transceiver(
     interface: str = Path(..., pattern=r"^eth\d+(?:\.\d+)?$"),
 ) -> TransceiverStatus:
     """Return live SFP/SFP+ DDM diagnostics for one Ethernet interface."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.ETHERNET)
     try:
         service = get_session_vyos_service(http_request)
         response = await run_in_threadpool(
@@ -1186,7 +1186,7 @@ async def configure_interface_batch(http_request: Request, request: InterfaceBat
     ```
     """
     # Check RBAC permission
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.ETHERNET)
 
     try:
         service = get_session_vyos_service(http_request)

--- a/backend/routers/interfaces/geneve.py
+++ b/backend/routers/interfaces/geneve.py
@@ -98,7 +98,7 @@ class GeneveInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for geneve interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.GENEVE)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.geneve import GeneveInterfaceBuilderMixin
     builder = GeneveInterfaceBuilderMixin(version=service.get_version())
@@ -108,7 +108,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=GeneveInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> GeneveInterfacesConfigResponse:
     """Get all geneve interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.GENEVE)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -211,7 +211,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `set_ipv6_address_interface_identifier` | Yes | Set SLAAC interface identifier |
     | `delete_ipv6_address_interface_identifier` | No | Remove SLAAC interface identifier |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.GENEVE)
 
     service = get_session_vyos_service(http_request)
     batch = service.create_geneve_batch()

--- a/backend/routers/interfaces/input.py
+++ b/backend/routers/interfaces/input.py
@@ -55,7 +55,7 @@ class InputInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for input interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.INPUT_IFACE)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.input import InputInterfaceBuilderMixin
     builder = InputInterfaceBuilderMixin(version=service.get_version())
@@ -65,7 +65,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=InputInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> InputInterfacesConfigResponse:
     """Get all input (IFB) interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.INPUT_IFACE)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -96,7 +96,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `delete_redirect` | No | Remove redirect |
     | `delete_interface` | No | Delete entire interface |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.INPUT_IFACE)
 
     service = get_session_vyos_service(http_request)
     batch = service.create_input_batch()

--- a/backend/routers/interfaces/loopback.py
+++ b/backend/routers/interfaces/loopback.py
@@ -58,7 +58,7 @@ class LoopbackInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for loopback interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.LOOPBACK)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.loopback import LoopbackInterfaceBuilderMixin
     builder = LoopbackInterfaceBuilderMixin(version=service.get_version())
@@ -68,7 +68,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=LoopbackInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> LoopbackInterfacesConfigResponse:
     """Get all loopback interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.LOOPBACK)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -105,7 +105,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `delete_redirect` | No | Remove redirect |
     | `delete_interface` | No | Delete entire interface |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.LOOPBACK)
 
     service = get_session_vyos_service(http_request)
     batch = service.create_loopback_batch()

--- a/backend/routers/interfaces/macsec.py
+++ b/backend/routers/interfaces/macsec.py
@@ -171,7 +171,7 @@ class MacsecInterfacesConfigResponse(BaseModel):
 @router.get("/capabilities")
 async def get_capabilities(request: Request) -> Dict[str, Any]:
     """Return version-aware feature capabilities for MACsec interfaces."""
-    await require_read_permission(request, FeatureGroup.INTERFACES)
+    await require_read_permission(request, FeatureGroup.MACSEC)
     service = get_session_vyos_service(request)
     from vyos_builders.interfaces.macsec import MacsecInterfaceBuilderMixin
     builder = MacsecInterfaceBuilderMixin(version=service.get_version())
@@ -181,7 +181,7 @@ async def get_capabilities(request: Request) -> Dict[str, Any]:
 @router.get("/config", response_model=MacsecInterfacesConfigResponse)
 async def get_config(http_request: Request, refresh: bool = False) -> MacsecInterfacesConfigResponse:
     """Get all MACsec interface configurations from VyOS."""
-    await require_read_permission(http_request, FeatureGroup.INTERFACES)
+    await require_read_permission(http_request, FeatureGroup.MACSEC)
     try:
         service = get_session_vyos_service(http_request)
         full_config = await run_in_threadpool(service.get_full_config, refresh)
@@ -240,7 +240,7 @@ async def batch_configure(http_request: Request, request: BatchRequest) -> VyOSR
     | `delete_security_static_peer_mac` | Yes | Remove peer MAC |
     | `delete_interface` | No | Delete entire interface |
     """
-    await require_write_permission(http_request, FeatureGroup.INTERFACES)
+    await require_write_permission(http_request, FeatureGroup.MACSEC)
 
     service = get_session_vyos_service(http_request)
     batch = service.create_macsec_batch()

--- a/backend/tests/test_rbac_interface_groups.py
+++ b/backend/tests/test_rbac_interface_groups.py
@@ -1,7 +1,6 @@
-"""Unit tests for the interface feature-group fallback (issue #428).
+"""Unit tests for the interface feature-group fallback (issues #428, #658).
 
-The six interface routers with dedicated feature groups (PSEUDO_ETHERNET,
-VIRTUAL_ETHERNET, VPP, VTI, WIRELESS, WWAN) enforce their own group, and
+Interface routers with dedicated feature groups enforce their own group, and
 ``_apply_parent_child_permissions`` propagates an INTERFACES grant to those
 groups. Together that gives the "dedicated group first, INTERFACES as
 fallback" behavior: a dedicated grant works on its own, an INTERFACES-only
@@ -21,6 +20,14 @@ from rbac_permissions import (
 
 
 DEDICATED_INTERFACE_GROUPS = [
+    FeatureGroup.BONDING,
+    FeatureGroup.BRIDGE,
+    FeatureGroup.DUMMY,
+    FeatureGroup.ETHERNET,
+    FeatureGroup.GENEVE,
+    FeatureGroup.INPUT_IFACE,
+    FeatureGroup.LOOPBACK,
+    FeatureGroup.MACSEC,
     FeatureGroup.PSEUDO_ETHERNET,
     FeatureGroup.VIRTUAL_ETHERNET,
     FeatureGroup.VPP,
@@ -30,6 +37,14 @@ DEDICATED_INTERFACE_GROUPS = [
 ]
 
 ROUTER_FILES = {
+    FeatureGroup.BONDING: "bonding.py",
+    FeatureGroup.BRIDGE: "bridge.py",
+    FeatureGroup.DUMMY: "dummy.py",
+    FeatureGroup.ETHERNET: "ethernet.py",
+    FeatureGroup.GENEVE: "geneve.py",
+    FeatureGroup.INPUT_IFACE: "input.py",
+    FeatureGroup.LOOPBACK: "loopback.py",
+    FeatureGroup.MACSEC: "macsec.py",
     FeatureGroup.PSEUDO_ETHERNET: "pseudo_ethernet.py",
     FeatureGroup.VIRTUAL_ETHERNET: "virtual_ethernet.py",
     FeatureGroup.VPP: "vpp.py",
@@ -66,7 +81,7 @@ def test_dedicated_grant_alone_grants_access():
                 assert permissions[other] == PermissionLevel.NONE
 
 
-def test_interfaces_only_grant_still_covers_all_six():
+def test_interfaces_only_grant_still_covers_all_dedicated():
     permissions = all_none()
     permissions[FeatureGroup.INTERFACES] = PermissionLevel.WRITE
     _apply_parent_child_permissions(permissions)

--- a/frontend/src/app/network/interfaces/page.tsx
+++ b/frontend/src/app/network/interfaces/page.tsx
@@ -381,6 +381,11 @@ function InterfacesPageInner() {
 
   const { canWrite, canRead } = usePermissions();
 
+  const canWriteVlanParentType =
+    vlanParent === "bonding"
+      ? canWrite(FeatureGroup.BONDING) || canWrite(FeatureGroup.INTERFACES)
+      : canWrite(FeatureGroup.ETHERNET) || canWrite(FeatureGroup.INTERFACES);
+
   const canWriteSelectedType = () => {
     switch (selectedType) {
       case "vxlan":
@@ -407,6 +412,8 @@ function InterfacesPageInner() {
         return canWrite(FeatureGroup.LOOPBACK) || canWrite(FeatureGroup.INTERFACES);
       case "macsec":
         return canWrite(FeatureGroup.MACSEC) || canWrite(FeatureGroup.INTERFACES);
+      case "vlan":
+        return canWriteVlanParentType;
       default:
         return canWrite(FeatureGroup.INTERFACES);
     }
@@ -789,7 +796,7 @@ function InterfacesPageInner() {
                         size="sm"
                         onClick={() => onEdit?.(item)}
                         className="h-7 w-7 p-0"
-                        disabled={!canWrite(FeatureGroup.INTERFACES)}
+                        disabled={!canWriteVlanParentType}
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </Button>
@@ -810,7 +817,7 @@ function InterfacesPageInner() {
                           setDeletingVLAN(base);
                         }}
                         className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                        disabled={!canWrite(FeatureGroup.INTERFACES)}
+                        disabled={!canWriteVlanParentType}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>

--- a/frontend/src/app/network/interfaces/page.tsx
+++ b/frontend/src/app/network/interfaces/page.tsx
@@ -381,6 +381,37 @@ function InterfacesPageInner() {
 
   const { canWrite, canRead } = usePermissions();
 
+  const canWriteSelectedType = () => {
+    switch (selectedType) {
+      case "vxlan":
+        return canWrite(FeatureGroup.VXLAN);
+      case "tunnel":
+        return canWrite(FeatureGroup.TUNNEL) || canWrite(FeatureGroup.INTERFACES);
+      case "pppoe":
+        return canWrite(FeatureGroup.PPPOE) || canWrite(FeatureGroup.INTERFACES);
+      case "sstpc":
+        return canWrite(FeatureGroup.SSTPC) || canWrite(FeatureGroup.INTERFACES);
+      case "bonding":
+        return canWrite(FeatureGroup.BONDING) || canWrite(FeatureGroup.INTERFACES);
+      case "bridge":
+        return canWrite(FeatureGroup.BRIDGE) || canWrite(FeatureGroup.INTERFACES);
+      case "dummy":
+        return canWrite(FeatureGroup.DUMMY) || canWrite(FeatureGroup.INTERFACES);
+      case "ethernet":
+        return canWrite(FeatureGroup.ETHERNET) || canWrite(FeatureGroup.INTERFACES);
+      case "geneve":
+        return canWrite(FeatureGroup.GENEVE) || canWrite(FeatureGroup.INTERFACES);
+      case "input":
+        return canWrite(FeatureGroup.INPUT_IFACE) || canWrite(FeatureGroup.INTERFACES);
+      case "loopback":
+        return canWrite(FeatureGroup.LOOPBACK) || canWrite(FeatureGroup.INTERFACES);
+      case "macsec":
+        return canWrite(FeatureGroup.MACSEC) || canWrite(FeatureGroup.INTERFACES);
+      default:
+        return canWrite(FeatureGroup.INTERFACES);
+    }
+  };
+
   const loadData = async () => {
     try {
       setError(null);
@@ -1059,6 +1090,7 @@ function InterfacesPageInner() {
             ) : (
               <div className="space-y-1 py-3">
                 {/* Bonding */}
+                {(canRead(FeatureGroup.BONDING) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("bonding")}
                   className={cn(
@@ -1091,8 +1123,10 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* Bridge */}
+                {(canRead(FeatureGroup.BRIDGE) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("bridge")}
                   className={cn(
@@ -1125,8 +1159,10 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* Dummy */}
+                {(canRead(FeatureGroup.DUMMY) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("dummy")}
                   className={cn(
@@ -1159,8 +1195,10 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* Ethernet */}
+                {(canRead(FeatureGroup.ETHERNET) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("ethernet")}
                   className={cn(
@@ -1193,8 +1231,10 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* GENEVE */}
+                {(canRead(FeatureGroup.GENEVE) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("geneve")}
                   className={cn(
@@ -1227,8 +1267,10 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* Input */}
+                {(canRead(FeatureGroup.INPUT_IFACE) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("input")}
                   className={cn(
@@ -1261,6 +1303,7 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* L2TPv3 */}
                 <button
@@ -1297,6 +1340,7 @@ function InterfacesPageInner() {
                 </button>
 
                 {/* Loopback */}
+                {(canRead(FeatureGroup.LOOPBACK) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("loopback")}
                   className={cn(
@@ -1329,8 +1373,10 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* MACsec */}
+                {(canRead(FeatureGroup.MACSEC) || canRead(FeatureGroup.INTERFACES)) && (
                 <button
                   onClick={() => setSelectedType("macsec")}
                   className={cn(
@@ -1363,6 +1409,7 @@ function InterfacesPageInner() {
                     </div>
                   </div>
                 </button>
+                )}
 
                 {/* PPPoE */}
                 {(canRead(FeatureGroup.PPPOE) || canRead(FeatureGroup.INTERFACES)) && (
@@ -1895,7 +1942,7 @@ function InterfacesPageInner() {
                     setIsCreateInterfaceModalOpen(true);
                   }
                 }}
-                disabled={selectedType === "vxlan" ? !canWrite(FeatureGroup.VXLAN) : selectedType === "tunnel" ? !canWrite(FeatureGroup.TUNNEL) && !canWrite(FeatureGroup.INTERFACES) : selectedType === "pppoe" ? !canWrite(FeatureGroup.PPPOE) && !canWrite(FeatureGroup.INTERFACES) : selectedType === "sstpc" ? !canWrite(FeatureGroup.SSTPC) && !canWrite(FeatureGroup.INTERFACES) : !canWrite(FeatureGroup.INTERFACES)}
+                disabled={!canWriteSelectedType()}
               >
                 <Plus className="h-4 w-4" />
                 {selectedType === "ethernet"
@@ -2144,7 +2191,7 @@ function InterfacesPageInner() {
                                     size="sm"
                                     onClick={() => setDiagnosticsInterface(iface.name)}
                                     className="h-7 w-7 p-0"
-                                    disabled={!canRead(FeatureGroup.INTERFACES)}
+                                    disabled={!canRead(FeatureGroup.ETHERNET) && !canRead(FeatureGroup.INTERFACES)}
                                     title="View transceiver diagnostics"
                                   >
                                     <Signal className="h-3.5 w-3.5" />
@@ -2154,7 +2201,7 @@ function InterfacesPageInner() {
                                     size="sm"
                                     onClick={() => setEditingInterface(iface)}
                                     className="h-7 w-7 p-0"
-                                    disabled={!canWrite(FeatureGroup.INTERFACES)}
+                                    disabled={!canWrite(FeatureGroup.ETHERNET) && !canWrite(FeatureGroup.INTERFACES)}
                                   >
                                     <Pencil className="h-3.5 w-3.5" />
                                   </Button>
@@ -2163,7 +2210,7 @@ function InterfacesPageInner() {
                                     size="sm"
                                     onClick={() => setDeletingInterface(iface)}
                                     className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                                    disabled={!canWrite(FeatureGroup.INTERFACES)}
+                                    disabled={!canWrite(FeatureGroup.ETHERNET) && !canWrite(FeatureGroup.INTERFACES)}
                                   >
                                     <Trash2 className="h-3.5 w-3.5" />
                                   </Button>
@@ -2424,7 +2471,7 @@ function InterfacesPageInner() {
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                {canWrite(FeatureGroup.INTERFACES) && (
+                                {(canWrite(FeatureGroup.DUMMY) || canWrite(FeatureGroup.INTERFACES)) && (
                                   <>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingDummy(dum)}>
                                       <Pencil className="h-3.5 w-3.5" />
@@ -2498,7 +2545,7 @@ function InterfacesPageInner() {
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                {canWrite(FeatureGroup.INTERFACES) && (
+                                {(canWrite(FeatureGroup.GENEVE) || canWrite(FeatureGroup.INTERFACES)) && (
                                   <>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingGeneve(gnv)}>
                                       <Pencil className="h-3.5 w-3.5" />
@@ -2636,7 +2683,7 @@ function InterfacesPageInner() {
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                {canWrite(FeatureGroup.INTERFACES) && (
+                                {(canWrite(FeatureGroup.INPUT_IFACE) || canWrite(FeatureGroup.INTERFACES)) && (
                                   <>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingInput(ifb)}>
                                       <Pencil className="h-3.5 w-3.5" />
@@ -2704,7 +2751,7 @@ function InterfacesPageInner() {
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                {canWrite(FeatureGroup.INTERFACES) && (
+                                {(canWrite(FeatureGroup.LOOPBACK) || canWrite(FeatureGroup.INTERFACES)) && (
                                   <>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingLoopback(lo)}>
                                       <Pencil className="h-3.5 w-3.5" />
@@ -2796,7 +2843,7 @@ function InterfacesPageInner() {
                               </TableCell>
                               <TableCell>
                                 <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                  {canWrite(FeatureGroup.INTERFACES) && (
+                                  {(canWrite(FeatureGroup.MACSEC) || canWrite(FeatureGroup.INTERFACES)) && (
                                     <>
                                       <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingMacsec(iface)}>
                                         <Pencil className="h-3.5 w-3.5" />
@@ -3441,7 +3488,7 @@ function InterfacesPageInner() {
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                {canWrite(FeatureGroup.INTERFACES) && (
+                                {(canWrite(FeatureGroup.BONDING) || canWrite(FeatureGroup.INTERFACES)) && (
                                   <>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingBonding(bond)}>
                                       <Pencil className="h-3.5 w-3.5" />
@@ -3550,7 +3597,7 @@ function InterfacesPageInner() {
                                 </TableCell>
                                 <TableCell>
                                   <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                    {canWrite(FeatureGroup.INTERFACES) && (
+                                    {(canWrite(FeatureGroup.BRIDGE) || canWrite(FeatureGroup.INTERFACES)) && (
                                       <>
                                         <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => setEditingBridge(br)}>
                                           <Pencil className="h-3.5 w-3.5" />
@@ -3569,7 +3616,7 @@ function InterfacesPageInner() {
                                     <div className="mx-4 mb-3 mt-1 rounded-lg border bg-muted/30">
                                       <div className="flex items-center justify-between px-4 py-2 border-b">
                                         <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">VIF Sub-interfaces ({vifCount})</span>
-                                        {canWrite(FeatureGroup.INTERFACES) && (
+                                        {(canWrite(FeatureGroup.BRIDGE) || canWrite(FeatureGroup.INTERFACES)) && (
                                           <Button size="sm" variant="outline" className="h-7 text-xs" onClick={() => setCreateVifForBridge(br.name)}>
                                             <Plus className="h-3 w-3 mr-1" /> Add VIF
                                           </Button>
@@ -3613,7 +3660,7 @@ function InterfacesPageInner() {
                                                 </TableCell>
                                                 <TableCell className="py-2 pr-3">
                                                   <div className="flex gap-1 opacity-0 group-hover/vif:opacity-100 transition-opacity justify-end">
-                                                    {canWrite(FeatureGroup.INTERFACES) && (
+                                                    {(canWrite(FeatureGroup.BRIDGE) || canWrite(FeatureGroup.INTERFACES)) && (
                                                       <>
                                                         <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => setEditingVif({ bridge: br.name, vif })}>
                                                           <Pencil className="h-3 w-3" />


### PR DESCRIPTION
Eight interface routers (ethernet, bonding, bridge, dummy, geneve, input, loopback, macsec) still required FeatureGroup.INTERFACES. A role with only MACSEC write got 403 on /vyos/macsec, and toggling that group in user management did nothing.

Each of those routers now checks its dedicated group. INTERFACES still covers them through parent-child propagation. The interfaces page shows and enables each type when the dedicated group or INTERFACES is granted, matching PPPoE.

Tests: PYTHONPATH=backend pytest backend/tests/test_rbac_interface_groups.py (7 passed). frontend npx tsc --noEmit and npm run lint.

Closes #658