### PR TITLE
fix: consume system search tab and section params

### DIFF
--- a/frontend/src/app/system/containers/page.tsx
+++ b/frontend/src/app/system/containers/page.tsx
@@ -1,12 +1,23 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
+import { Suspense } from "react";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { ContainerContent } from "@/components/container/ContainerContent";
 
-export default function ContainersPage() {
+function ContainersPageInner() {
   return (
     <AppLayout>
       <ContainerContent />
     </AppLayout>
+  );
+}
+
+export default function ContainersPage() {
+  return (
+    <Suspense>
+      <ContainersPageInner />
+    </Suspense>
   );
 }

--- a/frontend/src/components/container/ContainerContent.tsx
+++ b/frontend/src/components/container/ContainerContent.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+import { containerTabFromSearch, type ContainerTab } from "@/lib/query-tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -20,12 +22,14 @@ import { FeatureGroup } from "@/lib/api/user-management";
 export function ContainerContent() {
   const { canWrite } = usePermissions();
   const hasWritePermission = canWrite(FeatureGroup.CONTAINER);
+  const searchParams = useSearchParams();
 
   const [config, setConfig] = useState<ContainerConfig | null>(null);
   const [capabilities, setCapabilities] = useState<ContainerCapabilities | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [baseDirExists, setBaseDirExists] = useState<boolean | null>(null);
+  const [selectedTab, setSelectedTab] = useState<ContainerTab>("containers");
 
   const loadData = useCallback(async (refresh = false) => {
     try {
@@ -52,6 +56,14 @@ export function ContainerContent() {
 
   const showNetworks = capabilities?.features.container_networks?.supported !== false;
   const showRegistries = capabilities?.features.container_registries?.supported !== false;
+
+  useEffect(() => {
+    const tab = containerTabFromSearch((key) => searchParams.get(key));
+    if (!tab) return;
+    if (tab === "networks" && !showNetworks) return;
+    if (tab === "registries" && !showRegistries) return;
+    setSelectedTab(tab);
+  }, [searchParams, showNetworks, showRegistries]);
 
   const totalContainers = config?.containers.length ?? 0;
   const totalNetworks = config?.networks.length ?? 0;
@@ -150,7 +162,7 @@ export function ContainerContent() {
 
       {/* Tabs */}
       <div className="flex-1 p-6 pt-4 overflow-auto">
-        <Tabs defaultValue="containers">
+        <Tabs value={selectedTab} onValueChange={(value) => setSelectedTab(value as ContainerTab)}>
           <TabsList>
             <TabsTrigger value="containers">Containers</TabsTrigger>
             {showNetworks && <TabsTrigger value="networks">Networks</TabsTrigger>}

--- a/frontend/src/components/system/settings/ConntrackPanel.tsx
+++ b/frontend/src/components/system/settings/ConntrackPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { conntrackSectionFromSearch } from "@/lib/query-tabs";
 import {
   Card,
   CardContent,
@@ -168,7 +170,16 @@ function ConntrackTimeoutSortableRow({
 
 export function ConntrackPanel({ config, capabilities, isReadOnly, onRefresh }: Props) {
   const { toast } = useToast();
+  const searchParams = useSearchParams();
   const availableModules = capabilities.conntrack.available_modules;
+
+  useEffect(() => {
+    const section = conntrackSectionFromSearch((key) => searchParams.get(key));
+    if (!section) return;
+    requestAnimationFrame(() => {
+      document.getElementById(section)?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }, [searchParams]);
 
   // Module toggle
   const [togglingModule, setTogglingModule] = useState<string | null>(null);
@@ -639,7 +650,7 @@ export function ConntrackPanel({ config, capabilities, isReadOnly, onRefresh }: 
       </Card>
 
       {/* Table Sizes */}
-      <Card>
+      <Card id="table-sizes" className="scroll-mt-24">
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
@@ -717,7 +728,7 @@ export function ConntrackPanel({ config, capabilities, isReadOnly, onRefresh }: 
       </Card>
 
       {/* TCP Settings */}
-      <Card>
+      <Card id="tcp-settings" className="scroll-mt-24">
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>

--- a/frontend/src/lib/query-tabs.test.ts
+++ b/frontend/src/lib/query-tabs.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   bgpTabFromSearch,
+  conntrackSectionFromSearch,
+  containerTabFromSearch,
   staticRouteTabFromSearch,
 } from "./query-tabs";
 
@@ -45,5 +47,33 @@ describe("bgpTabFromSearch", () => {
 
   it("ignores unknown tabs", () => {
     assert.equal(bgpTabFromSearch(params({ tab: "arp" })), null);
+  });
+});
+
+describe("containerTabFromSearch", () => {
+  it("maps nav running to the containers tab", () => {
+    assert.equal(containerTabFromSearch(params({ tab: "running" })), "containers");
+  });
+
+  it("reads images and networks as nav emits them", () => {
+    assert.equal(containerTabFromSearch(params({ tab: "images" })), "images");
+    assert.equal(containerTabFromSearch(params({ tab: "networks" })), "networks");
+  });
+
+  it("ignores unknown tabs", () => {
+    assert.equal(containerTabFromSearch(params({ tab: "overview" })), null);
+    assert.equal(containerTabFromSearch(params({})), null);
+  });
+});
+
+describe("conntrackSectionFromSearch", () => {
+  it("reads section as search emits it", () => {
+    assert.equal(conntrackSectionFromSearch(params({ section: "table-sizes" })), "table-sizes");
+    assert.equal(conntrackSectionFromSearch(params({ section: "tcp-settings" })), "tcp-settings");
+  });
+
+  it("ignores unknown sections", () => {
+    assert.equal(conntrackSectionFromSearch(params({ section: "ignore" })), null);
+    assert.equal(conntrackSectionFromSearch(params({ tab: "conntrack" })), null);
   });
 });

--- a/frontend/src/lib/query-tabs.ts
+++ b/frontend/src/lib/query-tabs.ts
@@ -38,3 +38,43 @@ export function bgpTabFromSearch(
     ? (value as BgpTab)
     : null;
 }
+
+export const CONTAINER_TABS = [
+  "containers",
+  "networks",
+  "registries",
+  "images",
+  "apps",
+] as const;
+
+export type ContainerTab = (typeof CONTAINER_TABS)[number];
+
+/** Nav emits `running` for the containers list tab. */
+const CONTAINER_TAB_FROM_NAV: Record<string, ContainerTab> = {
+  running: "containers",
+  containers: "containers",
+  networks: "networks",
+  registries: "registries",
+  images: "images",
+  apps: "apps",
+};
+
+export function containerTabFromSearch(
+  get: (key: string) => string | null,
+): ContainerTab | null {
+  const value = get("tab");
+  return value ? CONTAINER_TAB_FROM_NAV[value] ?? null : null;
+}
+
+export const CONNTRACK_SECTIONS = ["table-sizes", "tcp-settings"] as const;
+
+export type ConntrackSection = (typeof CONNTRACK_SECTIONS)[number];
+
+export function conntrackSectionFromSearch(
+  get: (key: string) => string | null,
+): ConntrackSection | null {
+  const value = get("section");
+  return (CONNTRACK_SECTIONS as readonly string[]).includes(value ?? "")
+    ? (value as ConntrackSection)
+    : null;
+}


### PR DESCRIPTION
Search and nav emit /system/settings?tab=conntrack&section=table-sizes (and tcp-settings) plus /system/containers?tab=images (also running and networks). Settings already read tab, but ConntrackPanel had no section ids, and ContainerContent used defaultValue containers.

query-tabs now maps those nav tokens the same way BGP and static routes do. Conntrack cards get matching ids and scroll into view. The containers page is controlled from tab, mapping running to the containers list.

Tests: npx tsc --noEmit, npm run lint, npx tsx --test src/lib/query-tabs.test.ts (12 passed).

Closes #674