### PR TITLE
fix: drop version labels from sFlow and WireGuard UI

### DIFF
--- a/frontend/src/components/system/settings/FlowAccountingPanel.tsx
+++ b/frontend/src/components/system/settings/FlowAccountingPanel.tsx
@@ -467,7 +467,7 @@ export function FlowAccountingPanel({ config, capabilities, isReadOnly, onRefres
         </CardContent>
       </Card>
 
-      {/* sFlow — shown only when standalone sFlow is supported (1.5+) */}
+      {/* sFlow — shown only when standalone sFlow is supported */}
       {supportsStandaloneSflow && (
         <>
           <Card>
@@ -475,7 +475,7 @@ export function FlowAccountingPanel({ config, capabilities, isReadOnly, onRefres
               <div className="flex items-center justify-between">
                 <div>
                   <CardTitle>sFlow Configuration</CardTitle>
-                  <CardDescription>Standalone sFlow agent settings (VyOS 1.5+).</CardDescription>
+                  <CardDescription>Standalone sFlow agent settings.</CardDescription>
                 </div>
                 {!isReadOnly && (
                   editingSf ? (

--- a/frontend/src/components/vpn/CreateInterfaceModal.tsx
+++ b/frontend/src/components/vpn/CreateInterfaceModal.tsx
@@ -428,12 +428,12 @@ export function CreateInterfaceModal({
           </TabsContent>
         </Tabs>
 
-        {/* VyOS 1.4 peer requirement notice */}
+        {/* Peer requirement notice */}
         {capabilities?.features.peer_required_on_create?.supported && (
           <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
             <AlertCircle className="h-5 w-5 text-amber-600 shrink-0 mt-0.5" />
             <p className="text-sm text-amber-700">
-              VyOS 1.4 requires at least one peer when creating an interface. Please use the <strong>Quick Setup Wizard</strong> instead, which creates an interface and peer together.
+              This device requires at least one peer when creating an interface. Please use the <strong>Quick Setup Wizard</strong> instead, which creates an interface and peer together.
             </p>
           </div>
         )}

--- a/frontend/src/components/vpn/QuickSetupWizard.tsx
+++ b/frontend/src/components/vpn/QuickSetupWizard.tsx
@@ -228,7 +228,7 @@ PersistentKeepalive = 25`;
       }
 
       // Step 2: Generate client keypair upfront if creating a client
-      // (needed before interface creation on VyOS 1.4 for atomic commit)
+      // (needed before interface creation when a peer is required for atomic commit)
       let clientKeypair: { private_key?: string | null; public_key?: string | null } | null = null;
       if (createClient) {
         clientKeypair = await wireguardService.generateKeypair();
@@ -237,7 +237,7 @@ PersistentKeepalive = 25`;
         }
       }
 
-      // Step 3: Create interface (with peer included for atomic commit on 1.4)
+      // Step 3: Create interface (with peer included for atomic commit when required)
       const interfaceConfig: Parameters<typeof wireguardService.createInterface>[0] = {
         name: interfaceName.trim(),
         private_key: serverKeypair.private_key,
@@ -481,7 +481,7 @@ PersistentKeepalive = 25`;
                 </Label>
                 <p className="text-xs text-muted-foreground">
                   {peerRequiredOnCreate
-                    ? "VyOS 1.4 requires at least one peer when creating an interface."
+                    ? "This device requires at least one peer when creating an interface."
                     : "Generate a config file and QR code for your first device."}
                 </p>
               </div>


### PR DESCRIPTION
FlowAccountingPanel printed VyOS 1.5+ on the sFlow card even though it already hides behind supportsStandaloneSflow. CreateInterfaceModal and QuickSetupWizard printed VyOS 1.4 on the peer-required notice even though they already gate on peer_required_on_create.

Drop the version numbers. Device-relative copy only.

npx tsc --noEmit and npm run lint in frontend/ (0 errors; 2 pre-existing warnings outside these files).

Closes #686