### PR TITLE
fix: serve PPPoE sessions on the dashboard SSE stream

### DIFF
--- a/backend/pppoe_status.py
+++ b/backend/pppoe_status.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 from pydantic import BaseModel
 
+from starlette.concurrency import run_in_threadpool
+
 logger = logging.getLogger(__name__)
 
 
@@ -116,6 +118,11 @@ class PPPoEPpsTracker:
             )
             session.rx_pps = rx_pps
             session.tx_pps = tx_pps
+
+
+# Shared across the REST sessions endpoint and the dashboard SSE broadcaster so
+# PPS deltas stay continuous if both paths run against the same router.
+PPPOE_PPS_TRACKER = PPPoEPpsTracker(min_sample_interval=1.0)
 
 
 def _parse_bytes(value: str) -> int:
@@ -248,6 +255,42 @@ async def fetch_accel_ppp_sessions(service, protocol: str = "pppoe") -> Optional
     except Exception:
         logger.exception("ShowSessionsAccelppp fetch failed")
         return None
+
+
+def pppoe_configured(full_config) -> bool:
+    """True when ``service pppoe-server`` is configured (gates the dashboard fetch)."""
+    service = (full_config or {}).get("service", {}) or {}
+    return "pppoe-server" in service
+
+
+async def load_pppoe_sessions(service) -> List[PPPoESession]:
+    """Load sessions (GraphQL, then text-table fallback) and annotate PPS.
+
+    Used by both the REST sessions endpoint and the dashboard SSE broadcaster so
+    the two paths share one tracker. Failures degrade to an empty list rather
+    than raising, so a missing pppoe-server does not 502 the stream.
+    """
+    sessions = await fetch_accel_ppp_sessions(service)
+    if sessions is None:
+        try:
+            response = await run_in_threadpool(
+                service.device.show, path=["pppoe-server", "sessions"]
+            )
+        except Exception:
+            logger.exception("PPPoE sessions text-table fallback failed")
+            sessions = []
+        else:
+            if response.status != 200:
+                sessions = []
+            else:
+                output = (
+                    response.result.get("data", "")
+                    if isinstance(response.result, dict)
+                    else response.result
+                )
+                sessions = parse_pppoe_sessions(output or "")
+    PPPOE_PPS_TRACKER.annotate_sessions(str(id(service.device)), sessions)
+    return sessions
 
 
 def parse_pppoe_sessions(output: str) -> List[PPPoESession]:

--- a/backend/pppoe_status.py
+++ b/backend/pppoe_status.py
@@ -24,6 +24,14 @@ from starlette.concurrency import run_in_threadpool
 logger = logging.getLogger(__name__)
 
 
+class PPPoESessionsUnavailable(Exception):
+    """Both the GraphQL op and the text-table fallback failed to read sessions."""
+
+    def __init__(self, detail: str = "Unable to read PPPoE sessions") -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
 class PPPoESession(BaseModel):
     interface: str
     username: str
@@ -267,8 +275,10 @@ async def load_pppoe_sessions(service) -> List[PPPoESession]:
     """Load sessions (GraphQL, then text-table fallback) and annotate PPS.
 
     Used by both the REST sessions endpoint and the dashboard SSE broadcaster so
-    the two paths share one tracker. Failures degrade to an empty list rather
-    than raising, so a missing pppoe-server does not 502 the stream.
+    the two paths share one tracker. Raises ``PPPoESessionsUnavailable`` when
+    both the structured op and the text-table fallback fail. The REST endpoint
+    maps that to HTTP 502; the SSE path treats it as a fetch error and does not
+    502 the stream.
     """
     sessions = await fetch_accel_ppp_sessions(service)
     if sessions is None:
@@ -276,19 +286,19 @@ async def load_pppoe_sessions(service) -> List[PPPoESession]:
             response = await run_in_threadpool(
                 service.device.show, path=["pppoe-server", "sessions"]
             )
-        except Exception:
+        except Exception as exc:
             logger.exception("PPPoE sessions text-table fallback failed")
-            sessions = []
-        else:
-            if response.status != 200:
-                sessions = []
-            else:
-                output = (
-                    response.result.get("data", "")
-                    if isinstance(response.result, dict)
-                    else response.result
-                )
-                sessions = parse_pppoe_sessions(output or "")
+            raise PPPoESessionsUnavailable("Unable to read PPPoE sessions") from exc
+        if response.status != 200:
+            raise PPPoESessionsUnavailable(
+                response.error or "Unable to read PPPoE sessions"
+            )
+        output = (
+            response.result.get("data", "")
+            if isinstance(response.result, dict)
+            else response.result
+        )
+        sessions = parse_pppoe_sessions(output or "")
     PPPOE_PPS_TRACKER.annotate_sessions(str(id(service.device)), sessions)
     return sessions
 

--- a/backend/routers/pppoe_server/pppoe_server.py
+++ b/backend/routers/pppoe_server/pppoe_server.py
@@ -17,6 +17,7 @@ from rbac_permissions import FeatureGroup
 from starlette.concurrency import run_in_threadpool
 from pppoe_status import (
     PPPoESessionsResponse,
+    PPPoESessionsUnavailable,
     load_pppoe_sessions,
 )
 import inspect
@@ -118,7 +119,10 @@ async def get_pppoe_sessions(
     await require_read_permission(http_request, FeatureGroup.PPPOE)
     try:
         service = get_session_vyos_service(http_request)
-        sessions = await load_pppoe_sessions(service)
+        try:
+            sessions = await load_pppoe_sessions(service)
+        except PPPoESessionsUnavailable as exc:
+            raise HTTPException(status_code=502, detail=exc.detail) from exc
 
         total = len(sessions)
         page = sessions[offset:offset + limit]

--- a/backend/routers/pppoe_server/pppoe_server.py
+++ b/backend/routers/pppoe_server/pppoe_server.py
@@ -16,10 +16,8 @@ from fastapi_permissions import require_read_permission, require_write_permissio
 from rbac_permissions import FeatureGroup
 from starlette.concurrency import run_in_threadpool
 from pppoe_status import (
-    PPPoEPpsTracker,
     PPPoESessionsResponse,
-    fetch_accel_ppp_sessions,
-    parse_pppoe_sessions,
+    load_pppoe_sessions,
 )
 import inspect
 import logging
@@ -28,10 +26,6 @@ from batch_dispatch import resolve_batch_method
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/vyos/pppoe-server", tags=["pppoe-server"])
-# Derives per-session PPS from packet-counter deltas across polls. Scoped per
-# router connection inside annotate_sessions. min_sample_interval guards against
-# noisy sub-second deltas when the UI polls rapidly.
-_pppoe_pps_tracker = PPPoEPpsTracker(min_sample_interval=1.0)
 
 
 # ========================================================================
@@ -117,25 +111,14 @@ async def get_pppoe_sessions(
     from the counter deltas between polls. If that structured operation is
     unavailable, the endpoint falls back to parsing the ``show pppoe-server
     sessions`` text table, which has no packet counters, so PPS is left unset.
+
+    Live consumers should prefer the dashboard SSE ``pppoe-sessions`` event;
+    this REST path remains for a one-shot refresh.
     """
     await require_read_permission(http_request, FeatureGroup.PPPOE)
     try:
         service = get_session_vyos_service(http_request)
-
-        sessions = await fetch_accel_ppp_sessions(service)
-        if sessions is None:
-            # Structured op unavailable; fall back to the text-table path.
-            response = await run_in_threadpool(service.device.show, path=["pppoe-server", "sessions"])
-            if response.status != 200:
-                raise HTTPException(
-                    status_code=502,
-                    detail=response.error or "Unable to read PPPoE sessions",
-                )
-            output = response.result.get("data", "") if isinstance(response.result, dict) else response.result
-            sessions = parse_pppoe_sessions(output or "")
-
-        # Derive RX/TX PPS from the packet-counter deltas since the previous poll.
-        _pppoe_pps_tracker.annotate_sessions(str(id(service.device)), sessions)
+        sessions = await load_pppoe_sessions(service)
 
         total = len(sessions)
         page = sessions[offset:offset + limit]

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -1135,6 +1135,7 @@ class DeviceDataBroadcaster:
         self._subscribers = [item for item in self._subscribers if item[0] is not q]
         if not self._has_interest("pppoe-sessions") and self._pppoe_task and not self._pppoe_task.done():
             self._pppoe_task.cancel()
+            self._pppoe_task = None
         if not self._subscribers:
             if self._task and not self._task.done():
                 self._task.cancel()
@@ -1337,6 +1338,9 @@ class DeviceDataBroadcaster:
             if self._pppoe_task is not None and self._pppoe_task.done():
                 try:
                     sessions = self._pppoe_task.result() or []
+                except asyncio.CancelledError:
+                    self._pppoe_task = None
+                    return
                 except Exception:
                     logger.exception("Broadcaster: pppoe-sessions fetch error")
                     sessions = []

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -8,7 +8,7 @@ The SSE dashboard stream uses the VyOS GraphQL API to fetch all data in a single
 HTTP request, replacing multiple individual SSH show commands.
 """
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
@@ -35,6 +35,7 @@ from vrrp_status import vrrp_configured, vrrp_gql_fields, build_vrrp_status
 from bgp_status import bgp_configured, bgp_gql_fields, build_bgp_status
 from ipsec_status import ipsec_configured, ipsec_gql_fields, build_ipsec_status
 from hardware_status import HardwareSensorsResponse, parse_hardware_sensors
+from pppoe_status import load_pppoe_sessions, pppoe_configured
 import logging
 logger = logging.getLogger(__name__)
 
@@ -1065,6 +1066,7 @@ _FAST_INTERVAL = 3.0     # seconds between fast cycles (interface counters)
 _SLOW_EVERY = 5          # emit system-info / WG every N fast cycles (= every 15 s)
 _WG_MIN_INTERVAL = 15.0  # minimum seconds between WireGuard status queries
 _OPENVPN_MIN_INTERVAL = 6.0  # minimum seconds between (slow, erratic) OpenVPN status queries
+_STREAM_INTERESTS = frozenset({"pppoe-sessions"})
 
 
 class DeviceDataBroadcaster:
@@ -1081,7 +1083,7 @@ class DeviceDataBroadcaster:
     def __init__(self, key: str, service) -> None:
         self._key = key
         self._service = service
-        self._subscribers: list[asyncio.Queue] = []
+        self._subscribers: list[tuple[asyncio.Queue, frozenset[str]]] = []
         self._task: Optional[asyncio.Task] = None
         self._wg_task: Optional[asyncio.Task] = None
         self._last_wg_status: dict = {}
@@ -1104,15 +1106,25 @@ class DeviceDataBroadcaster:
         self._bgp_configured: bool = False
         # Whether IPSec is configured (gates the show ipsec connections fetch).
         self._ipsec_configured: bool = False
+        # Whether service pppoe-server is configured (gates the sessions fetch).
+        self._pppoe_configured: bool = False
+        self._pppoe_task: Optional[asyncio.Task] = None
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def subscribe(self) -> asyncio.Queue:
-        """Add a subscriber queue and ensure the background task is running."""
+    def subscribe(self, interests: Optional[set[str]] = None) -> asyncio.Queue:
+        """Add a subscriber queue and ensure the background task is running.
+
+        ``interests`` is an optional set of extra event types this subscriber
+        wants fetched. Only names in ``_STREAM_INTERESTS`` are honoured. The
+        PPPoE sessions GraphQL call runs only when at least one current
+        subscriber asked for ``pppoe-sessions``.
+        """
         q: asyncio.Queue = asyncio.Queue(maxsize=32)
-        self._subscribers.append(q)
+        wanted = frozenset(i for i in (interests or set()) if i in _STREAM_INTERESTS)
+        self._subscribers.append((q, wanted))
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self._run())
             self._task.add_done_callback(self._on_task_done)
@@ -1120,10 +1132,9 @@ class DeviceDataBroadcaster:
 
     def unsubscribe(self, q: asyncio.Queue) -> None:
         """Remove a subscriber queue; stop background tasks when the last one leaves."""
-        try:
-            self._subscribers.remove(q)
-        except ValueError:
-            pass
+        self._subscribers = [item for item in self._subscribers if item[0] is not q]
+        if not self._has_interest("pppoe-sessions") and self._pppoe_task and not self._pppoe_task.done():
+            self._pppoe_task.cancel()
         if not self._subscribers:
             if self._task and not self._task.done():
                 self._task.cancel()
@@ -1131,7 +1142,12 @@ class DeviceDataBroadcaster:
                 self._wg_task.cancel()
             if self._openvpn_task and not self._openvpn_task.done():
                 self._openvpn_task.cancel()
+            if self._pppoe_task and not self._pppoe_task.done():
+                self._pppoe_task.cancel()
             _broadcasters.pop(self._key, None)
+
+    def _has_interest(self, name: str) -> bool:
+        return any(name in interests for _, interests in self._subscribers)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -1139,7 +1155,7 @@ class DeviceDataBroadcaster:
 
     def _push_to_all(self, event: dict) -> None:
         """Put an event into every subscriber queue. Drop oldest if full."""
-        for q in list(self._subscribers):
+        for q, _interests in list(self._subscribers):
             if q.full():
                 try:
                     q.get_nowait()
@@ -1248,6 +1264,7 @@ class DeviceDataBroadcaster:
             self._vrrp_configured = vrrp_configured(cfg)
             self._bgp_configured = bgp_configured(cfg)
             self._ipsec_configured = ipsec_configured(cfg)
+            self._pppoe_configured = pppoe_configured(cfg)
         except Exception:
             logger.exception("Broadcaster: config-state refresh error")
 
@@ -1309,6 +1326,37 @@ class DeviceDataBroadcaster:
             logger.exception("Broadcaster: ipsec-status parse error")
             self._push_to_all({"type": "error", "data": {"channel": "ipsec-status", "message": "Parse failed"}})
 
+    def _handle_pppoe_cycle(self, *, start: bool) -> None:
+        """Collect a completed PPPoE sessions fetch; start a new one on the slow cycle.
+
+        ``ShowSessionsAccelppp`` is a ~2s GraphQL call, so it runs off the shared
+        query path (same pattern as OpenVPN) and is only started when pppoe-server
+        is configured and a subscriber asked for ``pppoe-sessions``.
+        """
+        try:
+            if self._pppoe_task is not None and self._pppoe_task.done():
+                try:
+                    sessions = self._pppoe_task.result() or []
+                except Exception:
+                    logger.exception("Broadcaster: pppoe-sessions fetch error")
+                    sessions = []
+                self._pppoe_task = None
+                payload = {
+                    "sessions": [s.model_dump() for s in sessions],
+                    "total": len(sessions),
+                }
+                self._push_to_all({"type": "pppoe-sessions", "data": payload})
+
+            if not start:
+                return
+            if not self._pppoe_configured or not self._has_interest("pppoe-sessions"):
+                return
+            if self._pppoe_task is None:
+                self._pppoe_task = asyncio.create_task(load_pppoe_sessions(self._service))
+        except Exception:
+            logger.exception("Broadcaster: pppoe-sessions error")
+            self._push_to_all({"type": "error", "data": {"channel": "pppoe-sessions", "message": "Failed to fetch"}})
+
     def _on_task_done(self, fut: asyncio.Future) -> None:
         """Clean up if _run() exits unexpectedly."""
         if fut.cancelled():
@@ -1321,6 +1369,8 @@ class DeviceDataBroadcaster:
                 self._wg_task.cancel()
             if self._openvpn_task and not self._openvpn_task.done():
                 self._openvpn_task.cancel()
+            if self._pppoe_task and not self._pppoe_task.done():
+                self._pppoe_task.cancel()
 
     # ------------------------------------------------------------------
     # Main loop
@@ -1367,6 +1417,10 @@ class DeviceDataBroadcaster:
                 if self._openvpn_configured:
                     self._handle_openvpn_cycle()
 
+                # Collect a completed PPPoE fetch every cycle so the first result
+                # is not delayed until the next slow tick; only start on slow.
+                self._handle_pppoe_cycle(start=(cycle % _SLOW_EVERY == 0))
+
                 cycle += 1
                 await asyncio.sleep(_FAST_INTERVAL)
         except asyncio.CancelledError:
@@ -1376,6 +1430,8 @@ class DeviceDataBroadcaster:
                 self._wg_task.cancel()
             if self._openvpn_task and not self._openvpn_task.done():
                 self._openvpn_task.cancel()
+            if self._pppoe_task and not self._pppoe_task.done():
+                self._pppoe_task.cancel()
 
 
 # Global broadcaster registry: instance_id -> DeviceDataBroadcaster
@@ -1397,29 +1453,40 @@ def _get_broadcaster(service) -> DeviceDataBroadcaster:
 
 
 @router.get("/stream")
-async def dashboard_stream(request: Request):
+async def dashboard_stream(
+    request: Request,
+    interest: Optional[List[str]] = Query(default=None),
+):
     """
     Server-Sent Events stream for dashboard data.
 
     All clients connected to the same VyOS instance share one DeviceDataBroadcaster
     that runs a single set of VyOS GraphQL queries.
 
-    Fast data  (interface counters): every 1 s.
-    Slow data  (system info, WG config): every 5 s.
+    Fast data  (interface counters): every 3 s.
+    Slow data  (system info, WG config, PPPoE sessions when requested): every 15 s.
     WG live peers: background task, 15 s minimum between queries.
+
+    Pass ``interest=pppoe-sessions`` to have the broadcaster fetch PPPoE session
+    counters. The fetch is skipped unless pppoe-server is configured and at least
+    one current subscriber requested that interest.
     """
     service = get_session_vyos_service(request)
     include_wireguard = await has_permission(request, FeatureGroup.WIREGUARD, PermissionLevel.READ)
     include_vrrp = await has_permission(request, FeatureGroup.HIGH_AVAILABILITY, PermissionLevel.READ)
     include_bgp = await has_permission(request, FeatureGroup.BGP, PermissionLevel.READ)
+    include_pppoe = await has_permission(request, FeatureGroup.PPPOE, PermissionLevel.READ)
     broadcaster = _get_broadcaster(service)
 
     instance_id: str = service.config.instance_id
     user_id: str = request.state.user["id"]
+    requested = {name for name in (interest or []) if name in _STREAM_INTERESTS}
+    if not include_pppoe:
+        requested.discard("pppoe-sessions")
 
     async def event_generator():
         from routers.events import _has_active_session
-        queue = broadcaster.subscribe()
+        queue = broadcaster.subscribe(requested)
         try:
             yield 'event: connected\ndata: {"message":"Dashboard stream connected"}\n\n'
             while True:
@@ -1446,6 +1513,8 @@ async def dashboard_stream(request: Request):
                 if event["type"] == "vrrp-status" and not include_vrrp:
                     continue
                 if event["type"] == "bgp-status" and not include_bgp:
+                    continue
+                if event["type"] == "pppoe-sessions" and not include_pppoe:
                     continue
                 yield f'event: {event["type"]}\ndata: {json.dumps(event["data"])}\n\n'
         finally:

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -1343,7 +1343,12 @@ class DeviceDataBroadcaster:
                     return
                 except Exception:
                     logger.exception("Broadcaster: pppoe-sessions fetch error")
-                    sessions = []
+                    self._pppoe_task = None
+                    self._push_to_all({
+                        "type": "error",
+                        "data": {"channel": "pppoe-sessions", "message": "Failed to fetch"},
+                    })
+                    return
                 self._pppoe_task = None
                 payload = {
                     "sessions": [s.model_dump() for s in sessions],

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -1358,7 +1358,13 @@ class DeviceDataBroadcaster:
 
             if not start:
                 return
-            if not self._pppoe_configured or not self._has_interest("pppoe-sessions"):
+            if not self._has_interest("pppoe-sessions"):
+                return
+            if not self._pppoe_configured:
+                self._push_to_all({
+                    "type": "pppoe-sessions",
+                    "data": {"sessions": [], "total": 0},
+                })
                 return
             if self._pppoe_task is None:
                 self._pppoe_task = asyncio.create_task(load_pppoe_sessions(self._service))

--- a/backend/tests/test_dashboard_pppoe_interest.py
+++ b/backend/tests/test_dashboard_pppoe_interest.py
@@ -76,3 +76,29 @@ def test_pppoe_cycle_swallows_cancelled_task_without_killing_the_loop():
         assert broadcaster._pppoe_task is None
 
     asyncio.run(scenario())
+
+
+def test_pppoe_cycle_failed_fetch_emits_error_not_empty_sessions():
+    async def scenario():
+        broadcaster = DeviceDataBroadcaster("instance", service=object())
+        pushed = []
+        broadcaster._push_to_all = lambda event: pushed.append(event)
+
+        async def boom():
+            raise RuntimeError("router down")
+
+        task = asyncio.create_task(boom())
+        try:
+            await task
+        except RuntimeError:
+            pass
+        broadcaster._pppoe_task = task
+        broadcaster._handle_pppoe_cycle(start=False)
+        assert all(event["type"] != "pppoe-sessions" for event in pushed)
+        assert any(
+            event["type"] == "error" and event["data"]["channel"] == "pppoe-sessions"
+            for event in pushed
+        )
+        assert broadcaster._pppoe_task is None
+
+    asyncio.run(scenario())

--- a/backend/tests/test_dashboard_pppoe_interest.py
+++ b/backend/tests/test_dashboard_pppoe_interest.py
@@ -45,3 +45,34 @@ def test_pppoe_cycle_does_not_start_fetch_without_config_and_interest():
     broadcaster._subscribers = []
     broadcaster._handle_pppoe_cycle(start=True)
     assert broadcaster._pppoe_task is None
+
+
+def test_unsubscribe_clears_in_flight_pppoe_task():
+    async def scenario():
+        broadcaster = DeviceDataBroadcaster("instance", service=object())
+        queue = asyncio.Queue()
+        other = asyncio.Queue()
+        broadcaster._subscribers.append((queue, frozenset({"pppoe-sessions"})))
+        broadcaster._subscribers.append((other, frozenset()))
+        broadcaster._pppoe_task = asyncio.create_task(asyncio.sleep(60))
+        broadcaster.unsubscribe(queue)
+        assert broadcaster._pppoe_task is None
+        assert broadcaster._subscribers == [(other, frozenset())]
+
+    asyncio.run(scenario())
+
+
+def test_pppoe_cycle_swallows_cancelled_task_without_killing_the_loop():
+    async def scenario():
+        broadcaster = DeviceDataBroadcaster("instance", service=object())
+        task = asyncio.create_task(asyncio.sleep(60))
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        broadcaster._pppoe_task = task
+        broadcaster._handle_pppoe_cycle(start=False)
+        assert broadcaster._pppoe_task is None
+
+    asyncio.run(scenario())

--- a/backend/tests/test_dashboard_pppoe_interest.py
+++ b/backend/tests/test_dashboard_pppoe_interest.py
@@ -47,6 +47,18 @@ def test_pppoe_cycle_does_not_start_fetch_without_config_and_interest():
     assert broadcaster._pppoe_task is None
 
 
+def test_pppoe_cycle_emits_empty_snapshot_when_not_configured():
+    broadcaster = DeviceDataBroadcaster("instance", service=object())
+    pushed = []
+    broadcaster._push_to_all = lambda event: pushed.append(event)
+    queue = asyncio.Queue()
+    broadcaster._subscribers.append((queue, frozenset({"pppoe-sessions"})))
+    broadcaster._pppoe_configured = False
+    broadcaster._handle_pppoe_cycle(start=True)
+    assert broadcaster._pppoe_task is None
+    assert pushed == [{"type": "pppoe-sessions", "data": {"sessions": [], "total": 0}}]
+
+
 def test_unsubscribe_clears_in_flight_pppoe_task():
     async def scenario():
         broadcaster = DeviceDataBroadcaster("instance", service=object())

--- a/backend/tests/test_dashboard_pppoe_interest.py
+++ b/backend/tests/test_dashboard_pppoe_interest.py
@@ -1,0 +1,47 @@
+"""Interest gating for the dashboard PPPoE sessions SSE event."""
+
+import asyncio
+
+from routers.show import DeviceDataBroadcaster, _STREAM_INTERESTS
+
+
+def test_stream_interests_allowlist():
+    assert _STREAM_INTERESTS == frozenset({"pppoe-sessions"})
+
+
+def test_has_interest_false_until_a_viewer_subscribes():
+    broadcaster = DeviceDataBroadcaster("instance", service=object())
+    assert broadcaster._has_interest("pppoe-sessions") is False
+
+    queue = asyncio.Queue()
+    broadcaster._subscribers.append((queue, frozenset({"pppoe-sessions"})))
+    assert broadcaster._has_interest("pppoe-sessions") is True
+
+    broadcaster.unsubscribe(queue)
+    assert broadcaster._has_interest("pppoe-sessions") is False
+    assert broadcaster._subscribers == []
+
+
+def test_unknown_interest_does_not_enable_pppoe_fetch():
+    broadcaster = DeviceDataBroadcaster("instance", service=object())
+    queue = asyncio.Queue()
+    broadcaster._subscribers.append((queue, frozenset({"not-a-real-interest"})))
+    assert broadcaster._has_interest("pppoe-sessions") is False
+
+
+def test_pppoe_cycle_does_not_start_fetch_without_config_and_interest():
+    broadcaster = DeviceDataBroadcaster("instance", service=object())
+    broadcaster._pppoe_configured = False
+    broadcaster._handle_pppoe_cycle(start=True)
+    assert broadcaster._pppoe_task is None
+
+    queue = asyncio.Queue()
+    broadcaster._subscribers.append((queue, frozenset({"pppoe-sessions"})))
+    broadcaster._handle_pppoe_cycle(start=True)
+    assert broadcaster._pppoe_task is None
+
+    broadcaster._pppoe_configured = True
+    # No interest after removing the subscriber.
+    broadcaster._subscribers = []
+    broadcaster._handle_pppoe_cycle(start=True)
+    assert broadcaster._pppoe_task is None

--- a/backend/tests/test_pppoe_status.py
+++ b/backend/tests/test_pppoe_status.py
@@ -3,6 +3,7 @@ from pppoe_status import (
     PPPoESession,
     parse_accel_ppp_sessions,
     parse_pppoe_sessions,
+    pppoe_configured,
 )
 
 
@@ -246,3 +247,11 @@ def test_parse_vyos_session_output_with_ipv6_and_decimal_units():
     assert sessions[0].rx_bytes == int(21.8 * 1024 ** 2)
     assert sessions[0].tx_bytes == int(607.0 * 1024 ** 2)
     assert sessions[1].ipv6_delegated is None
+
+
+def test_pppoe_configured_gates_on_service_tree():
+    assert pppoe_configured(None) is False
+    assert pppoe_configured({}) is False
+    assert pppoe_configured({"service": {}}) is False
+    assert pppoe_configured({"service": {"pppoe-server": {}}}) is True
+    assert pppoe_configured({"service": {"pppoe-server": {"interface": {"eth0": {}}}}}) is True

--- a/backend/tests/test_pppoe_status.py
+++ b/backend/tests/test_pppoe_status.py
@@ -5,6 +5,7 @@ from pppoe_status import (
     parse_pppoe_sessions,
     pppoe_configured,
 )
+import pytest
 
 
 def test_pppoe_pps_tracker_uses_counter_delta_and_elapsed_time():
@@ -255,3 +256,34 @@ def test_pppoe_configured_gates_on_service_tree():
     assert pppoe_configured({"service": {}}) is False
     assert pppoe_configured({"service": {"pppoe-server": {}}}) is True
     assert pppoe_configured({"service": {"pppoe-server": {"interface": {"eth0": {}}}}}) is True
+
+
+def test_load_pppoe_sessions_raises_when_fallback_fails():
+    import asyncio
+    from types import SimpleNamespace
+    from pppoe_status import PPPoESessionsUnavailable, load_pppoe_sessions
+
+    class Boom:
+        status = 502
+        error = "Unable to read PPPoE sessions"
+        result = {}
+
+    service = SimpleNamespace(
+        config=SimpleNamespace(
+            apikey="k", protocol="https", hostname="127.0.0.1", port=1, verify=False
+        ),
+        device=SimpleNamespace(show=lambda path: Boom()),
+    )
+
+    async def fake_fetch(_service, protocol="pppoe"):
+        return None
+
+    import pppoe_status as mod
+    original = mod.fetch_accel_ppp_sessions
+    mod.fetch_accel_ppp_sessions = fake_fetch
+    try:
+        with pytest.raises(PPPoESessionsUnavailable) as caught:
+            asyncio.run(load_pppoe_sessions(service))
+        assert "Unable to read PPPoE sessions" in str(caught.value.detail)
+    finally:
+        mod.fetch_accel_ppp_sessions = original

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -611,7 +611,7 @@ export default function Home() {
         </div>
 
         {/* Dashboard Grid */}
-        <DashboardDataProvider>
+        <DashboardDataProvider interests={cards.some((card) => card.type === "pppoe-statistics") ? ["pppoe-sessions"] : undefined}>
         {cards.length === 0 && !editMode ? (
           <div className="text-center py-12">
             <p className="text-muted-foreground mb-4">

--- a/frontend/src/app/service/pppoe-server/page.tsx
+++ b/frontend/src/app/service/pppoe-server/page.tsx
@@ -91,6 +91,7 @@ function PPPoEPageInner() {
   const [sessions, setSessions] = useState<SessionWithRates[]>([]);
   const [sessionTotal, setSessionTotal] = useState(0);
   const [sessionLoading, setSessionLoading] = useState(false);
+  const [sessionRefreshing, setSessionRefreshing] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const previousSessionBytes = useRef<Record<string, { rx: number; tx: number; at: number }>>({});
   const [statsHistory, setStatsHistory] = useState<Record<string, PPPoEStatsPoint[]>>({});
@@ -204,19 +205,21 @@ function PPPoEPageInner() {
 
   const fetchSessions = async () => {
     try {
-      setSessionLoading(true);
+      setSessionRefreshing(true);
       setSessionError(null);
       const response = await pppoeServerService.getSessions(500);
       applySessions(response);
+      setSessionLoading(false);
     } catch (err) {
       setSessionError(err instanceof Error ? err.message : "Failed to load active sessions");
-    } finally {
       setSessionLoading(false);
+    } finally {
+      setSessionRefreshing(false);
     }
   };
 
   const liveSessions = hasRead && !sessionPaused;
-  const { data: sessionStream, error: sessionStreamError } = useDashboardSSE({
+  const { data: sessionStream, error: sessionStreamError, status: sessionStreamStatus } = useDashboardSSE({
     interests: ["pppoe-sessions"],
     enabled: liveSessions,
   });
@@ -232,8 +235,16 @@ function PPPoEPageInner() {
   useEffect(() => {
     if (liveSessions) {
       setSessionLoading(true);
+    } else {
+      setSessionLoading(false);
     }
   }, [liveSessions]);
+
+  useEffect(() => {
+    if (sessionStreamStatus === "error") {
+      setSessionLoading(false);
+    }
+  }, [sessionStreamStatus]);
 
   useEffect(() => {
     if (!sessionStream.pppoeSessions) return;
@@ -508,8 +519,8 @@ function PPPoEPageInner() {
                         {sessionPaused ? <Play className="h-4 w-4 mr-2" /> : <Pause className="h-4 w-4 mr-2" />}
                         {sessionPaused ? "Resume" : "Pause"}
                       </Button>
-                      <Button variant="outline" size="sm" onClick={() => void fetchSessions()} disabled={sessionLoading}>
-                        <RefreshCw className={cn("h-4 w-4 mr-2", sessionLoading && "animate-spin")} />
+                      <Button variant="outline" size="sm" onClick={() => void fetchSessions()} disabled={sessionRefreshing}>
+                        <RefreshCw className={cn("h-4 w-4 mr-2", sessionRefreshing && "animate-spin")} />
                         Refresh
                       </Button>
                     </div>

--- a/frontend/src/app/service/pppoe-server/page.tsx
+++ b/frontend/src/app/service/pppoe-server/page.tsx
@@ -230,6 +230,12 @@ function PPPoEPageInner() {
   }, [searchParams]);
 
   useEffect(() => {
+    if (liveSessions) {
+      setSessionLoading(true);
+    }
+  }, [liveSessions]);
+
+  useEffect(() => {
     if (!sessionStream.pppoeSessions) return;
     setSessionError(null);
     applySessions(sessionStream.pppoeSessions);
@@ -237,9 +243,9 @@ function PPPoEPageInner() {
   }, [sessionStream.pppoeSessions]);
 
   useEffect(() => {
-    if (sessionStreamError) {
-      setSessionError(sessionStreamError);
-    }
+    if (!sessionStreamError || !sessionStreamError.startsWith("pppoe-sessions:")) return;
+    setSessionError(sessionStreamError.replace(/^pppoe-sessions:\s*/, "") || "Failed to load active sessions");
+    setSessionLoading(false);
   }, [sessionStreamError]);
 
   const onSuccess = () => fetchConfig(true);

--- a/frontend/src/app/service/pppoe-server/page.tsx
+++ b/frontend/src/app/service/pppoe-server/page.tsx
@@ -60,6 +60,7 @@ import {
   type PPPoESession,
 } from "@/lib/api/pppoe-server";
 import { usePermissions } from "@/hooks/usePermissions";
+import { useDashboardSSE } from "@/hooks/useDashboardSSE";
 import { FeatureGroup } from "@/lib/api/user-management";
 import {
   DeleteConfirmModal,
@@ -95,7 +96,6 @@ function PPPoEPageInner() {
   const [statsHistory, setStatsHistory] = useState<Record<string, PPPoEStatsPoint[]>>({});
   const [selectedStatsKey, setSelectedStatsKey] = useState<string | null>(null);
   const [sessionPaused, setSessionPaused] = useState(false);
-  const [refreshInterval, setRefreshInterval] = useState(5);
   const [sessionSearch, setSessionSearch] = useState("");
   const [minPps, setMinPps] = useState("");
   const [maxPps, setMaxPps] = useState("");
@@ -162,54 +162,64 @@ function PPPoEPageInner() {
     }
   };
 
+  const applySessions = (response: { sessions: PPPoESession[]; total: number }) => {
+    const now = Date.now();
+    const nextSessions = response.sessions.map((session) => {
+      const key = `${session.interface}:${session.username}:${session.calling_sid ?? ""}`;
+      const previous = previousSessionBytes.current[key];
+      const elapsed = previous ? (now - previous.at) / 1000 : 0;
+      const result: SessionWithRates = { ...session };
+      if (previous && elapsed > 0) {
+        result.rxRate = Math.max(0, (session.rx_bytes - previous.rx) * 8 / elapsed);
+        result.txRate = Math.max(0, (session.tx_bytes - previous.tx) * 8 / elapsed);
+      }
+      result.rxPps = session.rx_pps ?? undefined;
+      result.txPps = session.tx_pps ?? undefined;
+      previousSessionBytes.current[key] = { rx: session.rx_bytes, tx: session.tx_bytes, at: now };
+      return result;
+    });
+    setSessions(nextSessions);
+    setSessionTotal(response.total);
+    setStatsHistory((previous) => {
+      const next = { ...previous };
+      for (const session of nextSessions) {
+        const key = `${session.interface}:${session.username}:${session.calling_sid ?? ""}`;
+        const point: PPPoEStatsPoint = {
+          timestamp: now,
+          rxRate: session.rxRate ?? 0,
+          txRate: session.txRate ?? 0,
+          rxPps: session.rxPps ?? 0,
+          txPps: session.txPps ?? 0,
+          rxBytes: session.rx_bytes,
+          txBytes: session.tx_bytes,
+        };
+        next[key] = [...(next[key] ?? []), point]
+          .filter((item) => item.timestamp >= now - 120_000)
+          .slice(-120);
+      }
+      return next;
+    });
+    setSessionPage((page) => Math.min(page, Math.max(1, Math.ceil(nextSessions.length / sessionPageSize))));
+  };
+
   const fetchSessions = async () => {
     try {
       setSessionLoading(true);
       setSessionError(null);
       const response = await pppoeServerService.getSessions(500);
-      const now = Date.now();
-      const nextSessions = response.sessions.map((session) => {
-        const key = `${session.interface}:${session.username}:${session.calling_sid ?? ""}`;
-        const previous = previousSessionBytes.current[key];
-        const elapsed = previous ? (now - previous.at) / 1000 : 0;
-        const result: SessionWithRates = { ...session };
-        if (previous && elapsed > 0) {
-          result.rxRate = Math.max(0, (session.rx_bytes - previous.rx) * 8 / elapsed);
-          result.txRate = Math.max(0, (session.tx_bytes - previous.tx) * 8 / elapsed);
-        }
-        result.rxPps = session.rx_pps ?? undefined;
-        result.txPps = session.tx_pps ?? undefined;
-        previousSessionBytes.current[key] = { rx: session.rx_bytes, tx: session.tx_bytes, at: now };
-        return result;
-      });
-      setSessions(nextSessions);
-      setSessionTotal(response.total);
-      setStatsHistory((previous) => {
-        const next = { ...previous };
-        for (const session of nextSessions) {
-          const key = `${session.interface}:${session.username}:${session.calling_sid ?? ""}`;
-          const point: PPPoEStatsPoint = {
-            timestamp: now,
-            rxRate: session.rxRate ?? 0,
-            txRate: session.txRate ?? 0,
-            rxPps: session.rxPps ?? 0,
-            txPps: session.txPps ?? 0,
-            rxBytes: session.rx_bytes,
-            txBytes: session.tx_bytes,
-          };
-          next[key] = [...(next[key] ?? []), point]
-            .filter((item) => item.timestamp >= now - 120_000)
-            .slice(-120);
-        }
-        return next;
-      });
-      setSessionPage((page) => Math.min(page, Math.max(1, Math.ceil(nextSessions.length / sessionPageSize))));
+      applySessions(response);
     } catch (err) {
       setSessionError(err instanceof Error ? err.message : "Failed to load active sessions");
     } finally {
       setSessionLoading(false);
     }
   };
+
+  const liveSessions = hasRead && !sessionPaused;
+  const { data: sessionStream, error: sessionStreamError } = useDashboardSSE({
+    interests: ["pppoe-sessions"],
+    enabled: liveSessions,
+  });
 
   useEffect(() => {
     if (hasRead) fetchConfig();
@@ -220,12 +230,17 @@ function PPPoEPageInner() {
   }, [searchParams]);
 
   useEffect(() => {
-    if (!hasRead) return;
-    void fetchSessions();
-    if (sessionPaused || refreshInterval === 0) return;
-    const timer = window.setInterval(() => void fetchSessions(), refreshInterval * 1000);
-    return () => window.clearInterval(timer);
-  }, [hasRead, sessionPaused, refreshInterval]);
+    if (!sessionStream.pppoeSessions) return;
+    setSessionError(null);
+    applySessions(sessionStream.pppoeSessions);
+    setSessionLoading(false);
+  }, [sessionStream.pppoeSessions]);
+
+  useEffect(() => {
+    if (sessionStreamError) {
+      setSessionError(sessionStreamError);
+    }
+  }, [sessionStreamError]);
 
   const onSuccess = () => fetchConfig(true);
   const onSessionReset = () => { void fetchSessions(); };
@@ -478,23 +493,11 @@ function PPPoEPageInner() {
                     <div>
                       <h3 className="font-semibold">Active PPPoE Sessions</h3>
                       <p className="text-sm text-muted-foreground">
-                        {sessionPaused ? "Updates paused." : refreshInterval === 0 ? "Manual refresh only." : `Live counters refresh every ${refreshInterval} seconds.`}
+                        {sessionPaused ? "Updates paused." : "Live counters arrive with the dashboard stream."}
                       </p>
                     </div>
                     <div className="flex items-center gap-2">
                       <span className="text-xs text-muted-foreground">{sessionTotal} sessions</span>
-                      <select
-                        value={refreshInterval}
-                        onChange={(event) => setRefreshInterval(Number(event.target.value))}
-                        className="h-9 rounded-md border bg-background px-2 text-sm"
-                        aria-label="Session refresh interval"
-                      >
-                        <option value="1">1s</option>
-                        <option value="5">5s</option>
-                        <option value="10">10s</option>
-                        <option value="30">30s</option>
-                        <option value="0">Manual</option>
-                      </select>
                       <Button variant="outline" size="sm" onClick={() => setSessionPaused((paused) => !paused)}>
                         {sessionPaused ? <Play className="h-4 w-4 mr-2" /> : <Pause className="h-4 w-4 mr-2" />}
                         {sessionPaused ? "Resume" : "Pause"}

--- a/frontend/src/components/dashboard/PppoeStatsCard.tsx
+++ b/frontend/src/components/dashboard/PppoeStatsCard.tsx
@@ -5,8 +5,9 @@ import { Activity, Pause, Play, RefreshCw, X } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
-import { pppoeServerService } from "@/lib/api/pppoe-server";
+import { pppoeServerService, type PPPoESessionsResponse } from "@/lib/api/pppoe-server";
 import { PPPoEStatsChart, type PPPoEStatsPoint } from "@/components/pppoe-server/PPPoEStatsChart";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
 
 interface PppoeStatsCardProps {
   onRemove?: () => void;
@@ -16,37 +17,52 @@ interface PppoeStatsCardProps {
   onHeightChange?: (newHeight: number) => void;
 }
 
+function pointFromSessions(response: PPPoESessionsResponse, now: number): PPPoEStatsPoint {
+  const totals = response.sessions.reduce(
+    (sum, session) => ({
+      rxBytes: sum.rxBytes + session.rx_bytes,
+      txBytes: sum.txBytes + session.tx_bytes,
+      rxPackets: sum.rxPackets + (session.rx_pps ?? 0),
+      txPackets: sum.txPackets + (session.tx_pps ?? 0),
+    }),
+    { rxBytes: 0, txBytes: 0, rxPackets: 0, txPackets: 0 },
+  );
+  return {
+    timestamp: now,
+    rxRate: 0,
+    txRate: 0,
+    rxPps: totals.rxPackets,
+    txPps: totals.txPackets,
+    rxBytes: totals.rxBytes,
+    txBytes: totals.txBytes,
+    activeSessions: response.total,
+  };
+}
+
 export function PppoeStatsCard({ onRemove, span = 1, onSpanChange, height, onHeightChange }: PppoeStatsCardProps) {
+  const { data } = useDashboardData();
   const [points, setPoints] = useState<PPPoEStatsPoint[]>([]);
   const [sessionCount, setSessionCount] = useState(0);
   const [paused, setPaused] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (paused) return;
+    const response = data.pppoeSessions;
+    if (!response) return;
+    const now = Date.now();
+    setSessionCount(response.total);
+    const point = pointFromSessions(response, now);
+    setPoints((current) => [...current, point].filter((item) => item.timestamp >= now - 120_000).slice(-120));
+  }, [data.pppoeSessions, paused]);
 
   const fetchStats = async () => {
     try {
       setLoading(true);
       const response = await pppoeServerService.getSessions();
       const now = Date.now();
-      const totals = response.sessions.reduce(
-        (sum, session) => ({
-          rxBytes: sum.rxBytes + session.rx_bytes,
-          txBytes: sum.txBytes + session.tx_bytes,
-          rxPackets: sum.rxPackets + (session.rx_pps ?? 0),
-          txPackets: sum.txPackets + (session.tx_pps ?? 0),
-        }),
-        { rxBytes: 0, txBytes: 0, rxPackets: 0, txPackets: 0 },
-      );
-      const point: PPPoEStatsPoint = {
-        timestamp: now,
-        rxRate: 0,
-        txRate: 0,
-        rxPps: totals.rxPackets,
-        txPps: totals.txPackets,
-        rxBytes: totals.rxBytes,
-        txBytes: totals.txBytes,
-        activeSessions: response.total,
-      };
       setSessionCount(response.total);
+      const point = pointFromSessions(response, now);
       setPoints((current) => [...current, point].filter((item) => item.timestamp >= now - 120_000).slice(-120));
     } catch {
       // Dashboard cards remain available while a device is temporarily unreachable.
@@ -54,13 +70,6 @@ export function PppoeStatsCard({ onRemove, span = 1, onSpanChange, height, onHei
       setLoading(false);
     }
   };
-
-  useEffect(() => {
-    void fetchStats();
-    if (paused) return;
-    const timer = window.setInterval(() => void fetchStats(), 5000);
-    return () => window.clearInterval(timer);
-  }, [paused]);
 
   return (
     <Card className="flex h-full flex-col">

--- a/frontend/src/contexts/DashboardDataContext.tsx
+++ b/frontend/src/contexts/DashboardDataContext.tsx
@@ -13,8 +13,14 @@ const DashboardDataContext = createContext<DashboardSSEState | null>(null);
 // Provider
 // ============================================================================
 
-export function DashboardDataProvider({ children }: { children: React.ReactNode }) {
-  const sseState = useDashboardSSE();
+export function DashboardDataProvider({
+  children,
+  interests,
+}: {
+  children: React.ReactNode;
+  interests?: string[];
+}) {
+  const sseState = useDashboardSSE({ interests });
 
   return (
     <DashboardDataContext.Provider value={sseState}>

--- a/frontend/src/hooks/useDashboardSSE.ts
+++ b/frontend/src/hooks/useDashboardSSE.ts
@@ -5,6 +5,7 @@ import { InterfaceCounter } from "@/lib/api/show";
 import { QoSStatsResponse } from "@/lib/api/qos";
 import { OpenVpnStatus } from "@/lib/api/openvpn";
 import { IPSecStatus } from "@/lib/api/ipsec";
+import { PPPoESessionsResponse } from "@/lib/api/pppoe-server";
 
 // ============================================================================
 // Types
@@ -141,6 +142,7 @@ export interface DashboardSSEData {
   vrrpStatus: VrrpStatusData | null;
   bgpStatus: BgpStatusData | null;
   ipsecStatus: IPSecStatus | null;
+  pppoeSessions: PPPoESessionsResponse | null;
 }
 
 export interface DashboardSSEState {
@@ -153,17 +155,40 @@ export interface DashboardSSEState {
 // Hook
 // ============================================================================
 
-export function useDashboardSSE(): DashboardSSEState {
+export function useDashboardSSE(options?: {
+  interests?: string[];
+  enabled?: boolean;
+}): DashboardSSEState {
+  const interests = options?.interests ?? [];
+  const enabled = options?.enabled ?? true;
+  const interestsKey = interests.join(",");
   const [status, setStatus] = useState<SSEStatus>("disconnected");
-  const [data, setData] = useState<DashboardSSEData>({ interfaceCounters: null, systemInfo: null, wireguardPeers: null, qosStats: null, openvpnStatus: null, vrrpStatus: null, bgpStatus: null, ipsecStatus: null });
+  const [data, setData] = useState<DashboardSSEData>({
+    interfaceCounters: null,
+    systemInfo: null,
+    wireguardPeers: null,
+    qosStats: null,
+    openvpnStatus: null,
+    vrrpStatus: null,
+    bgpStatus: null,
+    ipsecStatus: null,
+    pppoeSessions: null,
+  });
   const [error, setError] = useState<string | null>(null);
   const esRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset status while (re)subscribing to the stream
+    if (!enabled) {
+      return;
+    }
     setStatus("connecting");
 
-    const es = new EventSource("/api/vyos/show/stream");
+    const params = new URLSearchParams();
+    for (const name of interests) {
+      params.append("interest", name);
+    }
+    const qs = params.toString();
+    const es = new EventSource(qs ? `/api/vyos/show/stream?${qs}` : "/api/vyos/show/stream");
     esRef.current = es;
 
     es.addEventListener("connected", () => {
@@ -243,6 +268,15 @@ export function useDashboardSSE(): DashboardSSEState {
       }
     });
 
+    es.addEventListener("pppoe-sessions", (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as PPPoESessionsResponse;
+        setData((prev) => ({ ...prev, pppoeSessions: payload }));
+      } catch {
+        // Ignore malformed payloads
+      }
+    });
+
     es.addEventListener("error", (event: MessageEvent) => {
       try {
         const payload = JSON.parse(event.data) as { channel: string; message: string };
@@ -262,7 +296,9 @@ export function useDashboardSSE(): DashboardSSEState {
       esRef.current = null;
       setStatus("disconnected");
     };
-  }, []);
+    // interests is represented by interestsKey so a new array identity does not reconnect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- interestsKey is the stable serialization of interests
+  }, [enabled, interestsKey]);
 
   return { status, data, error };
 }


### PR DESCRIPTION
PPPoE sessions were polled on their own REST interval from the PPPoE Server page and the dashboard PPPoE card. That was a second poll against the same router, not shared with the dashboard SSE broadcaster.

The dashboard stream now emits a pppoe-sessions event on the slow cycle. The fetch runs only when service pppoe-server is configured and a subscriber passed interest=pppoe-sessions. FeatureGroup.PPPOE READ is required to request that interest and to receive the event. ShowSessionsAccelppp still runs off the shared GraphQL path so a ~2s call cannot stall interface counters.

The PPPoE page and the dashboard PPPoE card consume the SSE event. GET /vyos/pppoe-server/sessions remains for a one-shot Refresh. PPS is still derived from packet-counter deltas, now on the broadcaster cadence, via a shared tracker.

Tests: pytest backend/tests/test_pppoe_status.py backend/tests/test_dashboard_pppoe_interest.py (21 passed). Full backend suite 1089 passed, 36 skipped. frontend npx tsc --noEmit. eslint clean on the touched files.

Closes #690
