### PR TITLE
fix: expose Kea dynamic-dns-update behavior leaves

### DIFF
--- a/backend/routers/dhcp/dhcp.py
+++ b/backend/routers/dhcp/dhcp.py
@@ -72,6 +72,16 @@ def _parse_dhcp_ddns(raw: Any) -> "DHCPDdnsConfig":
     return DHCPDdnsConfig(
         present=True,
         send_updates=raw.get("send-updates"),
+        conflict_resolution=raw.get("conflict-resolution"),
+        override_client_update=raw.get("override-client-update"),
+        override_no_update=raw.get("override-no-update"),
+        update_on_renew=raw.get("update-on-renew"),
+        replace_client_name=raw.get("replace-client-name"),
+        ttl_percent=str(raw["ttl-percent"]) if "ttl-percent" in raw else None,
+        generated_prefix=raw.get("generated-prefix"),
+        qualifying_suffix=raw.get("qualifying-suffix"),
+        hostname_char_replacement=raw.get("hostname-char-replacement"),
+        hostname_char_set=raw.get("hostname-char-set"),
         tsig_keys=keys,
         forward_domains=_parse_ddns_domains(raw.get("forward-domain")),
         reverse_domains=_parse_ddns_domains(raw.get("reverse-domain")),
@@ -180,6 +190,16 @@ class DHCPDdnsTsigKey(BaseModel):
 class DHCPDdnsConfig(BaseModel):
     present: bool = False
     send_updates: Optional[str] = None
+    conflict_resolution: Optional[str] = None
+    override_client_update: Optional[str] = None
+    override_no_update: Optional[str] = None
+    update_on_renew: Optional[str] = None
+    replace_client_name: Optional[str] = None
+    ttl_percent: Optional[str] = None
+    generated_prefix: Optional[str] = None
+    qualifying_suffix: Optional[str] = None
+    hostname_char_replacement: Optional[str] = None
+    hostname_char_set: Optional[str] = None
     tsig_keys: List[DHCPDdnsTsigKey] = []
     forward_domains: List[DHCPDdnsDomain] = []
     reverse_domains: List[DHCPDdnsDomain] = []

--- a/backend/tests/test_dhcp_version_gates.py
+++ b/backend/tests/test_dhcp_version_gates.py
@@ -136,6 +136,80 @@ def test_v14_emits_ddns_leaf():
     assert mapper.get_dynamic_dns_update() == ["service", "dhcp-server", "dynamic-dns-update"]
 
 
+DDNS_SCALAR_CASES = [
+    ("conflict-resolution", "enable"),
+    ("override-client-update", "enable"),
+    ("override-no-update", "enable"),
+    ("update-on-renew", "enable"),
+    ("replace-client-name", "always"),
+    ("ttl-percent", "50"),
+    ("generated-prefix", "myhost"),
+    ("qualifying-suffix", "example.com"),
+    ("hostname-char-replacement", "-"),
+    ("hostname-char-set", "[^A-Za-z0-9.-]"),
+]
+
+
+@pytest.mark.parametrize("field, value", DDNS_SCALAR_CASES)
+def test_v15_emits_ddns_scalar(field, value):
+    mapper = DHCPMapper("1.5")
+    assert mapper.get_ddns_scalar(field, value) == [
+        "service", "dhcp-server", "dynamic-dns-update", field, value,
+    ]
+    assert mapper.get_ddns_scalar_path(field) == [
+        "service", "dhcp-server", "dynamic-dns-update", field,
+    ]
+
+
+def test_v14_rejects_ddns_scalar_set():
+    mapper = DHCPMapper("1.4")
+    with pytest.raises(ValueError, match="not supported"):
+        mapper.get_ddns_scalar("conflict-resolution", "enable")
+
+
+def test_v14_ddns_scalar_delete_unguarded():
+    # Delete must stay reachable so a stale 1.5 leaf can be removed.
+    mapper = DHCPMapper("1.4")
+    assert mapper.get_ddns_scalar_path("ttl-percent")[-1] == "ttl-percent"
+
+
+def test_ddns_scalar_rejects_unknown_field():
+    mapper = DHCPMapper("1.5")
+    with pytest.raises(ValueError, match="unsupported dynamic-dns-update field"):
+        mapper.get_ddns_scalar("bogus-leaf", "x")
+    with pytest.raises(ValueError, match="unsupported dynamic-dns-update field"):
+        mapper.get_ddns_scalar_path("bogus-leaf")
+
+
+def test_v15_builder_ddns_scalar_set_delete():
+    builder = DHCPBatchBuilder(version="1.5")
+    builder.set_ddns_scalar("hostname-char-set|[^A-Za-z0-9.-]")
+    builder.delete_ddns_scalar("hostname-char-set")
+    ops = builder.get_operations()
+    assert ops[0] == {
+        "op": "set",
+        "path": ["service", "dhcp-server", "dynamic-dns-update", "hostname-char-set", "[^A-Za-z0-9.-]"],
+    }
+    assert ops[1] == {
+        "op": "delete",
+        "path": ["service", "dhcp-server", "dynamic-dns-update", "hostname-char-set"],
+    }
+
+
+def test_ddns_scalar_value_keeps_embedded_pipe():
+    # A value containing "|" must survive; only the first separator is the
+    # field/value boundary.
+    builder = DHCPBatchBuilder(version="1.5")
+    builder.set_ddns_scalar("hostname-char-set|[a|b]")
+    assert builder.get_operations()[0]["path"][-1] == "[a|b]"
+
+
+def test_v14_builder_rejects_ddns_scalar_set():
+    builder = DHCPBatchBuilder(version="1.4")
+    with pytest.raises(ValueError, match="not supported"):
+        builder.set_ddns_scalar("conflict-resolution|enable")
+
+
 def test_v14_builder_rejects_ddns_kea_and_ha_certs():
     builder = DHCPBatchBuilder(version="1.4")
     with pytest.raises(ValueError, match="not supported"):

--- a/backend/vyos_builders/dhcp/dhcp.py
+++ b/backend/vyos_builders/dhcp/dhcp.py
@@ -834,6 +834,20 @@ class DHCPBatchBuilder(BatchBuilder):
         path = self.mappers[self.mapper_key].get_ddns_send_updates(value)
         return self.add_set(path)
 
+    def set_ddns_scalar(self, spec: str) -> "DHCPBatchBuilder":
+        # Wire format is "<field>|<value>". Partition on the first separator so a
+        # value that itself contains "|" (e.g. a hostname-char-set regex) is kept
+        # intact instead of being truncated by the generic pipe splitter.
+        field, sep, value = spec.partition("|")
+        if not sep:
+            raise ValueError("set_ddns_scalar requires '<field>|<value>'")
+        path = self.mappers[self.mapper_key].get_ddns_scalar(field, value)
+        return self.add_set(path)
+
+    def delete_ddns_scalar(self, field: str) -> "DHCPBatchBuilder":
+        path = self.mappers[self.mapper_key].get_ddns_scalar_path(field)
+        return self.add_delete(path)
+
     def delete_ddns_send_updates(self) -> "DHCPBatchBuilder":
         path = self.mappers[self.mapper_key].get_ddns_send_updates_path()
         return self.add_delete(path)

--- a/backend/vyos_mappers/dhcp/dhcp.py
+++ b/backend/vyos_mappers/dhcp/dhcp.py
@@ -3,7 +3,7 @@
 Handles command path generation for DHCP server configuration.
 Integrates version-specific mappers for differences between VyOS 1.4 and 1.5.
 """
-from typing import List
+from typing import FrozenSet, List
 from ..base import BaseFeatureMapper
 from .dhcp_versions import DHCPMapperV1_4, DHCPMapperV1_5
 
@@ -818,6 +818,38 @@ class DHCPMapper(BaseFeatureMapper):
     def _require_ddns_kea(self) -> None:
         if not self.has_dynamic_dns_update_kea():
             raise ValueError("Kea dynamic-dns-update is not supported on this device")
+
+    # Container-level behavior leaves of the Kea dynamic-dns-update node. Each
+    # is a single value-taking leaf under dynamic-dns-update/<field>. Kept as an
+    # allowlist rather than one method per leaf so the set/delete path stays a
+    # single validated shape.
+    DDNS_SCALAR_FIELDS: FrozenSet[str] = frozenset({
+        "conflict-resolution",
+        "override-client-update",
+        "override-no-update",
+        "update-on-renew",
+        "replace-client-name",
+        "ttl-percent",
+        "generated-prefix",
+        "qualifying-suffix",
+        "hostname-char-replacement",
+        "hostname-char-set",
+    })
+
+    def _require_ddns_scalar_field(self, field: str) -> None:
+        if field not in self.DDNS_SCALAR_FIELDS:
+            raise ValueError(f"unsupported dynamic-dns-update field: {field}")
+
+    def get_ddns_scalar(self, field: str, value: str) -> List[str]:
+        self._require_ddns_kea()
+        self._require_ddns_scalar_field(field)
+        return ["service", "dhcp-server", "dynamic-dns-update", field, value]
+
+    def get_ddns_scalar_path(self, field: str) -> List[str]:
+        # Delete must stay reachable independent of the Kea set guard so a stale
+        # leaf can be removed. Only the field name is validated here.
+        self._require_ddns_scalar_field(field)
+        return ["service", "dhcp-server", "dynamic-dns-update", field]
 
     def get_ddns_send_updates(self, value: str) -> List[str]:
         self._require_ddns_kea()

--- a/frontend/src/components/services/DHCPDdnsModal.tsx
+++ b/frontend/src/components/services/DHCPDdnsModal.tsx
@@ -40,12 +40,24 @@ interface DHCPDdnsModalProps {
 const emptyDdns = (): DHCPDdnsConfig => ({
   present: false,
   send_updates: "",
+  conflict_resolution: "",
+  override_client_update: "",
+  override_no_update: "",
+  update_on_renew: "",
+  replace_client_name: "",
+  ttl_percent: "",
+  generated_prefix: "",
+  qualifying_suffix: "",
+  hostname_char_replacement: "",
+  hostname_char_set: "",
   tsig_keys: [],
   forward_domains: [],
   reverse_domains: [],
 });
 
 const ALGOS = ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"];
+const ENABLE_DISABLE = ["enable", "disable"];
+const REPLACE_CLIENT_NAME = ["never", "always", "when-present", "when-not-present"];
 
 export function DHCPDdnsModal({
   open,
@@ -66,6 +78,16 @@ export function DHCPDdnsModal({
     setForm({
       present: ddns.present,
       send_updates: ddns.send_updates ?? "",
+      conflict_resolution: ddns.conflict_resolution ?? "",
+      override_client_update: ddns.override_client_update ?? "",
+      override_no_update: ddns.override_no_update ?? "",
+      update_on_renew: ddns.update_on_renew ?? "",
+      replace_client_name: ddns.replace_client_name ?? "",
+      ttl_percent: ddns.ttl_percent ?? "",
+      generated_prefix: ddns.generated_prefix ?? "",
+      qualifying_suffix: ddns.qualifying_suffix ?? "",
+      hostname_char_replacement: ddns.hostname_char_replacement ?? "",
+      hostname_char_set: ddns.hostname_char_set ?? "",
       tsig_keys: ddns.tsig_keys.map((k) => ({ ...k })),
       forward_domains: ddns.forward_domains.map((d) => ({
         ...d,
@@ -280,6 +302,77 @@ export function DHCPDdnsModal({
                         <SelectItem value="disable">disable</SelectItem>
                       </SelectContent>
                     </Select>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    {(
+                      [
+                        ["conflict_resolution", "Conflict resolution", ENABLE_DISABLE],
+                        ["override_client_update", "Override client update", ENABLE_DISABLE],
+                        ["override_no_update", "Override no-update", ENABLE_DISABLE],
+                        ["update_on_renew", "Update on renew", ENABLE_DISABLE],
+                        ["replace_client_name", "Replace client name", REPLACE_CLIENT_NAME],
+                      ] as Array<["conflict_resolution" | "override_client_update" | "override_no_update" | "update_on_renew" | "replace_client_name", string, string[]]>
+                    ).map(([field, label, options]) => (
+                      <div className="space-y-1" key={field}>
+                        <Label>{label}</Label>
+                        <Select
+                          value={form[field] || "__none__"}
+                          onValueChange={(v) =>
+                            setForm((prev) => ({
+                              ...prev,
+                              [field]: v === "__none__" ? "" : v,
+                            }))
+                          }
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Unset" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="__none__">Unset</SelectItem>
+                            {options.map((o) => (
+                              <SelectItem key={o} value={o}>
+                                {o}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    ))}
+                    <div className="space-y-1">
+                      <Label>TTL percent (1-100)</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={100}
+                        placeholder="Unset"
+                        value={form.ttl_percent ?? ""}
+                        onChange={(e) =>
+                          setForm((prev) => ({ ...prev, ttl_percent: e.target.value }))
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    {(
+                      [
+                        ["generated_prefix", "Generated prefix", "myhost"],
+                        ["qualifying_suffix", "Qualifying suffix", "example.com"],
+                        ["hostname_char_set", "Hostname char set", "[^A-Za-z0-9.-]"],
+                        ["hostname_char_replacement", "Hostname char replacement", "-"],
+                      ] as Array<["generated_prefix" | "qualifying_suffix" | "hostname_char_set" | "hostname_char_replacement", string, string]>
+                    ).map(([field, label, ph]) => (
+                      <div className="space-y-1" key={field}>
+                        <Label>{label}</Label>
+                        <Input
+                          className="font-mono"
+                          placeholder={ph}
+                          value={form[field] ?? ""}
+                          onChange={(e) =>
+                            setForm((prev) => ({ ...prev, [field]: e.target.value }))
+                          }
+                        />
+                      </div>
+                    ))}
                   </div>
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">

--- a/frontend/src/lib/api/dhcp.ts
+++ b/frontend/src/lib/api/dhcp.ts
@@ -89,6 +89,16 @@ export interface DHCPDdnsTsigKey {
 export interface DHCPDdnsConfig {
   present: boolean;
   send_updates?: string;
+  conflict_resolution?: string;
+  override_client_update?: string;
+  override_no_update?: string;
+  update_on_renew?: string;
+  replace_client_name?: string;
+  ttl_percent?: string;
+  generated_prefix?: string;
+  qualifying_suffix?: string;
+  hostname_char_replacement?: string;
+  hostname_char_set?: string;
   tsig_keys: DHCPDdnsTsigKey[];
   forward_domains: DHCPDdnsDomain[];
   reverse_domains: DHCPDdnsDomain[];
@@ -1038,6 +1048,28 @@ class DHCPService {
         if (nextSend !== prevSend) {
           if (nextSend) operations.push({ op: "set_ddns_send_updates", value: nextSend });
           else operations.push({ op: "delete_ddns_send_updates" });
+        }
+        // Container-level behavior leaves. Key is the TS field, value is the
+        // VyOS leaf name; set wire format is "<leaf>|<value>", delete sends
+        // just "<leaf>".
+        const scalarFields: Array<[keyof DHCPDdnsConfig, string]> = [
+          ["conflict_resolution", "conflict-resolution"],
+          ["override_client_update", "override-client-update"],
+          ["override_no_update", "override-no-update"],
+          ["update_on_renew", "update-on-renew"],
+          ["replace_client_name", "replace-client-name"],
+          ["ttl_percent", "ttl-percent"],
+          ["generated_prefix", "generated-prefix"],
+          ["qualifying_suffix", "qualifying-suffix"],
+          ["hostname_char_replacement", "hostname-char-replacement"],
+          ["hostname_char_set", "hostname-char-set"],
+        ];
+        for (const [tsField, leaf] of scalarFields) {
+          const next = ((updated[tsField] as string | undefined) ?? "").trim();
+          const prev = ((original[tsField] as string | undefined) ?? "").trim();
+          if (next === prev) continue;
+          if (next) operations.push({ op: "set_ddns_scalar", value: `${leaf}|${next}` });
+          else operations.push({ op: "delete_ddns_scalar", value: leaf });
         }
         const origKeys = new Map(original.tsig_keys.map((k) => [k.name, k]));
         const nextKeys = new Map(updated.tsig_keys.filter((k) => k.name.trim()).map((k) => [k.name, k]));


### PR DESCRIPTION
The Kea (1.5) dynamic-dns-update subtree exposes ten scalar behavior leaves at the container level that VyManager did not map or render. #650 exposed DDNS but implemented only send-updates, tsig-key, forward-domain, and reverse-domain; these siblings were never shipped.

What was wrong

The DHCP mapper, builder, GET /config parse, and the DDNS modal had no support for conflict-resolution, override-client-update, override-no-update, update-on-renew, replace-client-name, ttl-percent, generated-prefix, qualifying-suffix, hostname-char-replacement, and hostname-char-set. They could not be set, read back, or seen in the UI.

What changed

Backend
- vyos_mappers/dhcp/dhcp.py: added a DDNS_SCALAR_FIELDS allowlist plus get_ddns_scalar (Kea-gated) and get_ddns_scalar_path (delete stays unguarded so a stale leaf can be removed; only the field name is validated). Unknown fields raise ValueError.
- vyos_builders/dhcp/dhcp.py: set_ddns_scalar / delete_ddns_scalar. set takes "<field>|<value>" and partitions on the first separator so a value containing "|" (e.g. a hostname-char-set regex) is not truncated by the generic batch pipe splitter.
- routers/dhcp/dhcp.py: added the ten fields to DHCPDdnsConfig and parsed them in _parse_dhcp_ddns.

Frontend
- lib/api/dhcp.ts: extended DHCPDdnsConfig and diffed the ten leaves in saveDdns (set as "<field>|<value>", delete sends the field name).
- components/services/DHCPDdnsModal.tsx: enable/disable selects for the four toggles, a mode select for replace-client-name, a numeric TTL percent, and text inputs for the prefix/suffix/hostname-char fields, all under the existing Kea branch.

No new capability flag: these ride under the existing dynamic_dns_update_kea field, already gated 1.5-only.

Tests run
- PYTHONPATH=backend pytest backend/tests/test_dhcp_version_gates.py backend/tests/test_dhcp_builder_paths.py -q: 92 passed. New cases cover all ten 1.5 set/delete paths, 1.4 set rejection, unguarded 1.4 delete, unknown-field rejection, builder set/delete, and embedded-pipe preservation.
- frontend: npx tsc --noEmit and eslint on the two touched files clean.
- Lab validateTmplPath on 1.4 (100.64.64.50) and 1.5 (100.64.64.5): all ten paths INVALID on 1.4, VALID on 1.5. discard only, no commit on the lab.

Closes #697
