### PR TITLE
fix: expose firewall global-options resolver-cache and resolver-interval

### DIFF
--- a/backend/routers/firewall_global_options/firewall_global_options.py
+++ b/backend/routers/firewall_global_options/firewall_global_options.py
@@ -76,6 +76,10 @@ class FirewallGlobalOptionsConfig(BaseModel):
     syn_cookies: Optional[str] = None  # enable, disable
     twa_hazards_protection: Optional[str] = None  # enable, disable
 
+    # DNS resolver
+    resolver_cache: Optional[bool] = None
+    resolver_interval: Optional[int] = None
+
     # State policies
     state_policy_established: Optional[StatePolicy] = None
     state_policy_invalid: Optional[StatePolicy] = None
@@ -271,6 +275,10 @@ def parse_global_options(data: dict) -> FirewallGlobalOptionsConfig:
         syn_cookies=data.get("syn-cookies"),
         twa_hazards_protection=data.get("twa-hazards-protection"),
 
+        # DNS resolver
+        resolver_cache="resolver-cache" in data,
+        resolver_interval=_parse_int(data.get("resolver-interval")),
+
         # State policies
         state_policy_established=established,
         state_policy_invalid=invalid,
@@ -377,6 +385,7 @@ async def update_firewall_global_options(http_request: Request, config: Firewall
         _build_source_routing_options(builder, config, current)
         _build_redirect_options(builder, config, current)
         _build_security_options(builder, config, current)
+        _build_dns_resolver_options(builder, config, current)
         _build_state_policy_options(builder, config, current)
         _build_bridged_traffic_options(builder, config, current)
         _build_timeout_options(builder, config, current)
@@ -476,6 +485,20 @@ def _build_security_options(builder: FirewallGlobalOptionsBatchBuilder, config: 
             builder.set_twa_hazards_protection(config.twa_hazards_protection)
         elif "twa-hazards-protection" in current:
             builder.delete_twa_hazards_protection()
+
+
+def _build_dns_resolver_options(builder: FirewallGlobalOptionsBatchBuilder, config: FirewallGlobalOptionsConfig, current: dict):
+    """Build operations for DNS resolver options."""
+    if config.resolver_cache is not None:
+        if config.resolver_cache:
+            builder.set_resolver_cache()
+        elif "resolver-cache" in current:
+            builder.delete_resolver_cache()
+
+    if config.resolver_interval is not None:
+        builder.set_resolver_interval(config.resolver_interval)
+    elif "resolver-interval" in current:
+        builder.delete_resolver_interval()
 
 
 def _build_state_policy_options(builder: FirewallGlobalOptionsBatchBuilder, config: FirewallGlobalOptionsConfig, current: dict):

--- a/backend/tests/test_firewall_global_options_builder_paths.py
+++ b/backend/tests/test_firewall_global_options_builder_paths.py
@@ -1,0 +1,33 @@
+"""Golden (method, args, op, expected_path) cases for FirewallGlobalOptionsBatchBuilder."""
+
+import pytest
+
+from vyos_builders.firewall_global_options.firewall_global_options import (
+    FirewallGlobalOptionsBatchBuilder,
+)
+
+
+BASE = ["firewall", "global-options"]
+
+CASES = [
+    ("set_resolver_cache", (), "set", BASE + ["resolver-cache"]),
+    ("delete_resolver_cache", (), "delete", BASE + ["resolver-cache"]),
+    ("set_resolver_interval", (60,), "set", BASE + ["resolver-interval", "60"]),
+    ("delete_resolver_interval", (), "delete", BASE + ["resolver-interval"]),
+]
+
+
+@pytest.mark.parametrize("method, args, op, expected_path", CASES)
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_firewall_global_options_resolver_paths(method, args, op, expected_path, version):
+    builder = FirewallGlobalOptionsBatchBuilder(version=version)
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_firewall_global_options_advertises_dns_resolver(version):
+    builder = FirewallGlobalOptionsBatchBuilder(version=version)
+    caps = builder.get_capabilities()
+    assert caps["features"]["dns_resolver"]["supported"] is True

--- a/backend/vyos_builders/firewall_global_options/firewall_global_options.py
+++ b/backend/vyos_builders/firewall_global_options/firewall_global_options.py
@@ -159,6 +159,30 @@ class FirewallGlobalOptionsBatchBuilder(BatchBuilder):
         return self.add_delete(path)
 
     # ========================================================================
+    # DNS Resolver
+    # ========================================================================
+
+    def set_resolver_cache(self) -> "FirewallGlobalOptionsBatchBuilder":
+        """Enable resolver-cache (valueless flag)."""
+        path = self.mappers[self.mapper_key].get_resolver_cache()
+        return self.add_set(path)
+
+    def delete_resolver_cache(self) -> "FirewallGlobalOptionsBatchBuilder":
+        """Delete resolver-cache setting."""
+        path = self.mappers[self.mapper_key].get_resolver_cache_path()
+        return self.add_delete(path)
+
+    def set_resolver_interval(self, seconds: int) -> "FirewallGlobalOptionsBatchBuilder":
+        """Set resolver-interval (seconds)."""
+        path = self.mappers[self.mapper_key].get_resolver_interval(seconds)
+        return self.add_set(path)
+
+    def delete_resolver_interval(self) -> "FirewallGlobalOptionsBatchBuilder":
+        """Delete resolver-interval setting."""
+        path = self.mappers[self.mapper_key].get_resolver_interval_path()
+        return self.add_delete(path)
+
+    # ========================================================================
     # State Policy - Established
     # ========================================================================
 
@@ -494,6 +518,10 @@ class FirewallGlobalOptionsBatchBuilder(BatchBuilder):
                 "security_options": {
                     "supported": True,
                     "description": "Security options (log-martians, syn-cookies, etc.)",
+                },
+                "dns_resolver": {
+                    "supported": True,
+                    "description": "Firewall FQDN resolver cache and update interval",
                 },
                 "state_policy": {
                     "supported": True,

--- a/backend/vyos_mappers/firewall_global_options/firewall_global_options.py
+++ b/backend/vyos_mappers/firewall_global_options/firewall_global_options.py
@@ -108,6 +108,24 @@ class FirewallGlobalOptionsMapper(BaseFeatureMapper):
         """Get command path for twa-hazards-protection (for deletion)."""
         return ["firewall", "global-options", "twa-hazards-protection"]
 
+    # ==================== DNS Resolver ====================
+
+    def get_resolver_cache(self) -> List[str]:
+        """Get command path for resolver-cache (valueless flag)."""
+        return ["firewall", "global-options", "resolver-cache"]
+
+    def get_resolver_cache_path(self) -> List[str]:
+        """Get command path for resolver-cache (for deletion)."""
+        return ["firewall", "global-options", "resolver-cache"]
+
+    def get_resolver_interval(self, seconds: int) -> List[str]:
+        """Get command path for resolver-interval (seconds)."""
+        return ["firewall", "global-options", "resolver-interval", str(seconds)]
+
+    def get_resolver_interval_path(self) -> List[str]:
+        """Get command path for resolver-interval (for deletion)."""
+        return ["firewall", "global-options", "resolver-interval"]
+
     # ==================== State Policy ====================
 
     def get_state_policy_established_action(self, action: str) -> List[str]:

--- a/docs-site/docs/user-guide/firewall.md
+++ b/docs-site/docs/user-guide/firewall.md
@@ -38,7 +38,7 @@ Reordering works when a single zone pair is selected and renumbers rules as 10, 
 
 ## Global options
 
-A settings form, not a rule table: ICMP behavior (all-ping, broadcast-ping), source routing, ICMP redirects, security options (log-martians, source validation, SYN cookies, TWA hazards protection) and state policies for established/invalid/related traffic. On VyOS 1.5 two more cards appear: bridged traffic handling and connection timeouts (per TCP state, UDP, ICMP). Changes are tracked and saved with an explicit Save button.
+A settings form, not a rule table: ICMP behavior (all-ping, broadcast-ping), source routing, ICMP redirects, security options (log-martians, source validation, SYN cookies, TWA hazards protection), DNS resolver (FQDN resolver cache and update interval) and state policies for established/invalid/related traffic. On VyOS 1.5 two more cards appear: bridged traffic handling and connection timeouts (per TCP state, UDP, ICMP). Changes are tracked and saved with an explicit Save button.
 
 ## Flowtables
 

--- a/frontend/src/app/firewall/global-options/page.tsx
+++ b/frontend/src/app/firewall/global-options/page.tsx
@@ -63,6 +63,10 @@ function FirewallGlobalOptionsPageInner() {
   const [synCookies, setSynCookies] = useState<string>("not_set");
   const [twaHazardsProtection, setTwaHazardsProtection] = useState<string>("not_set");
 
+  // Form state - DNS Resolver
+  const [resolverCache, setResolverCache] = useState(false);
+  const [resolverInterval, setResolverInterval] = useState<string>("");
+
   // Form state - State Policies
   const [establishedAction, setEstablishedAction] = useState<string>("not_set");
   const [establishedLog, setEstablishedLog] = useState(false);
@@ -110,6 +114,9 @@ function FirewallGlobalOptionsPageInner() {
     setSourceValidation(cfg.source_validation || "not_set");
     setSynCookies(cfg.syn_cookies || "not_set");
     setTwaHazardsProtection(cfg.twa_hazards_protection || "not_set");
+
+    setResolverCache(cfg.resolver_cache || false);
+    setResolverInterval(cfg.resolver_interval?.toString() || "");
 
     if (cfg.state_policy_established) {
       setEstablishedAction(cfg.state_policy_established.action || "not_set");
@@ -189,6 +196,8 @@ function FirewallGlobalOptionsPageInner() {
       sourceValidation: cfg.source_validation || "not_set",
       synCookies: cfg.syn_cookies || "not_set",
       twaHazardsProtection: cfg.twa_hazards_protection || "not_set",
+      resolverCache: cfg.resolver_cache || false,
+      resolverInterval: cfg.resolver_interval?.toString() || "",
       establishedAction: cfg.state_policy_established?.action || "not_set",
       establishedLog: cfg.state_policy_established?.log || false,
       establishedLogLevel: cfg.state_policy_established?.log_level || "not_set",
@@ -227,6 +236,7 @@ function FirewallGlobalOptionsPageInner() {
       timeoutTcpEstablished, timeoutTcpFinWait, timeoutTcpLastAck,
       timeoutTcpSynRecv, timeoutTcpSynSent, timeoutTcpTimeWait,
       timeoutUdpOther, timeoutUdpStream,
+      resolverCache, resolverInterval,
     };
     const changed = Object.keys(currentValues).some(
       (key) => currentValues[key as keyof typeof currentValues] !== initialValues[key]
@@ -241,7 +251,8 @@ function FirewallGlobalOptionsPageInner() {
     timeoutIcmp, timeoutOther, timeoutTcpClose, timeoutTcpCloseWait,
     timeoutTcpEstablished, timeoutTcpFinWait, timeoutTcpLastAck,
     timeoutTcpSynRecv, timeoutTcpSynSent, timeoutTcpTimeWait,
-    timeoutUdpOther, timeoutUdpStream, initialValues,
+    timeoutUdpOther, timeoutUdpStream, resolverCache, resolverInterval,
+    initialValues,
   ]);
 
   const loadData = useCallback(async (forceRefresh: boolean = true) => {
@@ -297,6 +308,8 @@ function FirewallGlobalOptionsPageInner() {
         source_validation: sourceValidation !== "not_set" ? sourceValidation : "",
         syn_cookies: synCookies !== "not_set" ? synCookies : "",
         twa_hazards_protection: twaHazardsProtection !== "not_set" ? twaHazardsProtection : "",
+        resolver_cache: resolverCache,
+        resolver_interval: resolverInterval ? parseInt(resolverInterval) : null,
       };
 
       // Always send state policy config so backend can delete if needed
@@ -623,6 +636,48 @@ function FirewallGlobalOptionsPageInner() {
                   options={enableDisableOptions}
                   description="RFC1337 TIME-WAIT protection"
                 />
+              </CardContent>
+            </Card>
+
+            {/* DNS Resolver */}
+            <Card id="dns-resolver">
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm font-semibold">DNS Resolver</CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-3 pt-0">
+                <div
+                  id="resolver-cache"
+                  className="flex items-center justify-between py-2 border-b border-border/50 scroll-mt-24"
+                >
+                  <div className="flex-1 min-w-0 pr-4">
+                    <span className="text-sm font-medium">Resolver Cache</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Retain last resolved value if domain resolution fails
+                    </p>
+                  </div>
+                  <Checkbox
+                    checked={resolverCache}
+                    onCheckedChange={(c) => setResolverCache(c === true)}
+                  />
+                </div>
+                <div
+                  id="resolver-interval"
+                  className="flex items-center justify-between py-2 scroll-mt-24"
+                >
+                  <div className="flex-1 min-w-0 pr-4">
+                    <span className="text-sm font-medium">Resolver Interval (sec)</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Domain resolver update interval (10-3600, default 300)
+                    </p>
+                  </div>
+                  <Input
+                    type="number"
+                    placeholder="300"
+                    value={resolverInterval}
+                    onChange={(e) => setResolverInterval(e.target.value)}
+                    className="w-[160px] h-8 text-xs"
+                  />
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/frontend/src/lib/api/firewall-global-options.ts
+++ b/frontend/src/lib/api/firewall-global-options.ts
@@ -49,6 +49,10 @@ export interface FirewallGlobalOptionsConfig {
   syn_cookies: string | null;  // enable, disable
   twa_hazards_protection: string | null;  // enable, disable
 
+  // DNS resolver
+  resolver_cache: boolean | null;
+  resolver_interval: number | null;
+
   // State policies
   state_policy_established: StatePolicy | null;
   state_policy_invalid: StatePolicy | null;
@@ -80,6 +84,10 @@ export interface FirewallGlobalOptionsCapabilities {
       description: string;
     };
     security_options: {
+      supported: boolean;
+      description: string;
+    };
+    dns_resolver: {
       supported: boolean;
       description: string;
     };

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -56,6 +56,7 @@ export const navigation: NavItem[] = [
           { id: "source-routing", title: "Source Routing", href: "/firewall/global-options", description: "Firewall source routing", searchParams: { section: "source-routing" } },
           { id: "icmp-redirects", title: "ICMP Redirects", href: "/firewall/global-options", description: "ICMP redirect behavior", searchParams: { section: "icmp-redirects" } },
           { id: "security-options", title: "Security Options", href: "/firewall/global-options", description: "Firewall security options", searchParams: { section: "security-options" } },
+          { id: "dns-resolver", title: "DNS Resolver", href: "/firewall/global-options", description: "Firewall FQDN resolver cache and interval", searchParams: { section: "dns-resolver" } },
           { id: "state-policies", title: "State Policies", href: "/firewall/global-options", description: "Firewall state policy settings", searchParams: { section: "state-policies" } },
           { id: "bridged-traffic", title: "Bridged Traffic", href: "/firewall/global-options", description: "Firewall bridged traffic options", searchParams: { section: "bridged-traffic" } },
           { id: "connection-timeouts", title: "Connection Timeouts", href: "/firewall/global-options", description: "Firewall connection timeout settings", searchParams: { section: "connection-timeouts" } },

--- a/frontend/src/lib/search/config-sources.ts
+++ b/frontend/src/lib/search/config-sources.ts
@@ -103,6 +103,7 @@ export const configSources: ConfigSourceDefinition[] = [
       if (s.includes("redirect")) return { section: "icmp-redirects" };
       if (s.includes("src_route") || s.includes("source")) return { section: "source-routing" };
       if (s.includes("ping") || s.includes("icmp")) return { section: "icmp-settings" };
+      if (s.includes("resolver")) return { section: "dns-resolver" };
       return { section: "security-options" };
     },
   },

--- a/frontend/src/lib/search/config-walker.ts
+++ b/frontend/src/lib/search/config-walker.ts
@@ -216,6 +216,7 @@ function findSectionLabel(path: string[], key?: string): string {
   }
   if (combined.includes("bridged")) return "Bridged Traffic";
   if (combined.includes("timeout") || combined.includes("tcp_") || combined.includes("udp_")) return "Connection Timeouts";
+  if (combined.includes("resolver")) return "DNS Resolver";
   if (combined.includes("log_martians") || combined.includes("source_validation") || combined.includes("syn_cookies") || combined.includes("twa_hazards")) {
     return "Security Options";
   }

--- a/frontend/src/lib/search/ui-fields-registry.ts
+++ b/frontend/src/lib/search/ui-fields-registry.ts
@@ -170,6 +170,25 @@ export const uiFieldDefinitions: UiFieldDefinition[] = [
     sectionTitle: "Security Options",
     aliases: ["time wait", "rfc1337"],
   }),
+  // DNS Resolver
+  fwGlobal({
+    id: "ui-fw-global-resolver-cache",
+    label: "Resolver Cache",
+    controlType: "toggle",
+    sectionId: "dns-resolver",
+    sectionTitle: "DNS Resolver",
+    aliases: ["fqdn resolver", "dns cache"],
+    hint: "Retain last resolved value if domain resolution fails",
+  }),
+  fwGlobal({
+    id: "ui-fw-global-resolver-interval",
+    label: "Resolver Interval",
+    controlType: "input",
+    sectionId: "dns-resolver",
+    sectionTitle: "DNS Resolver",
+    aliases: ["fqdn resolver", "resolver update interval"],
+    hint: "Domain resolver update interval in seconds",
+  }),
   // State Policies — Established
   fwGlobal({
     id: "ui-fw-global-established-action",


### PR DESCRIPTION
firewall global-options exposed most leaves but not the two DNS FQDN resolver leaves. validateTmplPath accepts firewall global-options resolver-cache and resolver-interval on both 1.4 and 1.5, but neither had a mapper path, builder method, emitted op, or UI control, so an operator could not tune the firewall FQDN resolver from VyManager.

Added both leaves on the firewall global-options base mapper (valid on both versions, no gate), builder set/delete methods, a dns_resolver capability flag read through get_capabilities, router config fields plus parse and build wiring, and a DNS Resolver card on the global options page. Wired the search registries (navigation section, config sources, config walker label, ui-fields-registry) so the new controls are discoverable.

resolver-cache is a valueless flag (parsed as presence, emitted as a bare set). resolver-interval is seconds (VyOS range 10-3600).

Tests: backend PYTHONPATH=. venv/bin/python -m pytest tests/test_firewall_global_options_builder_paths.py -q (10 passed). Frontend npx tsc --noEmit (clean) and npm run lint (0 errors). Lab-validated both emitted paths on 1.4 and 1.5 with validate-path.sh (all VALID).

Closes #700
