### PR TITLE
fix: expose syslog remote RFC 5424 format leaves

### DIFF
--- a/backend/routers/system.py
+++ b/backend/routers/system.py
@@ -83,6 +83,8 @@ class SyslogRemoteHost(BaseModel):
     facilities: List[SyslogFacility] = Field(default_factory=list)
     port: Optional[int] = None
     protocol: Optional[str] = None
+    format_include_timezone: bool = False
+    format_octet_counted: bool = False
 
 
 class SyslogFileEntry(BaseModel):
@@ -1029,6 +1031,8 @@ async def system_batch_configure(
         )
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         logger.exception("Unhandled error in system_batch_configure")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/tests/test_system_syslog_remote_format.py
+++ b/backend/tests/test_system_syslog_remote_format.py
@@ -1,0 +1,93 @@
+"""Syslog remote RFC 5424 format leaves — path, version-gate, capability, 400.
+
+`system syslog remote HOST format include-timezone` and `... octet-counted`
+exist only on VyOS 1.5. The mapper must emit them on 1.5 and raise on 1.4,
+the builder capability must advertise them only on 1.5, and the system batch
+handler must map the 1.4 guard's ValueError to HTTP 400 (not an opaque 500).
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from vyos_builders.system.system_batch_builder import SystemBatchBuilder
+
+
+HOST = "192.0.2.1"
+BASE = ["system", "syslog", "remote", HOST, "format"]
+
+
+@pytest.mark.parametrize(
+    "method, op, expected_path",
+    [
+        ("set_syslog_remote_format_include_timezone", "set", BASE + ["include-timezone"]),
+        ("delete_syslog_remote_format_include_timezone", "delete", BASE + ["include-timezone"]),
+        ("set_syslog_remote_format_octet_counted", "set", BASE + ["octet-counted"]),
+        ("delete_syslog_remote_format_octet_counted", "delete", BASE + ["octet-counted"]),
+    ],
+)
+def test_syslog_remote_format_paths_v1_5(method, op, expected_path):
+    builder = SystemBatchBuilder(version="1.5")
+    getattr(builder, method)(HOST)
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "set_syslog_remote_format_include_timezone",
+        "delete_syslog_remote_format_include_timezone",
+        "set_syslog_remote_format_octet_counted",
+        "delete_syslog_remote_format_octet_counted",
+    ],
+)
+def test_syslog_remote_format_rejected_on_v1_4(method):
+    builder = SystemBatchBuilder(version="1.4")
+    with pytest.raises(ValueError):
+        getattr(builder, method)(HOST)
+
+
+def test_capability_gated_to_v1_5():
+    caps_15 = SystemBatchBuilder(version="1.5").get_capabilities()
+    caps_14 = SystemBatchBuilder(version="1.4").get_capabilities()
+    assert caps_15["syslog"]["supports_remote_format"] is True
+    assert caps_14["syslog"]["supports_remote_format"] is False
+
+
+def test_system_batch_handler_maps_value_error_to_http_400():
+    """The 1.4 mapper guard raises ValueError; the system batch route must
+    return 400, not an opaque 500. Parse the source so this holds without a
+    DB or device."""
+    router_path = Path(__file__).resolve().parents[1] / "routers" / "system.py"
+    tree = ast.parse(router_path.read_text())
+
+    handler = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "system_batch_configure"
+    )
+
+    def _handler_names(exc):
+        names = set()
+        etype = exc.type
+        if isinstance(etype, ast.Name):
+            names.add(etype.id)
+        elif isinstance(etype, ast.Tuple):
+            names.update(e.id for e in etype.elts if isinstance(e, ast.Name))
+        return names
+
+    value_error_handlers = [
+        h for h in ast.walk(handler)
+        if isinstance(h, ast.ExceptHandler) and "ValueError" in _handler_names(h)
+    ]
+    assert value_error_handlers, "system_batch_configure must catch ValueError"
+
+    status_codes = set()
+    for h in value_error_handlers:
+        for node in ast.walk(h):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "HTTPException":
+                for kw in node.keywords:
+                    if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
+                        status_codes.add(kw.value.value)
+    assert 400 in status_codes, "ValueError must map to HTTP 400"

--- a/backend/vyos_builders/system/system_batch_builder.py
+++ b/backend/vyos_builders/system/system_batch_builder.py
@@ -248,6 +248,18 @@ class SystemBatchBuilder(BatchBuilder):
     def delete_syslog_remote(self, host: str) -> "SystemBatchBuilder":
         return self.add_delete(self.mapper.get_delete_syslog_remote_path(host))
 
+    def set_syslog_remote_format_include_timezone(self, host: str) -> "SystemBatchBuilder":
+        return self.add_set(self.mapper.get_syslog_remote_format_include_timezone_path(host))
+
+    def delete_syslog_remote_format_include_timezone(self, host: str) -> "SystemBatchBuilder":
+        return self.add_delete(self.mapper.get_syslog_remote_format_include_timezone_path(host))
+
+    def set_syslog_remote_format_octet_counted(self, host: str) -> "SystemBatchBuilder":
+        return self.add_set(self.mapper.get_syslog_remote_format_octet_counted_path(host))
+
+    def delete_syslog_remote_format_octet_counted(self, host: str) -> "SystemBatchBuilder":
+        return self.add_delete(self.mapper.get_syslog_remote_format_octet_counted_path(host))
+
     def set_syslog_console_facility(self, facility: str, level: str) -> "SystemBatchBuilder":
         return self.add_set(self.mapper.get_syslog_console_facility_path(facility, level))
 
@@ -1109,6 +1121,7 @@ class SystemBatchBuilder(BatchBuilder):
                 "supports_file": self.mapper.supports_syslog_file(),
                 "supports_user": self.mapper.supports_syslog_user(),
                 "supports_marker_disable": self.mapper.supports_syslog_marker_disable(),
+                "supports_remote_format": self.mapper.supports_syslog_remote_format(),
                 "facilities": [
                     "all", "auth", "authpriv", "cron", "daemon", "kern", "lpr",
                     "mail", "mark", "news", "protocols", "security", "syslog",

--- a/backend/vyos_mappers/system/config_parse.py
+++ b/backend/vyos_mappers/system/config_parse.py
@@ -99,12 +99,15 @@ def parse_syslog(system_config: dict, mapper) -> Dict[str, Any]:
             if host_cfg is None:
                 host_cfg = {}
             port_val = host_cfg.get("port")
+            format_cfg = host_cfg.get("format", {}) or {}
             remote_hosts.append(
                 {
                     "host": host,
                     "facilities": parse_syslog_facilities(host_cfg),
                     "port": int(port_val) if port_val else None,
                     "protocol": host_cfg.get("protocol"),
+                    "format_include_timezone": "include-timezone" in format_cfg,
+                    "format_octet_counted": "octet-counted" in format_cfg,
                 }
             )
 

--- a/backend/vyos_mappers/system/system_mapper.py
+++ b/backend/vyos_mappers/system/system_mapper.py
@@ -209,6 +209,14 @@ class SystemMapper(BaseFeatureMapper):
     def get_delete_syslog_remote_path(self, host: str) -> List[str]:
         return ["system", "syslog", "remote", host]
 
+    def get_syslog_remote_format_include_timezone_path(self, host: str) -> List[str]:
+        """1.5: system syslog remote <host> format include-timezone"""
+        return ["system", "syslog", "remote", host, "format", "include-timezone"]
+
+    def get_syslog_remote_format_octet_counted_path(self, host: str) -> List[str]:
+        """1.5: system syslog remote <host> format octet-counted"""
+        return ["system", "syslog", "remote", host, "format", "octet-counted"]
+
     def get_syslog_console_facility_path(self, facility: str, level: str) -> List[str]:
         return ["system", "syslog", "console", "facility", facility, "level", level]
 
@@ -264,6 +272,9 @@ class SystemMapper(BaseFeatureMapper):
         return False
 
     def supports_syslog_marker_disable(self) -> bool:
+        return True
+
+    def supports_syslog_remote_format(self) -> bool:
         return True
 
     # =========================================================================

--- a/backend/vyos_mappers/system/system_versions/v1_4.py
+++ b/backend/vyos_mappers/system/system_versions/v1_4.py
@@ -15,6 +15,12 @@ Key differences from 1.5:
 from typing import List
 
 
+_SYSLOG_REMOTE_FORMAT_UNSUPPORTED = (
+    "Syslog remote format (include-timezone, octet-counted) requires VyOS 1.5+. "
+    "Current device is running v1.4"
+)
+
+
 class SystemMapperV1_4:
     """VyOS 1.4 specific system path overrides."""
 
@@ -41,6 +47,12 @@ class SystemMapperV1_4:
 
     def get_delete_syslog_remote_path(self, host: str) -> List[str]:
         return ["system", "syslog", "host", host]
+
+    def get_syslog_remote_format_include_timezone_path(self, host: str) -> List[str]:
+        raise ValueError(_SYSLOG_REMOTE_FORMAT_UNSUPPORTED)
+
+    def get_syslog_remote_format_octet_counted_path(self, host: str) -> List[str]:
+        raise ValueError(_SYSLOG_REMOTE_FORMAT_UNSUPPORTED)
 
     def get_syslog_console_facility_path(self, facility: str, level: str) -> List[str]:
         """1.4 has no syslog console target — returns empty so batch is no-op."""
@@ -98,6 +110,9 @@ class SystemMapperV1_4:
         return True
 
     def supports_syslog_marker_disable(self) -> bool:
+        return False
+
+    def supports_syslog_remote_format(self) -> bool:
         return False
 
     # =========================================================================

--- a/backend/vyos_mappers/system/system_versions/v1_5.py
+++ b/backend/vyos_mappers/system/system_versions/v1_5.py
@@ -38,6 +38,9 @@ class SystemMapperV1_5:
     def supports_syslog_marker_disable(self) -> bool:
         return True
 
+    def supports_syslog_remote_format(self) -> bool:
+        return True
+
     def supports_watchdog(self) -> bool:
         return True
 

--- a/frontend/src/components/system/settings/SyslogPanel.tsx
+++ b/frontend/src/components/system/settings/SyslogPanel.tsx
@@ -56,7 +56,7 @@ interface Props {
 
 export function SyslogPanel({ config, capabilities, isReadOnly, onRefresh }: Props) {
   const { toast } = useToast();
-  const { syslog: { facilities, levels, supports_console, supports_file, supports_user, supports_marker_disable } } =
+  const { syslog: { facilities, levels, supports_console, supports_file, supports_user, supports_marker_disable, supports_remote_format } } =
     capabilities;
 
   // Local facility add
@@ -79,6 +79,35 @@ export function SyslogPanel({ config, capabilities, isReadOnly, onRefresh }: Pro
   // Delete remote
   const [deleteRemoteTarget, setDeleteRemoteTarget] = useState<string | null>(null);
   const [deletingRemote, setDeletingRemote] = useState(false);
+
+  // Edit remote format flags (1.5 only)
+  const [formatEditHost, setFormatEditHost] = useState<string | null>(null);
+  const [formatTz, setFormatTz] = useState(false);
+  const [formatOctet, setFormatOctet] = useState(false);
+  const [formatSaving, setFormatSaving] = useState(false);
+
+  const handleSaveRemoteFormat = async () => {
+    if (!formatEditHost) return;
+    setFormatSaving(true);
+    try {
+      const result = await systemSettingsService.setSyslogRemoteFormat(
+        formatEditHost,
+        formatTz,
+        formatOctet,
+      );
+      if (!result.success) {
+        toast.error("Save failed", result.error ?? "Failed to update format");
+      } else {
+        toast.success("Remote format updated");
+        setFormatEditHost(null);
+        onRefresh();
+      }
+    } catch {
+      toast.error("Save failed", "An unexpected error occurred");
+    } finally {
+      setFormatSaving(false);
+    }
+  };
 
   // Syslog marker
   const [editingMarker, setEditingMarker] = useState(false);
@@ -265,13 +294,14 @@ export function SyslogPanel({ config, capabilities, isReadOnly, onRefresh }: Pro
                 <TableHead>Host</TableHead>
                 <TableHead>Port</TableHead>
                 <TableHead>Facilities</TableHead>
+                {supports_remote_format && <TableHead>Format</TableHead>}
                 {!isReadOnly && <TableHead className="text-right">Actions</TableHead>}
               </TableRow>
             </TableHeader>
             <TableBody>
               {config.syslog.remote_hosts.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={isReadOnly ? 3 : 4} className="text-center text-muted-foreground py-6">
+                  <TableCell colSpan={isReadOnly ? (supports_remote_format ? 4 : 3) : (supports_remote_format ? 5 : 4)} className="text-center text-muted-foreground py-6">
                     No remote hosts configured
                   </TableCell>
                 </TableRow>
@@ -289,8 +319,36 @@ export function SyslogPanel({ config, capabilities, isReadOnly, onRefresh }: Pro
                         ))}
                       </div>
                     </TableCell>
+                    {supports_remote_format && (
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {rh.format_include_timezone && (
+                            <Badge variant="outline" className="text-xs">include-timezone</Badge>
+                          )}
+                          {rh.format_octet_counted && (
+                            <Badge variant="outline" className="text-xs">octet-counted</Badge>
+                          )}
+                          {!rh.format_include_timezone && !rh.format_octet_counted && (
+                            <span className="text-xs text-muted-foreground">Default</span>
+                          )}
+                        </div>
+                      </TableCell>
+                    )}
                     {!isReadOnly && (
                       <TableCell className="text-right">
+                        {supports_remote_format && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                              setFormatEditHost(rh.host);
+                              setFormatTz(rh.format_include_timezone);
+                              setFormatOctet(rh.format_octet_counted);
+                            }}
+                          >
+                            <Edit2 className="h-4 w-4" />
+                          </Button>
+                        )}
                         <Button
                           variant="ghost"
                           size="sm"
@@ -532,6 +590,7 @@ export function SyslogPanel({ config, capabilities, isReadOnly, onRefresh }: Pro
         onOpenChange={setRemoteModalOpen}
         facilities={facilities}
         levels={levels}
+        supportsFormat={supports_remote_format}
         onSuccess={onRefresh}
       />
 
@@ -551,6 +610,45 @@ export function SyslogPanel({ config, capabilities, isReadOnly, onRefresh }: Pro
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {deletingRemote ? "Removing…" : "Remove"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={!!formatEditHost} onOpenChange={(o: boolean) => { if (!o) setFormatEditHost(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Edit Message Format</AlertDialogTitle>
+            <AlertDialogDescription>
+              RFC 5424 framing for syslog forwarding to <strong>{formatEditHost}</strong>.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="edit-fmt-tz"
+                checked={formatTz}
+                onCheckedChange={(v) => setFormatTz(!!v)}
+              />
+              <Label htmlFor="edit-fmt-tz" className="text-sm font-normal">
+                Include timezone (RFC 5424 with RFC 3339 timestamp)
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="edit-fmt-octet"
+                checked={formatOctet}
+                onCheckedChange={(v) => setFormatOctet(!!v)}
+              />
+              <Label htmlFor="edit-fmt-octet" className="text-sm font-normal">
+                Octet-counted framing (multi-line messages, TCP only)
+              </Label>
+            </div>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={formatSaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleSaveRemoteFormat} disabled={formatSaving}>
+              {formatSaving ? "Saving…" : "Save"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/components/system/settings/SyslogRemoteModal.tsx
+++ b/frontend/src/components/system/settings/SyslogRemoteModal.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { AlertCircle, Plus, X, Server } from "lucide-react";
 import {
   systemSettingsService,
@@ -30,15 +31,18 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   facilities: string[];
   levels: string[];
+  supportsFormat: boolean;
   onSuccess: () => void;
 }
 
-export function SyslogRemoteModal({ open, onOpenChange, facilities, levels, onSuccess }: Props) {
+export function SyslogRemoteModal({ open, onOpenChange, facilities, levels, supportsFormat, onSuccess }: Props) {
   const [host, setHost] = useState("");
   const [port, setPort] = useState("");
   const [facList, setFacList] = useState<SyslogFacility[]>([]);
   const [facInput, setFacInput] = useState("all");
   const [levelInput, setLevelInput] = useState("info");
+  const [includeTimezone, setIncludeTimezone] = useState(false);
+  const [octetCounted, setOctetCounted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,6 +53,8 @@ export function SyslogRemoteModal({ open, onOpenChange, facilities, levels, onSu
       setFacList([]);
       setFacInput("all");
       setLevelInput("info");
+      setIncludeTimezone(false);
+      setOctetCounted(false);
       setError(null);
     }
   }, [open]);
@@ -88,6 +94,8 @@ export function SyslogRemoteModal({ open, onOpenChange, facilities, levels, onSu
         host.trim(),
         facList,
         port ? parseInt(port, 10) : null,
+        supportsFormat ? includeTimezone : undefined,
+        supportsFormat ? octetCounted : undefined,
       );
 
       if (!result.success) {
@@ -202,6 +210,32 @@ export function SyslogRemoteModal({ open, onOpenChange, facilities, levels, onSu
               </Button>
             </div>
           </div>
+
+          {supportsFormat && (
+            <div className="space-y-2">
+              <Label>Message Format (RFC 5424)</Label>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="fmt-tz"
+                  checked={includeTimezone}
+                  onCheckedChange={(v) => setIncludeTimezone(!!v)}
+                />
+                <Label htmlFor="fmt-tz" className="text-sm font-normal">
+                  Include timezone (RFC 5424 with RFC 3339 timestamp)
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="fmt-octet"
+                  checked={octetCounted}
+                  onCheckedChange={(v) => setOctetCounted(!!v)}
+                />
+                <Label htmlFor="fmt-octet" className="text-sm font-normal">
+                  Octet-counted framing (multi-line messages, TCP only)
+                </Label>
+              </div>
+            </div>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button type="button" variant="outline" onClick={handleClose} disabled={loading}>

--- a/frontend/src/lib/api/system-settings.ts
+++ b/frontend/src/lib/api/system-settings.ts
@@ -30,6 +30,7 @@ export interface SystemCapabilities {
     supports_file: boolean;
     supports_user: boolean;
     supports_marker_disable: boolean;
+    supports_remote_format: boolean;
     facilities: string[];
     levels: string[];
   };
@@ -93,6 +94,8 @@ export interface SyslogRemoteHost {
   facilities: SyslogFacility[];
   port: number | null;
   protocol: string | null;
+  format_include_timezone: boolean;
+  format_octet_counted: boolean;
 }
 
 export interface SyslogFileEntry {
@@ -594,12 +597,36 @@ class SystemSettingsService {
     host: string,
     facilities: { facility: string; level: string }[],
     port?: number | null,
+    formatIncludeTimezone?: boolean,
+    formatOctetCounted?: boolean,
   ): Promise<VyOSResponse> {
     const ops: BatchOp[] = facilities.map((f) => ({
       op: "set_syslog_remote_facility",
       value: `${f.facility},${f.level}`,
     }));
     if (port) ops.push({ op: "set_syslog_remote_port", value: String(port) });
+    if (formatIncludeTimezone) ops.push({ op: "set_syslog_remote_format_include_timezone" });
+    if (formatOctetCounted) ops.push({ op: "set_syslog_remote_format_octet_counted" });
+    return this.batch(host, ops);
+  }
+
+  async setSyslogRemoteFormat(
+    host: string,
+    includeTimezone: boolean,
+    octetCounted: boolean,
+  ): Promise<VyOSResponse> {
+    const ops: BatchOp[] = [
+      {
+        op: includeTimezone
+          ? "set_syslog_remote_format_include_timezone"
+          : "delete_syslog_remote_format_include_timezone",
+      },
+      {
+        op: octetCounted
+          ? "set_syslog_remote_format_octet_counted"
+          : "delete_syslog_remote_format_octet_counted",
+      },
+    ];
     return this.batch(host, ops);
   }
 


### PR DESCRIPTION
System syslog was exposed but the remote-host RFC 5424 format leaves were not. validateTmplPath accepts system syslog remote HOST format include-timezone and format octet-counted on 1.5 and rejects both on 1.4, but neither had a mapper path, builder method, emitted op, or UI control, so an operator could not tune remote syslog framing from VyManager.

Added both leaves on the base system mapper (1.5 default shape), with 1.4 overrides that raise ValueError so a 1.4 device never sees the path (the merge factory checks the version mapper before base). Added builder set/delete methods and a supports_remote_format capability flag (base and v1_5 True, v1_4 False), read through get_capabilities. The system batch route now maps ValueError to HTTP 400 before its generic handler, matching the sibling-router convention, so the 1.4 guard returns 400 not an opaque 500. Router SyslogRemoteHost model gained format_include_timezone and format_octet_counted, and config_parse reads them per host. Frontend types, capability field, createSyslogRemoteHost format args and a setSyslogRemoteFormat method, capability-gated format checkboxes in the add-host modal, and a Format column plus per-host format editor in the syslog panel. All gated by the capability flag, no version-number strings in the UI.

Both leaves are valueless flags. Format state is set-only per flag with an explicit delete for toggling off, mirroring how the whole host is removed via delete_syslog_remote.

Tests: backend PYTHONPATH=. venv/bin/python -m pytest tests/test_system_syslog_remote_format.py -q (10 passed: 1.5 golden set/delete paths, 1.4 raises for all four methods, capability True/False, and an AST regression that the system batch handler maps ValueError to 400, verified failing without the fix). Manual config_parse check via venv. Frontend npx tsc --noEmit clean and npm run lint 0 errors (2 pre-existing warnings in untouched files). Lab-validated with validate-path.sh: both VALID on 1.5, both INVALID on 1.4.

Closes #701
