### PR TITLE
fix: ride Hardware Sensors card on the dashboard SSE stream

### DIFF
--- a/backend/hardware_status.py
+++ b/backend/hardware_status.py
@@ -136,3 +136,21 @@ def parse_hardware_sensors(text: str) -> HardwareSensorsResponse:
         ))
     
     return HardwareSensorsResponse(sensors=sensors, raw=text or "", summary=_build_hardware_summary(sensors))
+
+
+def hardware_gql_fields(key_literal: str) -> List[str]:
+    """GraphQL alias field fetching ``show environment sensors`` via ``Show``.
+
+    ``key_literal`` must be a JSON-encoded API key (``json.dumps(key)``), matching
+    the other ``*_gql_fields`` helpers folded into the dashboard broadcaster query.
+    """
+    return [
+        f'HardwareSensors: Show(data: {{key: {key_literal}, path: ["environment", "sensors"]}}) {{ data {{ result }} }}'
+    ]
+
+
+def build_hardware_status(gql: dict) -> dict:
+    """Build the ``hardware-sensors`` SSE payload from the shared GraphQL result."""
+    node = (gql or {}).get("HardwareSensors") or {}
+    result = (node.get("data") or {}).get("result")
+    return parse_hardware_sensors(result if isinstance(result, str) else "").dict()

--- a/backend/routers/show.py
+++ b/backend/routers/show.py
@@ -34,7 +34,7 @@ from openvpn_status import openvpn_configured, openvpn_gql_fields, build_openvpn
 from vrrp_status import vrrp_configured, vrrp_gql_fields, build_vrrp_status
 from bgp_status import bgp_configured, bgp_gql_fields, build_bgp_status
 from ipsec_status import ipsec_configured, ipsec_gql_fields, build_ipsec_status
-from hardware_status import HardwareSensorsResponse, parse_hardware_sensors
+from hardware_status import HardwareSensorsResponse, parse_hardware_sensors, hardware_gql_fields, build_hardware_status
 from pppoe_status import load_pppoe_sessions, pppoe_configured
 import logging
 logger = logging.getLogger(__name__)
@@ -157,6 +157,7 @@ def _build_gql_payload(api_key: str, include_wireguard: bool, cake_targets: Opti
         f"InterfaceCounters: ShowCountersInterfaces(data: {{key: {k}}}) {{ data {{ result }} }}",
     ]
     fields += qos_gql_fields(k, cake_targets or [])
+    fields += hardware_gql_fields(k)
     if include_vrrp:
         fields += vrrp_gql_fields(k)
     if include_bgp:
@@ -1327,6 +1328,14 @@ class DeviceDataBroadcaster:
             logger.exception("Broadcaster: ipsec-status parse error")
             self._push_to_all({"type": "error", "data": {"channel": "ipsec-status", "message": "Parse failed"}})
 
+    def _broadcast_hardware(self, gql: dict) -> None:
+        """Parse hardware sensor readings from the shared GraphQL result and push an event."""
+        try:
+            self._push_to_all({"type": "hardware-sensors", "data": build_hardware_status(gql)})
+        except Exception:
+            logger.exception("Broadcaster: hardware-sensors parse error")
+            self._push_to_all({"type": "error", "data": {"channel": "hardware-sensors", "message": "Parse failed"}})
+
     def _handle_pppoe_cycle(self, *, start: bool) -> None:
         """Collect a completed PPPoE sessions fetch; start a new one on the slow cycle.
 
@@ -1409,6 +1418,7 @@ class DeviceDataBroadcaster:
                         self._broadcast_system_info(gql)
                         self._handle_wg_cycle(gql)
                         self._broadcast_qos(gql, targets)
+                        self._broadcast_hardware(gql)
                         if vrrp:
                             self._broadcast_vrrp(gql)
                         if bgp:
@@ -1491,6 +1501,7 @@ async def dashboard_stream(
     include_vrrp = await has_permission(request, FeatureGroup.HIGH_AVAILABILITY, PermissionLevel.READ)
     include_bgp = await has_permission(request, FeatureGroup.BGP, PermissionLevel.READ)
     include_pppoe = await has_permission(request, FeatureGroup.PPPOE, PermissionLevel.READ)
+    include_hardware = await has_permission(request, FeatureGroup.INTERFACES, PermissionLevel.READ)
     broadcaster = _get_broadcaster(service)
 
     instance_id: str = service.config.instance_id
@@ -1530,6 +1541,8 @@ async def dashboard_stream(
                 if event["type"] == "bgp-status" and not include_bgp:
                     continue
                 if event["type"] == "pppoe-sessions" and not include_pppoe:
+                    continue
+                if event["type"] == "hardware-sensors" and not include_hardware:
                     continue
                 yield f'event: {event["type"]}\ndata: {json.dumps(event["data"])}\n\n'
         finally:

--- a/frontend/src/components/dashboard/HardwareSensorsCard.tsx
+++ b/frontend/src/components/dashboard/HardwareSensorsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -22,7 +22,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { CardSizeMenu } from "@/components/dashboard/CardSizeMenu";
-import { showService, type HardwareSensorsResponse } from "@/lib/api/show";
+import { type HardwareSensorsResponse } from "@/lib/api/show";
+import { useDashboardData } from "@/contexts/DashboardDataContext";
 
 // ============================================================================
 // Props
@@ -49,39 +50,16 @@ export function HardwareSensorsCard({
   onHeightChange,
 }: HardwareSensorsCardProps) {
   const [autoRefresh, setAutoRefresh] = useState(true);
-  const [data, setData] = useState<HardwareSensorsResponse | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setData(await showService.getHardwareSensors());
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Unable to load hardware sensors");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  // Auto-refresh on mount and when autoRefresh is enabled
+  const { status: sseStatus, data: sseData } = useDashboardData();
+  // Snapshot the stream so "Paused" freezes the displayed readings.
+  const [snapshot, setSnapshot] = useState<HardwareSensorsResponse | null>(null);
   useEffect(() => {
-    if (!autoRefresh) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- freeze the last SSE snapshot for the paused view
+    if (autoRefresh && sseData.hardwareSensors) setSnapshot(sseData.hardwareSensors);
+  }, [autoRefresh, sseData.hardwareSensors]);
 
-    // Initial load
-    refresh();
-
-    // Set up interval for periodic refresh (every 30 seconds)
-    const interval = setInterval(() => {
-      refresh();
-    }, 30000);
-
-    return () => clearInterval(interval);
-  }, [autoRefresh]);
-
-  const isLoading = loading && !data;
-  const showData = autoRefresh ? data : null;
+  const showData = snapshot;
+  const isLoading = showData === null && autoRefresh;
 
   const cpuSensors = showData?.sensors.filter((sensor) => {
     const name = sensor.name.toLowerCase();
@@ -116,13 +94,10 @@ export function HardwareSensorsCard({
           <Button
             variant={autoRefresh ? "default" : "outline"}
             size="sm"
-            onClick={() => {
-              setAutoRefresh((v) => !v);
-              if (!autoRefresh) refresh();
-            }}
-            title={autoRefresh ? "Auto-refresh enabled" : "Auto-refresh paused"}
+            onClick={() => setAutoRefresh((v) => !v)}
+            title={autoRefresh ? `Live via dashboard stream (${sseStatus})` : "Paused"}
           >
-            <RefreshCw className={`h-4 w-4 mr-1 ${loading ? "animate-spin" : ""}`} />
+            <RefreshCw className={`h-4 w-4 mr-1 ${autoRefresh && sseStatus === "connected" ? "animate-spin" : ""}`} />
             {autoRefresh ? "Live" : "Paused"}
           </Button>
           {onSpanChange && (
@@ -147,10 +122,6 @@ export function HardwareSensorsCard({
             <Loader2 className="animate-spin" />
             Reading sensors...
           </div>
-        ) : error ? (
-          <p className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-            {error}
-          </p>
         ) : showData && !showData.sensors.length ? (
           <p className="py-8 text-sm text-muted-foreground">
             No hardware sensors available (may be running in a virtualized environment).

--- a/frontend/src/hooks/useDashboardSSE.ts
+++ b/frontend/src/hooks/useDashboardSSE.ts
@@ -6,6 +6,7 @@ import { QoSStatsResponse } from "@/lib/api/qos";
 import { OpenVpnStatus } from "@/lib/api/openvpn";
 import { IPSecStatus } from "@/lib/api/ipsec";
 import { PPPoESessionsResponse } from "@/lib/api/pppoe-server";
+import { HardwareSensorsResponse } from "@/lib/api/show";
 
 // ============================================================================
 // Types
@@ -143,6 +144,7 @@ export interface DashboardSSEData {
   bgpStatus: BgpStatusData | null;
   ipsecStatus: IPSecStatus | null;
   pppoeSessions: PPPoESessionsResponse | null;
+  hardwareSensors: HardwareSensorsResponse | null;
 }
 
 export interface DashboardSSEState {
@@ -173,6 +175,7 @@ export function useDashboardSSE(options?: {
     bgpStatus: null,
     ipsecStatus: null,
     pppoeSessions: null,
+    hardwareSensors: null,
   });
   const [error, setError] = useState<string | null>(null);
   const esRef = useRef<EventSource | null>(null);
@@ -272,6 +275,15 @@ export function useDashboardSSE(options?: {
       try {
         const payload = JSON.parse(event.data) as PPPoESessionsResponse;
         setData((prev) => ({ ...prev, pppoeSessions: payload }));
+      } catch {
+        // Ignore malformed payloads
+      }
+    });
+
+    es.addEventListener("hardware-sensors", (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as HardwareSensorsResponse;
+        setData((prev) => ({ ...prev, hardwareSensors: payload }));
       } catch {
         // Ignore malformed payloads
       }


### PR DESCRIPTION
Hardware Sensors was the only live dashboard card not riding the SSE stream. It ran a per-card 30s setInterval calling GET /vyos/show/hardware-sensors, which uses pyvyos device.show (SSH), not GraphQL. Every other live card reads useDashboardData() fed by the GraphQL DeviceDataBroadcaster.

This folds sensors into the broadcaster. backend/hardware_status.py gains hardware_gql_fields() and build_hardware_status() (same pattern as vrrp_status and ipsec_status). routers/show.py adds the field to the slow GraphQL query, adds _broadcast_hardware() on the slow cycle, and gates the hardware-sensors SSE event by FeatureGroup.INTERFACES read, matching the REST endpoint's existing authorization. The frontend hook adds the hardwareSensors channel and listener; the card now consumes useDashboardData() with the same Live/Paused snapshot pattern as VrrpStatusCard, dropping its poll.

No route or Pydantic model changed, so no OpenAPI regeneration. The REST endpoint and showService.getHardwareSensors are kept, matching the interface-counters precedent.

Verified on both lab hosts that Show(path:["environment","sensors"]) returns the same text the REST path parses.

Tests run:
backend/tests/test_transceiver_status.py and test_dashboard_pppoe_interest.py pass (16). New builders exercised against hypervisor, real-sensor, and missing-node GraphQL inputs. Frontend tsc --noEmit clean, eslint clean on touched files, npm run build compiled and TypeScript passed. ruff F401/F811 clean on both backend files.
