### PR TITLE
fix: read PPPoE sessions via ShowSessionsAccelppp for fleet-wide per-session PPS

### DIFF
--- a/backend/pppoe_status.py
+++ b/backend/pppoe_status.py
@@ -1,12 +1,25 @@
-"""Parsing helpers for VyOS PPPoE server operational status."""
+"""Parsing helpers for VyOS PPPoE server operational status.
 
-import asyncio
-import os
+Active PPPoE sessions are read from the router GraphQL ``ShowSessionsAccelppp``
+operation, which returns structured per-session data including cumulative
+packet counters (``rx_pkts``/``tx_pkts``) for every session in a single call.
+Packets-per-second is derived from the counter deltas between polls by
+``PPPoEPpsTracker``.
+
+If the structured operation is unavailable, the caller falls back to parsing
+the pipe-delimited ``show pppoe-server sessions`` table (``parse_pppoe_sessions``),
+which lists sessions but carries no packet counters, so PPS is left unknown.
+"""
+
+import json
+import logging
 import time
 from typing import Any, Dict, List, Optional
 
+import httpx
 from pydantic import BaseModel
-from starlette.concurrency import run_in_threadpool
+
+logger = logging.getLogger(__name__)
 
 
 class PPPoESession(BaseModel):
@@ -88,128 +101,21 @@ class PPPoEPpsTracker:
         self._previous[key] = (rx_packets, tx_packets, now)
         return rx_pps, tx_pps
 
+    def annotate_sessions(self, device_key: str, sessions: List[PPPoESession]) -> None:
+        """Derive RX/TX PPS for every session from its packet-counter delta.
 
-class PPPoEStatsStore:
-    """Backend-owned cache with a configurable sample window.
-
-    The intention is that each PPPoE interface should be sampled at most once
-    per window cycle and the load is spread dynamically across the active
-    sessions count.
-    """
-
-    def __init__(
-        self,
-        poll_window_seconds: int = 300,
-        sample_batch_size: int = 1,
-        max_concurrent_samples: int = 1,
-        min_sample_interval: float = 1.0,
-    ) -> None:
-        self.poll_window_seconds = int(
-            os.getenv("PPPOE_STATS_POLL_WINDOW_SECONDS", str(poll_window_seconds))
-        )
-        self.sample_batch_size = int(
-            os.getenv("PPPOE_STATS_SAMPLE_BATCH_SIZE", str(sample_batch_size))
-        )
-        self.max_concurrent_samples = int(
-            os.getenv("PPPOE_STATS_POLL_CONCURRENCY", str(max_concurrent_samples))
-        )
-        self.min_sample_interval = float(min_sample_interval)
-        self._last_sample_at: Dict[str, float] = {}
-        self._snapshots: Dict[str, Dict[str, Any]] = {}
-        self._tracker = PPPoEPpsTracker(min_sample_interval=self.min_sample_interval)
-        self._rotate = 0
-
-    def sample_interval_for_session_count(self, session_count: int) -> float:
-        """Return the per-session sample cadence, assuming one sample per session per window."""
-        if session_count <= 0:
-            return float(self.poll_window_seconds)
-        return max(float(self.poll_window_seconds) / float(session_count), 1.0)
-
-    def annotate_sessions_from_cache(self, sessions: List[PPPoESession]) -> None:
-        for session in sessions:
-            cache = self._snapshots.get(session.interface)
-            if not cache:
-                continue
-            session.rx_packets = cache.get("rx_packets", session.rx_packets)
-            session.tx_packets = cache.get("tx_packets", session.tx_packets)
-            session.rx_pps = cache.get("rx_pps", session.rx_pps)
-            session.tx_pps = cache.get("tx_pps", session.tx_pps)
-
-    async def sample_due_sessions(self, service, sessions: List[PPPoESession]) -> None:
-        """Sample only a tiny round-robin subset of sessions each sessions read.
-
-        This keeps PPS and packet counter updates backend-owned while making the
-        request pressure far lighter: the API only asks for one interface's
-        statistics table per response instead of issuing one per session.
+        ``device_key`` scopes the tracked counters to one router connection so
+        interfaces on different instances never collide. Sessions without packet
+        counters (e.g. the text-table fallback) leave PPS unset.
         """
-        if not sessions:
-            return
-
-        session_count = len(sessions)
-        sample_interval = self.sample_interval_for_session_count(session_count)
         now = time.monotonic()
-
-        due_sessions = []
         for session in sessions:
-            last_sample_at = self._last_sample_at.get(session.interface)
-            if last_sample_at is None or (now - last_sample_at) >= sample_interval:
-                due_sessions.append(session)
-
-        if not due_sessions:
-            self.annotate_sessions_from_cache(sessions)
-            return
-
-        # Rotate the due list so we do not hammer the same interfaces repeatedly
-        # and spread the requests evenly through the configured window.
-        batch_size = min(self.sample_batch_size, len(due_sessions))
-        start = self._rotate % len(due_sessions)
-        ordered_due = due_sessions[start:] + due_sessions[:start]
-        selected_sessions = ordered_due[:batch_size]
-        self._rotate = (self._rotate + batch_size) % len(due_sessions)
-
-        semaphore = asyncio.Semaphore(self.max_concurrent_samples)
-
-        async def fetch_one(session: PPPoESession) -> None:
-            async with semaphore:
-                stats_response = await run_in_threadpool(
-                    service.device.show,
-                    path=["interfaces", "pppoe", session.interface, "statistics"],
-                )
-            if stats_response.status != 200:
-                return
-
-            stats_output = (
-                stats_response.result.get("data", "")
-                if isinstance(stats_response.result, dict)
-                else stats_response.result
+            key = f"{device_key}:{session.interface}"
+            rx_pps, tx_pps = self.update(
+                key, session.rx_packets, session.tx_packets, timestamp=now
             )
-            rx_packets, tx_packets = parse_pppoe_interface_statistics(stats_output or "")
-            if rx_packets is None or tx_packets is None:
-                return
-
-            key = f"{id(service.device)}:{session.interface}"
-            rx_pps, tx_pps = self._tracker.update(key, rx_packets, tx_packets, timestamp=time.monotonic())
-            self._last_sample_at[session.interface] = time.monotonic()
-            self._snapshots[session.interface] = {
-                "rx_packets": rx_packets,
-                "tx_packets": tx_packets,
-                "rx_pps": rx_pps,
-                "tx_pps": tx_pps,
-                "updated_at": time.monotonic(),
-            }
-
-            session.rx_packets = rx_packets
-            session.tx_packets = tx_packets
             session.rx_pps = rx_pps
             session.tx_pps = tx_pps
-
-        for session in selected_sessions:
-            try:
-                await fetch_one(session)
-            except Exception:
-                logger.exception("Unhandled error while sampling PPPoE interface statistics for %s", session.interface)
-
-        self.annotate_sessions_from_cache(sessions)
 
 
 def _parse_bytes(value: str) -> int:
@@ -234,32 +140,123 @@ def _parse_bytes(value: str) -> int:
 
 
 def _parse_counter(value: Optional[str]) -> Optional[int]:
-    if not value:
+    if value is None:
+        return None
+    text = str(value).replace(",", "").strip()
+    if not text:
         return None
     try:
-        return int(value.replace(",", ""))
+        return int(text)
     except ValueError:
         return None
 
 
-def parse_pppoe_interface_statistics(output: str) -> tuple[Optional[int], Optional[int]]:
-    """Parse IN and OUT packet counters from PPPoE interface statistics."""
-    if not output or not isinstance(output, str):
-        return None, None
+def _format_uptime(seconds: Optional[str]) -> Optional[str]:
+    """Format accel-ppp ``uptime-raw`` seconds as ``[Nd ]HH:MM:SS``."""
+    total = _parse_counter(seconds)
+    if total is None or total < 0:
+        return None
+    days, remainder = divmod(total, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if days:
+        return f"{days}d {hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
-    numbers = []
-    for line in output.splitlines():
-        fields = line.split()
-        if len(fields) >= 10 and fields[1].isdigit() and fields[5] == "|" and fields[7].isdigit():
-            numbers = [fields[1], fields[7]]
-            break
-    if not numbers:
-        return None, None
-    return int(numbers[0]), int(numbers[1])
+
+def _accel_ppp_sessions_query(api_key: str, protocol: str = "pppoe") -> Dict[str, str]:
+    """Build the GraphQL body for ``ShowSessionsAccelppp``."""
+    key = json.dumps(api_key)
+    proto = json.dumps(protocol)
+    query = (
+        "{ ShowSessionsAccelppp(data: {key: "
+        + key
+        + ", protocol: "
+        + proto
+        + "}) { success errors data { result } } }"
+    )
+    return {"query": query}
+
+
+def parse_accel_ppp_sessions(result: Any) -> List[PPPoESession]:
+    """Parse the structured session list returned by ``ShowSessionsAccelppp``.
+
+    ``result`` is the GraphQL ``data.result`` value: a list of per-session dicts
+    (accel-ppp field names, ``-`` mangled to ``_``). Some deployments return it as
+    a JSON-encoded string, which is decoded here.
+    """
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except ValueError:
+            return []
+    if not isinstance(result, list):
+        return []
+
+    sessions: List[PPPoESession] = []
+    for entry in result:
+        if not isinstance(entry, dict):
+            continue
+        ifname = entry.get("ifname")
+        username = entry.get("username")
+        if not ifname or not username:
+            continue
+        sessions.append(PPPoESession(
+            interface=str(ifname),
+            username=str(username),
+            ip=entry.get("ip") or None,
+            ipv6=entry.get("ip6") or None,
+            ipv6_delegated=entry.get("ip6_dp") or None,
+            calling_sid=entry.get("calling_sid") or None,
+            rate_limit=entry.get("rate_limit") or None,
+            state=str(entry.get("state") or "unknown"),
+            uptime=_format_uptime(entry.get("uptime_raw")),
+            rx_bytes=_parse_counter(entry.get("rx_bytes_raw")) or 0,
+            tx_bytes=_parse_counter(entry.get("tx_bytes_raw")) or 0,
+            rx_packets=_parse_counter(entry.get("rx_pkts")),
+            tx_packets=_parse_counter(entry.get("tx_pkts")),
+        ))
+    return sessions
+
+
+async def fetch_accel_ppp_sessions(service, protocol: str = "pppoe") -> Optional[List[PPPoESession]]:
+    """Fetch active sessions via the ``ShowSessionsAccelppp`` GraphQL operation.
+
+    Returns the parsed session list (possibly empty) on success, or ``None`` when
+    the structured operation is unavailable so the caller can fall back to the
+    text-table path. A ``success: false`` op-mode error (e.g. pppoe-server not
+    configured) is treated as unavailable rather than an empty session set, so the
+    fallback decides the final answer.
+    """
+    api_key = str(service.config.apikey)
+    url = f"{service.config.protocol}://{service.config.hostname}:{service.config.port}/graphql"
+    payload = _accel_ppp_sessions_query(api_key, protocol)
+    try:
+        async with httpx.AsyncClient(verify=service.config.verify, timeout=15.0) as client:
+            resp = await client.post(url, json=payload, auth=("vyos", api_key))
+        if resp.status_code != 200:
+            logger.warning("ShowSessionsAccelppp HTTP error %d", resp.status_code)
+            return None
+        body = resp.json()
+        if body.get("errors"):
+            logger.warning("ShowSessionsAccelppp field errors: %s", body["errors"])
+        node = (body.get("data") or {}).get("ShowSessionsAccelppp") or {}
+        if not node.get("success"):
+            return None
+        result = (node.get("data") or {}).get("result")
+        return parse_accel_ppp_sessions(result)
+    except Exception:
+        logger.exception("ShowSessionsAccelppp fetch failed")
+        return None
 
 
 def parse_pppoe_sessions(output: str) -> List[PPPoESession]:
-    """Parse the pipe-delimited table from ``show pppoe-server sessions``."""
+    """Parse the pipe-delimited table from ``show pppoe-server sessions``.
+
+    Fallback for when the structured ``ShowSessionsAccelppp`` operation is
+    unavailable. The table carries no packet counters in normal operation, so
+    ``rx_packets``/``tx_packets`` (and therefore PPS) are typically unknown here.
+    """
     if not output or not isinstance(output, str):
         return []
 

--- a/backend/routers/pppoe_server/pppoe_server.py
+++ b/backend/routers/pppoe_server/pppoe_server.py
@@ -16,9 +16,9 @@ from fastapi_permissions import require_read_permission, require_write_permissio
 from rbac_permissions import FeatureGroup
 from starlette.concurrency import run_in_threadpool
 from pppoe_status import (
-    PPPoEStatsStore,
     PPPoEPpsTracker,
     PPPoESessionsResponse,
+    fetch_accel_ppp_sessions,
     parse_pppoe_sessions,
 )
 import inspect
@@ -28,7 +28,10 @@ from batch_dispatch import resolve_batch_method
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/pppoe-server", tags=["pppoe-server"])
-_pppoe_stats_store = PPPoEStatsStore()
+# Derives per-session PPS from packet-counter deltas across polls. Scoped per
+# router connection inside annotate_sessions. min_sample_interval guards against
+# noisy sub-second deltas when the UI polls rapidly.
+_pppoe_pps_tracker = PPPoEPpsTracker(min_sample_interval=1.0)
 
 
 # ========================================================================
@@ -107,28 +110,32 @@ async def get_pppoe_sessions(
     limit: int = Query(default=500, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
 ):
-    """Return active PPPoE sessions and backend-maintained PPS snapshots.
+    """Return active PPPoE sessions with per-session packet counters and PPS.
 
-    The backend will not hammer every PPPoE interface statistics endpoint on
-    each request. Instead, it spreads one survey per session across a
-    configurable rolling window, and returns stored RX/TX PPS values from the
-    backend-owned stats store.
+    Sessions are read in a single ``ShowSessionsAccelppp`` GraphQL call, which
+    returns cumulative ``rx_pkts``/``tx_pkts`` for every session. PPS is derived
+    from the counter deltas between polls. If that structured operation is
+    unavailable, the endpoint falls back to parsing the ``show pppoe-server
+    sessions`` text table, which has no packet counters, so PPS is left unset.
     """
     await require_read_permission(http_request, FeatureGroup.PPPOE)
     try:
         service = get_session_vyos_service(http_request)
-        response = await run_in_threadpool(service.device.show, path=["pppoe-server", "sessions"])
-        if response.status != 200:
-            raise HTTPException(
-                status_code=502,
-                detail=response.error or "Unable to read PPPoE sessions",
-            )
-        output = response.result.get("data", "") if isinstance(response.result, dict) else response.result
-        sessions = parse_pppoe_sessions(output or "")
 
-        # Spread the statistics query load over the configured window so the
-        # backend stores PPS values and only samples sessions when due.
-        await _pppoe_stats_store.sample_due_sessions(service, sessions)
+        sessions = await fetch_accel_ppp_sessions(service)
+        if sessions is None:
+            # Structured op unavailable; fall back to the text-table path.
+            response = await run_in_threadpool(service.device.show, path=["pppoe-server", "sessions"])
+            if response.status != 200:
+                raise HTTPException(
+                    status_code=502,
+                    detail=response.error or "Unable to read PPPoE sessions",
+                )
+            output = response.result.get("data", "") if isinstance(response.result, dict) else response.result
+            sessions = parse_pppoe_sessions(output or "")
+
+        # Derive RX/TX PPS from the packet-counter deltas since the previous poll.
+        _pppoe_pps_tracker.annotate_sessions(str(id(service.device)), sessions)
 
         total = len(sessions)
         page = sessions[offset:offset + limit]

--- a/backend/tests/test_pppoe_status.py
+++ b/backend/tests/test_pppoe_status.py
@@ -1,4 +1,9 @@
-from pppoe_status import PPPoEPpsTracker, parse_pppoe_interface_statistics, parse_pppoe_sessions
+from pppoe_status import (
+    PPPoEPpsTracker,
+    PPPoESession,
+    parse_accel_ppp_sessions,
+    parse_pppoe_sessions,
+)
 
 
 def test_pppoe_pps_tracker_uses_counter_delta_and_elapsed_time():
@@ -24,17 +29,140 @@ def test_pppoe_pps_tracker_throttles_sampling_by_min_interval():
     assert tracker.update("device:ppp0", 220, 440, timestamp=11.0) == (120.0, 240.0)
 
 
-def test_parse_pppoe_interface_statistics():
-    output = """
-      IN   PACK VJCOMP  VJUNC  VJERR  |      OUT   PACK VJCOMP  VJUNC NON-VJ
-322444349 480580      0      0      0  | 2074508103 1731184      0      0 1731184
-"""
+def test_annotate_sessions_derives_pps_from_packet_counter_deltas():
+    tracker = PPPoEPpsTracker()
+    device = "device-a"
 
-    assert parse_pppoe_interface_statistics(output) == (480580, 1731184)
+    first = [PPPoESession(interface="ppp0", username="u", state="active", rx_packets=100, tx_packets=200)]
+    tracker.annotate_sessions(device, first)
+    # No prior sample yet, so PPS is unknown on the first poll.
+    assert first[0].rx_pps is None and first[0].tx_pps is None
+
+    # Advance the tracker's stored timestamp so elapsed > 0 on the next poll.
+    import time as _time
+    key = f"{device}:ppp0"
+    rx, tx, _ = tracker._previous[key]
+    tracker._previous[key] = (rx, tx, _time.monotonic() - 4.0)
+
+    second = [PPPoESession(interface="ppp0", username="u", state="active", rx_packets=140, tx_packets=280)]
+    tracker.annotate_sessions(device, second)
+    assert second[0].rx_pps is not None and second[0].rx_pps > 0
+    assert second[0].tx_pps is not None and second[0].tx_pps > second[0].rx_pps
 
 
-def test_parse_empty_pppoe_interface_statistics():
-    assert parse_pppoe_interface_statistics("") == (None, None)
+def test_annotate_sessions_scopes_counters_per_device():
+    tracker = PPPoEPpsTracker()
+
+    a = [PPPoESession(interface="ppp0", username="u", state="active", rx_packets=100, tx_packets=100)]
+    b = [PPPoESession(interface="ppp0", username="u", state="active", rx_packets=999, tx_packets=999)]
+    tracker.annotate_sessions("device-a", a)
+    tracker.annotate_sessions("device-b", b)
+
+    # Different device keys must not share counter history for the same interface.
+    assert tracker._previous["device-a:ppp0"][0] == 100
+    assert tracker._previous["device-b:ppp0"][0] == 999
+
+
+def test_parse_accel_ppp_sessions_reads_packet_counters_and_bytes():
+    result = [
+        {
+            "ifname": "ppp0",
+            "username": "labuser",
+            "ip": "10.55.55.10",
+            "ip6": "",
+            "ip6_dp": "",
+            "type": "pppoe",
+            "rate_limit": "10000/5000",
+            "state": "active",
+            "uptime_raw": "30",
+            "calling_sid": "5a:2f:45:d9:b0:16",
+            "sid": "7da9cdc301f030c1",
+            "comp": "",
+            "rx_bytes_raw": "4186",
+            "tx_bytes_raw": "3870",
+            "rx_pkts": "29",
+            "tx_pkts": "25",
+        }
+    ]
+
+    sessions = parse_accel_ppp_sessions(result)
+
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s.interface == "ppp0"
+    assert s.username == "labuser"
+    assert s.ip == "10.55.55.10"
+    assert s.rate_limit == "10000/5000"
+    assert s.rx_bytes == 4186
+    assert s.tx_bytes == 3870
+    assert s.rx_packets == 29
+    assert s.tx_packets == 25
+    assert s.uptime == "00:00:30"
+    # Empty accel-ppp fields become None, not "".
+    assert s.ipv6 is None
+    assert s.ipv6_delegated is None
+
+
+def test_parse_accel_ppp_sessions_formats_dual_stack_and_long_uptime():
+    result = [
+        {
+            "ifname": "ppp2",
+            "username": "user-1",
+            "ip": "192.0.2.10",
+            "ip6": "2001:db8:200::/64",
+            "ip6_dp": "2001:db8:140::/56",
+            "state": "active",
+            "uptime_raw": str(2 * 86400 + 3 * 3600 + 4 * 60 + 5),
+            "rx_bytes_raw": "1000",
+            "tx_bytes_raw": "2000",
+            "rx_pkts": "10",
+            "tx_pkts": "20",
+        }
+    ]
+
+    s = parse_accel_ppp_sessions(result)[0]
+
+    assert s.ipv6 == "2001:db8:200::/64"
+    assert s.ipv6_delegated == "2001:db8:140::/56"
+    assert s.uptime == "2d 03:04:05"
+
+
+def test_parse_accel_ppp_sessions_accepts_json_encoded_string_result():
+    import json
+    result = json.dumps([
+        {"ifname": "ppp0", "username": "u", "state": "active", "rx_pkts": "5", "tx_pkts": "6"}
+    ])
+
+    sessions = parse_accel_ppp_sessions(result)
+
+    assert len(sessions) == 1
+    assert sessions[0].rx_packets == 5
+    assert sessions[0].tx_packets == 6
+
+
+def test_parse_accel_ppp_sessions_ignores_incomplete_or_invalid_rows():
+    assert parse_accel_ppp_sessions(None) == []
+    assert parse_accel_ppp_sessions("not json") == []
+    assert parse_accel_ppp_sessions([{"ifname": "ppp0"}]) == []  # missing username
+    assert parse_accel_ppp_sessions([{"username": "u"}]) == []  # missing ifname
+    assert parse_accel_ppp_sessions(["nonsense", 42]) == []
+
+
+def test_parse_accel_ppp_sessions_missing_counters_leave_pps_unknown():
+    result = [{"ifname": "ppp0", "username": "u", "state": "active"}]
+
+    s = parse_accel_ppp_sessions(result)[0]
+
+    assert s.rx_packets is None
+    assert s.tx_packets is None
+    assert s.rx_bytes == 0
+    assert s.tx_bytes == 0
+
+
+# ----------------------------------------------------------------------------
+# Text-table fallback (parse_pppoe_sessions): retained for when the structured
+# ShowSessionsAccelppp operation is unavailable.
+# ----------------------------------------------------------------------------
 
 
 def test_parse_ipv4_pppoe_session_table():

--- a/docs-site/docs/api/get-pppoe-sessions-vyos-pppoe-server-sessions-get.api.mdx
+++ b/docs-site/docs/api/get-pppoe-sessions-vyos-pppoe-server-sessions-get.api.mdx
@@ -1,7 +1,7 @@
 ---
 id: get-pppoe-sessions-vyos-pppoe-server-sessions-get
 title: "Get Pppoe Sessions"
-description: "Return active PPPoE sessions and their cumulative traffic counters."
+description: "Return active PPPoE sessions with per-session packet counters and derived packets-per-second."
 sidebar_label: "Get Pppoe Sessions"
 hide_title: true
 hide_table_of_contents: true
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 
 
-Return active PPPoE sessions and their cumulative traffic counters.
+Return active PPPoE sessions with per-session packet counters and derived packets-per-second.
 
 <Heading
   id={"request"}

--- a/docs-site/openapi/vymanager.json
+++ b/docs-site/openapi/vymanager.json
@@ -15465,7 +15465,7 @@
           "pppoe-server"
         ],
         "summary": "Get Pppoe Sessions",
-        "description": "Return active PPPoE sessions and their cumulative traffic counters.",
+        "description": "Return active PPPoE sessions with per-session packet counters and derived packets-per-second.",
         "operationId": "get_pppoe_sessions_vyos_pppoe_server_sessions_get",
         "parameters": [
           {


### PR DESCRIPTION
## What was wrong

`GET /vyos/pppoe-server/sessions` derived per-session PPS the expensive way. The text table from `show pppoe-server sessions` carries no packet columns, so the backend round-robined `show interfaces pppoe <if> statistics` one interface per request across a 300s window (`PPPoEStatsStore`). With N sessions any given session's PPS refreshed at best once per window, so PPS was stale for most sessions most of the time.

## What changed

Read sessions from the router `ShowSessionsAccelppp(protocol: "pppoe")` GraphQL operation, which returns structured per-session data including cumulative `rx_pkts`/`tx_pkts` for every session in a single call. PPS is derived from the counter deltas between polls for all sessions each poll.

- `backend/pppoe_status.py`: add `fetch_accel_ppp_sessions` (single GraphQL POST, same pattern as the dashboard in `routers/show.py`) and `parse_accel_ppp_sessions`. `PPPoEPpsTracker` gains `annotate_sessions`, which derives RX/TX PPS from each session's packet-counter delta, scoped per router connection. Removed the `PPPoEStatsStore` round-robin per-interface sampler, `parse_pppoe_interface_statistics`, and the `PPPOE_STATS_*` env knobs.
- `backend/routers/pppoe_server/pppoe_server.py`: sessions endpoint calls the GraphQL path, falls back to the text-table parser when the structured op is unavailable, then annotates PPS.
- The `PPPoESession`/`PPPoESessionsResponse` shape is unchanged, so the frontend contract holds; no frontend type or display changes were needed. `uptime_raw` seconds are formatted to the `[Nd ]HH:MM:SS` string the UI already renders.
- Text-table fallback (`parse_pppoe_sessions`) retained for when the op errors (e.g. pppoe-server not configured).
- Docs: synced the sessions endpoint description in the committed OpenAPI spec and API mdx page. A full `export_openapi.py` regen was intentionally avoided because it rewrites operationIds/summaries/schema refs across hundreds of unrelated endpoints (FastAPI/pydantic version drift vs the committed artifact).

## Tests

- `pytest backend/tests/test_pppoe_status.py` — 16 passed. New coverage: `ShowSessionsAccelppp` parse (packet counters, bytes, dual-stack, uptime formatting incl. multi-day, JSON-string result, invalid/incomplete rows), per-device PPS scoping, and PPS derivation via `annotate_sessions`.
- Full backend suite: 1084 passed, 36 skipped.
- Live lab validation: stood up a real PPPoE session (1.4 server on 100.64.64.50, 1.5 client on 100.64.64.5), ran the actual `fetch_accel_ppp_sessions` + `annotate_sessions` code against the live router under a traffic stream. Poll 1 seeded counters (PPS unset by design), poll 2 derived ~32 pps both directions from the delta; `ip`, `rx_bytes`, and formatted `uptime` populated correctly. Config was applied then deleted (never saved); both hosts verified clean with management/API intact.

Closes #688
