### PR TITLE
fix: raise on 1.4 DNS forwarding zone-cache

### DIFF
--- a/backend/tests/test_dns_forwarding_version_gates.py
+++ b/backend/tests/test_dns_forwarding_version_gates.py
@@ -1,0 +1,53 @@
+"""DNS forwarding zone-cache is 1.5-only; ECS exists on 1.4."""
+
+import pytest
+
+from vyos_builders.dns_forwarding.dns_forwarding_batch_builder import (
+    DNSForwardingBatchBuilder,
+)
+from vyos_mappers.dns_forwarding.dns_forwarding_versions import get_dns_forwarding_mapper
+
+
+def test_v14_zone_cache_set_raises():
+    mapper = get_dns_forwarding_mapper("1.4")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        mapper.get_zone_cache_url("example.com", "https://example.com/zone")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        mapper.get_zone_cache_axfr("example.com", "192.0.2.1")
+
+
+def test_v14_zone_cache_delete_unguarded():
+    mapper = get_dns_forwarding_mapper("1.4")
+    assert mapper.get_zone_cache_delete("example.com") == [
+        "service", "dns", "forwarding", "zone-cache", "example.com",
+    ]
+
+
+def test_v15_zone_cache_emits():
+    mapper = get_dns_forwarding_mapper("1.5")
+    assert mapper.get_zone_cache_url("example.com", "https://example.com/zone") == [
+        "service", "dns", "forwarding", "zone-cache", "example.com",
+        "source", "url", "https://example.com/zone",
+    ]
+
+
+def test_v14_ecs_emits():
+    mapper = get_dns_forwarding_mapper("1.4")
+    assert mapper.get_options_ecs_add_for("192.0.2.0/24") == [
+        "service", "dns", "forwarding", "options", "ecs-add-for", "192.0.2.0/24",
+    ]
+
+
+def test_v14_builder_zone_cache_raises():
+    builder = DNSForwardingBatchBuilder(version="1.4")
+    with pytest.raises(NotImplementedError, match="not supported"):
+        builder.set_zone_cache_url("example.com", "https://example.com/zone")
+
+
+def test_capabilities_read_mapper_zone_cache():
+    v14 = DNSForwardingBatchBuilder(version="1.4").get_capabilities()
+    v15 = DNSForwardingBatchBuilder(version="1.5").get_capabilities()
+    assert v14["features"]["zone_cache"]["supported"] is False
+    assert v15["features"]["zone_cache"]["supported"] is True
+    assert v14["features"]["options_ecs"]["supported"] is True
+    assert v15["features"]["options_ecs"]["supported"] is True

--- a/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
+++ b/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
@@ -509,7 +509,7 @@ class DNSForwardingBatchBuilder(BatchBuilder):
         return self.add_delete(self.m.get_zone_caches_delete())
 
     # -----------------------------------------------------------------------
-    # Options / ECS (1.5 only)
+    # Options / ECS
     # -----------------------------------------------------------------------
 
     def set_options_ecs_add_for(self, network: str) -> "DNSForwardingBatchBuilder":

--- a/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
+++ b/backend/vyos_builders/dns_forwarding/dns_forwarding_batch_builder.py
@@ -10,10 +10,10 @@ Key sections:
   - Domain forwarders: per-domain upstream resolvers
   - Authoritative domains: local DNS zones with A/AAAA/CNAME/MX/TXT/NS/PTR records
   - Zone cache (1.5 only): cached remote zones via URL or AXFR
-  - Options/ECS (1.5 only): EDNS Client Subnet settings
+  - Options/ECS: EDNS Client Subnet settings
 
 Version differences:
-  - zone-cache and options (ECS) subtrees are only available on VyOS 1.5
+  - zone-cache is 1.5-only; the 1.4 mapper raises on set
 """
 
 from typing import Dict, Any
@@ -127,12 +127,12 @@ class DNSForwardingBatchBuilder(BatchBuilder):
                     "description": "Local authoritative DNS zones with A/AAAA/CNAME/MX/TXT/NS/PTR records",
                 },
                 "zone_cache": {
-                    "supported": is_1_5,
-                    "description": "Cached remote zones loaded via URL or AXFR (VyOS 1.5 only)",
+                    "supported": bool(self.m.supports_zone_cache()),
+                    "description": "Cached remote zones loaded via URL or AXFR",
                 },
                 "options_ecs": {
-                    "supported": is_1_5,
-                    "description": "EDNS Client Subnet options (VyOS 1.5 only)",
+                    "supported": True,
+                    "description": "EDNS Client Subnet options",
                 },
             },
             "version_info": {
@@ -491,7 +491,7 @@ class DNSForwardingBatchBuilder(BatchBuilder):
         return self.add_set(self.m.get_zone_cache_refresh_on_reload(zone))
 
     def delete_zone_cache_refresh_on_reload(self, zone: str) -> "DNSForwardingBatchBuilder":
-        return self.add_delete(self.m.get_zone_cache_refresh_on_reload(zone))
+        return self.add_delete(self.m.get_zone_cache_refresh_on_reload_delete(zone))
 
     def set_zone_cache_retry_interval(self, zone: str, interval: str) -> "DNSForwardingBatchBuilder":
         return self.add_set(self.m.get_zone_cache_retry_interval(zone, interval))

--- a/backend/vyos_mappers/dns_forwarding/dns_forwarding.py
+++ b/backend/vyos_mappers/dns_forwarding/dns_forwarding.py
@@ -301,7 +301,7 @@ class DNSForwardingMapper(BaseFeatureMapper):
         return BASE + ["authoritative-domain", domain, "records", "ptr", hostname]
 
     # ========================================================================
-    # Zone cache (1.5 only — base returns empty list, v1_5 overrides)
+    # Zone cache (1.5 only — 1.4 mapper overrides set methods to raise)
     # ========================================================================
 
     def get_zone_cache_url(self, zone: str, url: str) -> List[str]:
@@ -322,6 +322,9 @@ class DNSForwardingMapper(BaseFeatureMapper):
     def get_zone_cache_refresh_on_reload(self, zone: str) -> List[str]:
         return BASE + ["zone-cache", zone, "options", "refresh", "on-reload"]
 
+    def get_zone_cache_refresh_on_reload_delete(self, zone: str) -> List[str]:
+        return BASE + ["zone-cache", zone, "options", "refresh", "on-reload"]
+
     def get_zone_cache_retry_interval(self, zone: str, interval: str) -> List[str]:
         return BASE + ["zone-cache", zone, "options", "retry-interval", interval]
 
@@ -337,8 +340,11 @@ class DNSForwardingMapper(BaseFeatureMapper):
     def get_zone_caches_delete(self) -> List[str]:
         return BASE + ["zone-cache"]
 
+    def supports_zone_cache(self) -> bool:
+        return True
+
     # ========================================================================
-    # Options / ECS (1.5 only)
+    # Options / ECS
     # ========================================================================
 
     def get_options_ecs_add_for(self, network: str) -> List[str]:

--- a/backend/vyos_mappers/dns_forwarding/dns_forwarding_versions/v1_4.py
+++ b/backend/vyos_mappers/dns_forwarding/dns_forwarding_versions/v1_4.py
@@ -1,5 +1,37 @@
-"""VyOS 1.4 DNS Forwarding mapper — no zone-cache or ECS options support."""
+"""VyOS 1.4 DNS Forwarding mapper — zone-cache is 1.5-only.
+
+Set methods raise. Delete helpers stay on the base mapper so a stale
+zone-cache node can still be removed.
+"""
 
 
 class DNSForwardingMapperV1_4:
-    pass
+    def supports_zone_cache(self) -> bool:
+        return False
+
+    def get_zone_cache_url(self, zone: str, url: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_axfr(self, zone: str, ip: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_dnssec(self, zone: str, mode: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_max_zone_size(self, zone: str, size: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_refresh_interval(self, zone: str, interval: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_refresh_on_reload(self, zone: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_retry_interval(self, zone: str, interval: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_timeout(self, zone: str, timeout: str):
+        raise NotImplementedError("not supported on this VyOS version")
+
+    def get_zone_cache_zonemd(self, zone: str, mode: str):
+        raise NotImplementedError("not supported on this VyOS version")

--- a/frontend/src/lib/api/dns-forwarding.ts
+++ b/frontend/src/lib/api/dns-forwarding.ts
@@ -275,7 +275,7 @@ class DNSForwardingService {
       ops.push({ op: "set_exclude_throttle_address", value: addr });
     }
 
-    // ECS options (1.5 only)
+    // ECS options
     if (caps.features.options_ecs.supported) {
       ops.push({ op: "delete_options_ecs_add_for_all" });
       for (const net of config.ecs_options.ecs_add_for) {


### PR DESCRIPTION
1.4 rejects set service dns forwarding zone-cache. The 1.4 mapper stub did not override the base set methods, so the path still emitted. ECS was flagged 1.5-only even though 1.4 accepts it.

The 1.4 mapper now raises on zone-cache set. Delete stays unguarded so a stale node can still be removed. get_capabilities reads supports_zone_cache from the mapper. options_ecs is supported on both versions.

Lab validateTmplPath: zone-cache INVALID on 1.4, VALID on 1.5. ecs-add-for and ecs-ipv4-bits VALID on both. Tests: PYTHONPATH=backend pytest backend/tests/test_dns_forwarding_version_gates.py (6 passed).

Closes #678