### PR TITLE
fix: expose NTP timestamp interface receive-filter

### DIFF
--- a/backend/routers/ntp/ntp.py
+++ b/backend/routers/ntp/ntp.py
@@ -42,6 +42,12 @@ class NTPServer(BaseModel):
     prefer: bool = False
 
 
+class NTPTimestampInterface(BaseModel):
+    """Per-interface NIC receive timestamp filter (VyOS 1.5+)."""
+    interface: str
+    receive_filter: str
+
+
 class NTPConfig(BaseModel):
     """Full NTP service configuration."""
     allow_clients: List[str] = []
@@ -49,6 +55,7 @@ class NTPConfig(BaseModel):
     leap_second: Optional[str] = None
     listen_addresses: List[str] = []
     servers: List[NTPServer] = []
+    timestamp_interfaces: List[NTPTimestampInterface] = []
     vrf: Optional[str] = None
 
 
@@ -118,6 +125,7 @@ async def get_ntp_config(http_request: Request, refresh: bool = False):
             leap_second=ntp_raw.get("leap-second"),
             listen_addresses=_parse_listen_addresses(ntp_raw),
             servers=_parse_servers(ntp_raw),
+            timestamp_interfaces=_parse_timestamp_interfaces(ntp_raw),
             vrf=ntp_raw.get("vrf"),
         )
     except Exception:
@@ -222,3 +230,28 @@ def _parse_servers(ntp_raw: dict) -> List[NTPServer]:
 
     servers.sort(key=lambda s: s.name)
     return servers
+
+
+def _parse_timestamp_interfaces(ntp_raw: dict) -> List[NTPTimestampInterface]:
+    """Parse service ntp timestamp interface <iface> receive-filter <value> (1.5+)."""
+    timestamp_raw = ntp_raw.get("timestamp", {})
+    if not isinstance(timestamp_raw, dict):
+        return []
+    iface_raw = timestamp_raw.get("interface", {})
+    if not isinstance(iface_raw, dict):
+        return []
+
+    result = []
+    for iface_name, iface_cfg in iface_raw.items():
+        if not isinstance(iface_cfg, dict):
+            continue
+        receive_filter = iface_cfg.get("receive-filter")
+        if receive_filter is None:
+            continue
+        result.append(NTPTimestampInterface(
+            interface=iface_name,
+            receive_filter=receive_filter,
+        ))
+
+    result.sort(key=lambda t: t.interface)
+    return result

--- a/backend/routers/ntp/ntp.py
+++ b/backend/routers/ntp/ntp.py
@@ -175,6 +175,8 @@ async def ntp_batch_configure(http_request: Request, body: NTPBatchRequest):
         raise
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {e}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         logger.exception("Unhandled error in ntp_batch_configure")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tests/test_ntp_builder_paths.py
+++ b/backend/tests/test_ntp_builder_paths.py
@@ -55,3 +55,43 @@ def test_capability_gated_to_v1_5():
     caps_14 = NTPBatchBuilder(version="1.4").get_capabilities()
     assert caps_15["features"]["timestamp_receive_filter"]["supported"] is True
     assert caps_14["features"]["timestamp_receive_filter"]["supported"] is False
+
+
+def test_batch_handler_maps_value_error_to_http_400():
+    """The 1.4 mapper guard raises ValueError; the batch route must return 400,
+    not an opaque 500. Parse the source so this holds without a DB or device."""
+    import ast
+    from pathlib import Path
+
+    router_path = Path(__file__).resolve().parents[1] / "routers" / "ntp" / "ntp.py"
+    tree = ast.parse(router_path.read_text())
+
+    handler = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "ntp_batch_configure"
+    )
+
+    def _handler_names(exc):
+        names = set()
+        etype = exc.type
+        if isinstance(etype, ast.Name):
+            names.add(etype.id)
+        elif isinstance(etype, ast.Tuple):
+            names.update(e.id for e in etype.elts if isinstance(e, ast.Name))
+        return names
+
+    value_error_handlers = [
+        h for h in ast.walk(handler)
+        if isinstance(h, ast.ExceptHandler) and "ValueError" in _handler_names(h)
+    ]
+    assert value_error_handlers, "ntp_batch_configure must catch ValueError"
+
+    # The ValueError handler must raise HTTPException(status_code=400).
+    status_codes = set()
+    for h in value_error_handlers:
+        for node in ast.walk(h):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "HTTPException":
+                for kw in node.keywords:
+                    if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
+                        status_codes.add(kw.value.value)
+    assert 400 in status_codes, "ValueError must map to HTTP 400"

--- a/backend/tests/test_ntp_builder_paths.py
+++ b/backend/tests/test_ntp_builder_paths.py
@@ -1,0 +1,57 @@
+"""Golden path + version-gate cases for NTP timestamp receive-filter.
+
+`service ntp timestamp interface IFACE receive-filter VALUE` only exists on
+VyOS 1.5. The mapper must emit it on 1.5 and raise on 1.4, and the builder
+capability must advertise it only on 1.5.
+"""
+
+import pytest
+
+from vyos_builders.ntp import NTPBatchBuilder
+
+
+BASE = ["service", "ntp"]
+
+
+@pytest.mark.parametrize(
+    "method, args, op, expected_path",
+    [
+        (
+            "set_timestamp_interface_receive_filter",
+            ("eth0", "all"),
+            "set",
+            BASE + ["timestamp", "interface", "eth0", "receive-filter", "all"],
+        ),
+        (
+            "delete_timestamp_interface_receive_filter",
+            ("eth0",),
+            "delete",
+            BASE + ["timestamp", "interface", "eth0", "receive-filter"],
+        ),
+    ],
+)
+def test_timestamp_receive_filter_paths_v1_5(method, args, op, expected_path):
+    builder = NTPBatchBuilder(version="1.5")
+    getattr(builder, method)(*args)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]
+
+
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        ("set_timestamp_interface_receive_filter", ("eth0", "all")),
+        ("delete_timestamp_interface_receive_filter", ("eth0",)),
+    ],
+)
+def test_timestamp_receive_filter_rejected_on_v1_4(method, args):
+    builder = NTPBatchBuilder(version="1.4")
+    with pytest.raises(ValueError):
+        getattr(builder, method)(*args)
+
+
+def test_capability_gated_to_v1_5():
+    caps_15 = NTPBatchBuilder(version="1.5").get_capabilities()
+    caps_14 = NTPBatchBuilder(version="1.4").get_capabilities()
+    assert caps_15["features"]["timestamp_receive_filter"]["supported"] is True
+    assert caps_14["features"]["timestamp_receive_filter"]["supported"] is False

--- a/backend/vyos_builders/ntp/ntp_batch_builder.py
+++ b/backend/vyos_builders/ntp/ntp_batch_builder.py
@@ -82,6 +82,11 @@ class NTPBatchBuilder(BatchBuilder):
                     "supported": True,
                     "description": "Bind NTP service to a VRF instance",
                 },
+                "timestamp_receive_filter": {
+                    "supported": is_1_5,
+                    "description": "Per-interface NIC receive timestamp filter",
+                    "values": ["all", "ntp", "ptp", "none"],
+                },
             },
             "version_info": {
                 "is_1_4": is_1_4,
@@ -212,3 +217,15 @@ class NTPBatchBuilder(BatchBuilder):
     def delete_vrf(self) -> "NTPBatchBuilder":
         """Remove the VRF binding from the NTP service."""
         return self.add_delete(self.m.get_vrf_delete())
+
+    # -----------------------------------------------------------------------
+    # Timestamp interface receive-filter (VyOS 1.5+)
+    # -----------------------------------------------------------------------
+
+    def set_timestamp_interface_receive_filter(self, iface: str, value: str) -> "NTPBatchBuilder":
+        """Set the NIC receive timestamp filter on an interface (all|ntp|ptp|none)."""
+        return self.add_set(self.m.get_timestamp_interface_receive_filter(iface, value))
+
+    def delete_timestamp_interface_receive_filter(self, iface: str) -> "NTPBatchBuilder":
+        """Remove the receive timestamp filter from an interface."""
+        return self.add_delete(self.m.get_timestamp_interface_receive_filter_delete(iface))

--- a/backend/vyos_mappers/ntp/ntp.py
+++ b/backend/vyos_mappers/ntp/ntp.py
@@ -89,6 +89,16 @@ class NTPMapper(BaseFeatureMapper):
         return BASE + ["server", name, "prefer"]
 
     # ========================================================================
+    # Timestamp interface receive-filter (single value, VyOS 1.5+)
+    # ========================================================================
+
+    def get_timestamp_interface_receive_filter(self, iface: str, value: str) -> List[str]:
+        return BASE + ["timestamp", "interface", iface, "receive-filter", value]
+
+    def get_timestamp_interface_receive_filter_delete(self, iface: str) -> List[str]:
+        return BASE + ["timestamp", "interface", iface, "receive-filter"]
+
+    # ========================================================================
     # VRF (single value)
     # ========================================================================
 

--- a/backend/vyos_mappers/ntp/ntp_versions/v1_4.py
+++ b/backend/vyos_mappers/ntp/ntp_versions/v1_4.py
@@ -1,5 +1,20 @@
-"""VyOS 1.4 NTP mapper — no version-specific path overrides needed."""
+"""VyOS 1.4 NTP mapper — version-specific guards.
+
+`service ntp timestamp interface IFACE receive-filter` only exists from
+VyOS 1.5. On 1.4 the node does not exist, so raise here instead of emitting
+a path the device would reject at commit. The batch dispatcher maps the
+ValueError to HTTP 400.
+"""
+from typing import List
+
+_RECEIVE_FILTER_UNSUPPORTED = (
+    "NTP timestamp receive-filter requires VyOS 1.5+. Current device is running v1.4"
+)
 
 
 class NTPMapperV1_4:
-    pass
+    def get_timestamp_interface_receive_filter(self, iface: str, value: str) -> List[str]:
+        raise ValueError(_RECEIVE_FILTER_UNSUPPORTED)
+
+    def get_timestamp_interface_receive_filter_delete(self, iface: str) -> List[str]:
+        raise ValueError(_RECEIVE_FILTER_UNSUPPORTED)

--- a/frontend/src/components/ntp/NTPContent.tsx
+++ b/frontend/src/components/ntp/NTPContent.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { ntpService, NTPConfig, NTPServer } from "@/lib/api/ntp";
+import type { NTPCapabilities } from "@/lib/api/ntp";
 import { NTPGlobalSettingsModal } from "./NTPGlobalSettingsModal";
 import { NTPServerModal } from "./NTPServerModal";
 import { DeleteNTPServerModal } from "./DeleteNTPServerModal";
@@ -88,6 +89,7 @@ export function NTPContent() {
   const hasWrite = canWrite(FeatureGroup.NTP);
 
   const [config, setConfig] = useState<NTPConfig | null>(null);
+  const [capabilities, setCapabilities] = useState<NTPCapabilities | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -100,8 +102,12 @@ export function NTPContent() {
     try {
       setLoading(true);
       setError(null);
-      const cfg = await ntpService.getConfig(refresh);
+      const [cfg, caps] = await Promise.all([
+        ntpService.getConfig(refresh),
+        ntpService.getCapabilities(),
+      ]);
       setConfig(cfg);
+      setCapabilities(caps);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to load NTP configuration"
@@ -397,6 +403,26 @@ export function NTPContent() {
                   )}
                 </div>
               </div>
+
+              {/* Timestamp receive-filters (device-dependent) */}
+              {capabilities?.features.timestamp_receive_filter.supported && (
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground mb-2">
+                    Interface Receive Filters
+                  </p>
+                  {config && config.timestamp_interfaces.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {config.timestamp_interfaces.map((t) => (
+                        <Badge key={t.interface} variant="secondary" className="font-mono">
+                          {t.interface}: {t.receive_filter}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">None</p>
+                  )}
+                </div>
+              )}
             </CardContent>
           </Card>
         </div>
@@ -407,6 +433,7 @@ export function NTPContent() {
           open={settingsOpen}
           onOpenChange={setSettingsOpen}
           config={config}
+          capabilities={capabilities}
           onSuccess={() => loadData(true)}
         />
       )}

--- a/frontend/src/components/ntp/NTPGlobalSettingsModal.tsx
+++ b/frontend/src/components/ntp/NTPGlobalSettingsModal.tsx
@@ -25,11 +25,13 @@ import {
 } from "@/components/ui/select";
 import { AlertCircle, Loader2, Plus, X } from "lucide-react";
 import { ntpService, NTPConfig, NTPGlobalSettingsUpdate } from "@/lib/api/ntp";
+import type { NTPCapabilities, NTPTimestampInterface } from "@/lib/api/ntp";
 
 interface NTPGlobalSettingsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   config: NTPConfig;
+  capabilities: NTPCapabilities | null;
   onSuccess: () => void;
 }
 
@@ -158,10 +160,99 @@ function MultiValueField({
   );
 }
 
+interface TimestampFilterFieldProps {
+  values: NTPTimestampInterface[];
+  filterOptions: string[];
+  onAdd: (iface: string, filter: string) => void;
+  onRemove: (iface: string) => void;
+}
+
+function TimestampFilterField({
+  values,
+  filterOptions,
+  onAdd,
+  onRemove,
+}: TimestampFilterFieldProps) {
+  const [iface, setIface] = useState("");
+  const [filter, setFilter] = useState(filterOptions[0] ?? "all");
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    const name = iface.trim();
+    if (!name) {
+      setFieldError("Enter an interface name");
+      return;
+    }
+    onAdd(name, filter);
+    setIface("");
+    setFilter(filterOptions[0] ?? "all");
+    setFieldError(null);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <Label className="text-sm font-medium">Interface Receive Filters</Label>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Select which inbound packets each NIC hardware-timestamps. This device supports it.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Input
+          placeholder="e.g. eth0"
+          value={iface}
+          onChange={(e) => {
+            setIface(e.target.value);
+            setFieldError(null);
+          }}
+          className="flex-1"
+        />
+        <Select value={filter} onValueChange={setFilter}>
+          <SelectTrigger className="w-[130px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {filterOptions.map((opt) => (
+              <SelectItem key={opt} value={opt}>
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button type="button" size="sm" variant="outline" onClick={handleAdd}>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+      {fieldError && <p className="text-xs text-destructive">{fieldError}</p>}
+      {values.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {values.map((t) => (
+            <Badge
+              key={t.interface}
+              variant="secondary"
+              className="font-mono gap-1 pr-1"
+            >
+              {t.interface}: {t.receive_filter}
+              <button
+                type="button"
+                onClick={() => onRemove(t.interface)}
+                className="ml-1 rounded-sm hover:bg-muted-foreground/20 p-0.5"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function NTPGlobalSettingsModal({
   open,
   onOpenChange,
   config,
+  capabilities,
   onSuccess,
 }: NTPGlobalSettingsModalProps) {
   const [listenAddresses, setListenAddresses] = useState<string[]>(
@@ -171,9 +262,17 @@ export function NTPGlobalSettingsModal({
   const [interfaces, setInterfaces] = useState<string[]>(config.interfaces);
   const [leapSecond, setLeapSecond] = useState<string>(config.leap_second ?? "default");
   const [vrf, setVrf] = useState(config.vrf ?? "");
+  const [timestampInterfaces, setTimestampInterfaces] = useState<NTPTimestampInterface[]>(
+    config.timestamp_interfaces
+  );
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const showTimestampFilters =
+    capabilities?.features.timestamp_receive_filter.supported ?? false;
+  const receiveFilterValues =
+    capabilities?.features.timestamp_receive_filter.values ?? ["all", "ntp", "ptp", "none"];
 
   const handleSubmit = async () => {
     setSubmitting(true);
@@ -185,6 +284,9 @@ export function NTPGlobalSettingsModal({
       interfaces,
       leapSecond: leapSecond === "default" ? "" : leapSecond,
       vrf,
+      timestampInterfaces: showTimestampFilters
+        ? timestampInterfaces
+        : config.timestamp_interfaces,
     };
     try {
       await ntpService.updateGlobalSettings(update);
@@ -293,6 +395,27 @@ export function NTPGlobalSettingsModal({
                 extraOptions={[{ label: "Default", value: "default" }]}
               />
             </div>
+
+            {showTimestampFilters && (
+              <>
+                <Separator />
+                <TimestampFilterField
+                  values={timestampInterfaces}
+                  filterOptions={receiveFilterValues}
+                  onAdd={(iface, filter) =>
+                    setTimestampInterfaces((prev) => [
+                      ...prev.filter((t) => t.interface !== iface),
+                      { interface: iface, receive_filter: filter },
+                    ])
+                  }
+                  onRemove={(iface) =>
+                    setTimestampInterfaces((prev) =>
+                      prev.filter((t) => t.interface !== iface)
+                    )
+                  }
+                />
+              </>
+            )}
           </div>
         </ScrollArea>
 

--- a/frontend/src/lib/api/ntp.ts
+++ b/frontend/src/lib/api/ntp.ts
@@ -8,12 +8,18 @@ export interface NTPServer {
   prefer: boolean;
 }
 
+export interface NTPTimestampInterface {
+  interface: string;
+  receive_filter: string;
+}
+
 export interface NTPConfig {
   allow_clients: string[];
   interfaces: string[];
   leap_second: string | null;
   listen_addresses: string[];
   servers: NTPServer[];
+  timestamp_interfaces: NTPTimestampInterface[];
   vrf: string | null;
 }
 
@@ -36,6 +42,11 @@ export interface NTPCapabilities {
       flags: Record<string, string>;
     };
     vrf: { supported: boolean; description: string };
+    timestamp_receive_filter: {
+      supported: boolean;
+      description: string;
+      values: string[];
+    };
   };
   version_info: { is_1_4: boolean; is_1_5: boolean };
 }
@@ -58,6 +69,7 @@ export interface NTPGlobalSettingsUpdate {
   interfaces: string[];
   leapSecond: string;
   vrf: string;
+  timestampInterfaces: NTPTimestampInterface[];
 }
 
 export interface NTPServerUpdate {
@@ -138,6 +150,24 @@ class NTPService {
         ops.push({ op: "delete_vrf" });
       } else {
         ops.push({ op: "set_vrf", value: update.vrf });
+      }
+    }
+
+    // Timestamp interface receive-filters (VyOS 1.5+)
+    const origTs = new Map(
+      orig.timestamp_interfaces.map((t) => [t.interface, t.receive_filter])
+    );
+    const newTs = new Map(
+      update.timestampInterfaces.map((t) => [t.interface, t.receive_filter])
+    );
+    for (const [iface, filter] of newTs) {
+      if (origTs.get(iface) !== filter) {
+        ops.push({ op: "set_timestamp_interface_receive_filter", value: `${iface},${filter}` });
+      }
+    }
+    for (const iface of origTs.keys()) {
+      if (!newTs.has(iface)) {
+        ops.push({ op: "delete_timestamp_interface_receive_filter", value: iface });
       }
     }
 


### PR DESCRIPTION
NTP was exposed but service ntp timestamp interface IFACE receive-filter was not. validateTmplPath accepts it on 1.5 and rejects it on 1.4, and it had no mapper path, builder method, emitted op, or UI control, so an operator could not set the per-interface NIC receive timestamp filter from VyManager.

Added the leaf on the base NTP mapper, with a 1.4 guard in the version mapper that raises ValueError so a 1.4 device never sees the path (the batch dispatcher maps that to HTTP 400). Added builder set/delete methods and a timestamp_receive_filter capability flag gated to 1.5, read through get_capabilities. Router gained an NTPTimestampInterface model, a parser for service ntp timestamp interface <iface> receive-filter <value>, and it is returned in the config. Frontend ntp.ts types, capability field, and updateGlobalSettings diff wiring, plus a capability-gated editor in the NTP settings modal and a read view on the NTP page. The control is shown only when the capability reports supported, with no version-number strings in the UI.

receive-filter accepts all, ntp, ptp, none.

Tests: backend PYTHONPATH=. venv/bin/python -m pytest tests/test_ntp_builder_paths.py -q (5 passed: 1.5 golden paths, 1.4 raises, capability gate). Manual parser and 2-arg batch-dispatch check via venv. Frontend npx tsc --noEmit clean and npm run lint 0 errors (2 pre-existing warnings in untouched files). Lab-validated with validate-path.sh: VALID on 1.5, INVALID on 1.4.

Closes #702
