### PR TITLE
fix: expose BGP l2vpn-evpn address-family control flags

### DIFF
--- a/backend/routers/bgp/bgp.py
+++ b/backend/routers/bgp/bgp.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Optional, Any
 from session_vyos_service import get_session_vyos_service
 from vyos_builders import BgpBatchBuilder
+from vyos_mappers.bgp.bgp import BgpMapper
 from fastapi_permissions import require_read_permission, require_write_permission
 from rbac_permissions import FeatureGroup
 import inspect
@@ -253,6 +254,7 @@ class BgpAddressFamily(BaseModel):
     redistribute: List[BgpRedistribute] = []
     maximum_paths_ebgp: Optional[int] = None
     maximum_paths_ibgp: Optional[int] = None
+    evpn_flags: List[str] = []
 
 
 class BgpListenRange(BaseModel):
@@ -719,14 +721,11 @@ def parse_peer_groups(raw: dict) -> List[BgpPeerGroup]:
 def parse_address_families(raw: dict) -> List[BgpAddressFamily]:
     """Parse global address-family configurations."""
     families = []
+    evpn_flag_names = BgpMapper("1.5").l2vpn_evpn_control_flags()
 
     for afi, afi_config in raw.items():
         if afi_config is None:
             afi_config = {}
-
-        # Skip L2VPN-EVPN for now (complex, separate handling)
-        if afi == "l2vpn-evpn":
-            continue
 
         networks = []
         for prefix, net_config in (afi_config.get("network", {}) or {}).items():
@@ -775,6 +774,12 @@ def parse_address_families(raw: dict) -> List[BgpAddressFamily]:
                 ))
 
         max_paths = afi_config.get("maximum-paths", {}) or {}
+        evpn_flags = []
+        if afi == "l2vpn-evpn":
+            evpn_flags = [
+                flag for flag in evpn_flag_names
+                if flag in afi_config
+            ]
 
         families.append(BgpAddressFamily(
             afi=afi,
@@ -783,6 +788,7 @@ def parse_address_families(raw: dict) -> List[BgpAddressFamily]:
             redistribute=redistribute,
             maximum_paths_ebgp=_safe_int(max_paths.get("ebgp")),
             maximum_paths_ibgp=_safe_int(max_paths.get("ibgp")),
+            evpn_flags=evpn_flags,
         ))
 
     return families
@@ -854,6 +860,8 @@ async def bgp_batch_configure(http_request: Request, body: BgpBatchRequest):
         )
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
     except Exception as e:

--- a/backend/routers/vrf/vrf.py
+++ b/backend/routers/vrf/vrf.py
@@ -1006,6 +1006,10 @@ async def vrf_batch_configure(http_request: Request, body: VrfBatchRequest):
             data={"message": "VRF configuration updated"},
             error=response.error if response.error else None
         )
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except AttributeError as e:
         raise HTTPException(status_code=400, detail=f"Unknown operation: {str(e)}")
     except Exception as e:

--- a/backend/tests/test_bgp_l2vpn_evpn_flags.py
+++ b/backend/tests/test_bgp_l2vpn_evpn_flags.py
@@ -1,0 +1,131 @@
+"""BGP L2VPN EVPN address-family control flags — path, parse, capability, 400."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from routers.bgp.bgp import parse_address_families
+from vyos_builders.bgp.bgp_batch_builder import BgpBatchBuilder
+from vyos_builders.vrf.vrf_batch_builder import VrfBatchBuilder
+from vyos_mappers.bgp.bgp import BgpMapper
+from vyos_mappers.vrf.vrf_bgp import VrfBgpMapper
+
+
+def _method(flag: str, verb: str) -> str:
+    return f"{verb}_af_l2vpn_evpn_{flag.replace('-', '_')}"
+
+
+def _flag_cases():
+    flags = sorted(BgpMapper("1.5").l2vpn_evpn_control_flags())
+    cases = []
+    for flag in flags:
+        path = ["protocols", "bgp", "address-family", "l2vpn-evpn", flag]
+        cases.append((_method(flag, "set"), "set", path))
+        cases.append((_method(flag, "delete"), "delete", path))
+    return cases
+
+
+@pytest.mark.parametrize("method, op, expected_path", _flag_cases())
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_l2vpn_evpn_control_flag_paths(method, op, expected_path, version):
+    builder = BgpBatchBuilder(version=version)
+    getattr(builder, method)()
+    operations = builder.get_operations()
+    assert [(item["op"], item["path"]) for item in operations] == [(op, expected_path)]
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_unknown_flag_rejected(version):
+    mapper = BgpMapper(version)
+    with pytest.raises(ValueError):
+        mapper.get_af_l2vpn_evpn_flag("not-a-real-flag")
+    vrf = VrfBgpMapper(version)
+    with pytest.raises(ValueError):
+        vrf.get_bgp_af_l2vpn_evpn_flag("blue", "not-a-real-flag")
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_capability_reads_mapper_allowlist(version):
+    mapper_flags = BgpMapper(version).l2vpn_evpn_control_flags()
+    caps = BgpBatchBuilder(version=version).get_capabilities()
+    feature = caps["features"]["l2vpn_evpn_control_flags"]
+    assert feature["supported"] is True
+    assert set(feature["flags"]) == set(mapper_flags)
+    vrf_caps = VrfBatchBuilder(version=version).get_capabilities()
+    assert vrf_caps["features"]["l2vpn_evpn_control_flags"]["supported"] is True
+
+
+def test_vrf_reuses_global_builder_with_prefix():
+    global_ops = (
+        BgpBatchBuilder("1.5")
+        .set_af_l2vpn_evpn_advertise_all_vni()
+        .get_operations()
+    )
+    vrf = VrfBatchBuilder("1.5")
+    vrf.set_vrf_bgp_af_l2vpn_evpn_advertise_all_vni("blue")
+    assert vrf.get_operations() == [
+        {"op": op["op"], "path": ["vrf", "name", "blue"] + op["path"]}
+        for op in global_ops
+    ]
+
+
+def test_parse_l2vpn_evpn_flags():
+    families = parse_address_families({
+        "ipv4-unicast": {"network": {"192.0.2.0/24": {}}},
+        "l2vpn-evpn": {
+            "advertise-all-vni": {},
+            "rt-auto-derive": {},
+            "rd": "1:1",
+        },
+    })
+    by_afi = {f.afi: f for f in families}
+    assert "l2vpn-evpn" in by_afi
+    assert set(by_afi["l2vpn-evpn"].evpn_flags) == {
+        "advertise-all-vni",
+        "rt-auto-derive",
+    }
+    assert by_afi["ipv4-unicast"].evpn_flags == []
+    assert by_afi["ipv4-unicast"].networks[0].prefix == "192.0.2.0/24"
+
+
+def _handler_maps_value_error_to_400(router_path: Path, handler_name: str) -> None:
+    tree = ast.parse(router_path.read_text())
+    handler = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == handler_name
+    )
+
+    def _handler_names(exc):
+        names = set()
+        etype = exc.type
+        if isinstance(etype, ast.Name):
+            names.add(etype.id)
+        elif isinstance(etype, ast.Tuple):
+            names.update(e.id for e in etype.elts if isinstance(e, ast.Name))
+        return names
+
+    value_error_handlers = [
+        h for h in ast.walk(handler)
+        if isinstance(h, ast.ExceptHandler) and "ValueError" in _handler_names(h)
+    ]
+    assert value_error_handlers, f"{handler_name} must catch ValueError"
+
+    status_codes = set()
+    for h in value_error_handlers:
+        for node in ast.walk(h):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "HTTPException":
+                for kw in node.keywords:
+                    if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
+                        status_codes.add(kw.value.value)
+    assert 400 in status_codes, "ValueError must map to HTTP 400"
+
+
+def test_bgp_batch_handler_maps_value_error_to_http_400():
+    router_path = Path(__file__).resolve().parents[1] / "routers" / "bgp" / "bgp.py"
+    _handler_maps_value_error_to_400(router_path, "bgp_batch_configure")
+
+
+def test_vrf_batch_handler_maps_value_error_to_http_400():
+    router_path = Path(__file__).resolve().parents[1] / "routers" / "vrf" / "vrf.py"
+    _handler_maps_value_error_to_400(router_path, "vrf_batch_configure")

--- a/backend/vyos_builders/bgp/bgp_batch_builder.py
+++ b/backend/vyos_builders/bgp/bgp_batch_builder.py
@@ -918,6 +918,48 @@ class BgpBatchBuilder(BatchBuilder):
     # ========================================================================
 
     # Network
+    def set_af_l2vpn_evpn_advertise_all_vni(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("advertise-all-vni"))
+
+    def delete_af_l2vpn_evpn_advertise_all_vni(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("advertise-all-vni"))
+
+    def set_af_l2vpn_evpn_advertise_default_gw(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("advertise-default-gw"))
+
+    def delete_af_l2vpn_evpn_advertise_default_gw(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("advertise-default-gw"))
+
+    def set_af_l2vpn_evpn_advertise_pip(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("advertise-pip"))
+
+    def delete_af_l2vpn_evpn_advertise_pip(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("advertise-pip"))
+
+    def set_af_l2vpn_evpn_advertise_svi_ip(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("advertise-svi-ip"))
+
+    def delete_af_l2vpn_evpn_advertise_svi_ip(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("advertise-svi-ip"))
+
+    def set_af_l2vpn_evpn_rt_auto_derive(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("rt-auto-derive"))
+
+    def delete_af_l2vpn_evpn_rt_auto_derive(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("rt-auto-derive"))
+
+    def set_af_l2vpn_evpn_disable_ead_evi_rx(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("disable-ead-evi-rx"))
+
+    def delete_af_l2vpn_evpn_disable_ead_evi_rx(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("disable-ead-evi-rx"))
+
+    def set_af_l2vpn_evpn_disable_ead_evi_tx(self) -> "BgpBatchBuilder":
+        return self.add_set(self.m.get_af_l2vpn_evpn_flag("disable-ead-evi-tx"))
+
+    def delete_af_l2vpn_evpn_disable_ead_evi_tx(self) -> "BgpBatchBuilder":
+        return self.add_delete(self.m.get_af_l2vpn_evpn_flag("disable-ead-evi-tx"))
+
     def set_af_network(self, afi: str, prefix: str) -> "BgpBatchBuilder":
         return self.add_set(self.m.get_af_network(afi, prefix))
 
@@ -1164,6 +1206,11 @@ class BgpBatchBuilder(BatchBuilder):
                 "redistribute_nhrp": {
                     "supported": "nhrp" in self.m.redistribute_protocols(),
                     "description": "Redistribute NHRP routes (VyOS 1.5+)",
+                },
+                "l2vpn_evpn_control_flags": {
+                    "supported": bool(self.m.l2vpn_evpn_control_flags()),
+                    "flags": sorted(self.m.l2vpn_evpn_control_flags()),
+                    "description": "L2VPN EVPN address-family control flags",
                 },
             },
             "address_family_types": {

--- a/backend/vyos_builders/vrf/vrf_batch_builder.py
+++ b/backend/vyos_builders/vrf/vrf_batch_builder.py
@@ -274,6 +274,10 @@ class VrfBatchBuilder(
                     "supported": "nhrp" in self.mappers["vrf_bgp"].redistribute_protocols(),
                     "description": "BGP redistribute NHRP (VyOS 1.5+ only)",
                 },
+                "l2vpn_evpn_control_flags": {
+                    "supported": bool(self.mappers["vrf_bgp"].l2vpn_evpn_control_flags()),
+                    "description": "BGP L2VPN EVPN address-family control flags",
+                },
             },
             "version_info": {
                 "is_1_4": is_1_4,

--- a/backend/vyos_mappers/bgp/bgp.py
+++ b/backend/vyos_mappers/bgp/bgp.py
@@ -25,6 +25,18 @@ class BgpMapper(BaseFeatureMapper):
         "pre-policy", "post-policy",
     )
 
+    # Valueless control leaves under address-family l2vpn-evpn. Present on
+    # both 1.4 and 1.5 (global and VRF).
+    _L2VPN_EVPN_CONTROL_FLAGS = (
+        "advertise-all-vni",
+        "advertise-default-gw",
+        "advertise-pip",
+        "advertise-svi-ip",
+        "rt-auto-derive",
+        "disable-ead-evi-rx",
+        "disable-ead-evi-tx",
+    )
+
     def __init__(self, version: str):
         super().__init__(version)
 
@@ -45,6 +57,14 @@ class BgpMapper(BaseFeatureMapper):
         if policy not in self.bmp_monitor_policies():
             raise ValueError(
                 f"BMP monitor policy {policy} is not supported on this device")
+
+    def l2vpn_evpn_control_flags(self) -> FrozenSet[str]:
+        return frozenset(self._L2VPN_EVPN_CONTROL_FLAGS)
+
+    def _require_l2vpn_evpn_control_flag(self, flag: str) -> None:
+        if flag not in self.l2vpn_evpn_control_flags():
+            raise ValueError(
+                f"l2vpn-evpn flag {flag} is not supported on this device")
 
     # ========================================================================
     # Helper base paths
@@ -969,6 +989,7 @@ class BgpMapper(BaseFeatureMapper):
         return self._af("l2vpn-evpn")
 
     def get_af_l2vpn_evpn_flag(self, flag: str) -> List[str]:
+        self._require_l2vpn_evpn_control_flag(flag)
         return self._af("l2vpn-evpn") + [flag]
 
     def get_af_l2vpn_evpn_advertise_ipv4_unicast(self) -> List[str]:

--- a/backend/vyos_mappers/vrf/vrf_bgp.py
+++ b/backend/vyos_mappers/vrf/vrf_bgp.py
@@ -27,6 +27,16 @@ class VrfBgpMapper:
         "pre-policy", "post-policy",
     )
 
+    _L2VPN_EVPN_CONTROL_FLAGS = (
+        "advertise-all-vni",
+        "advertise-default-gw",
+        "advertise-pip",
+        "advertise-svi-ip",
+        "rt-auto-derive",
+        "disable-ead-evi-rx",
+        "disable-ead-evi-tx",
+    )
+
     def __init__(self, version: str = ""):
         self.version = version
 
@@ -47,6 +57,14 @@ class VrfBgpMapper:
         if policy not in self.bmp_monitor_policies():
             raise ValueError(
                 f"BMP monitor policy {policy} is not supported on this device")
+
+    def l2vpn_evpn_control_flags(self) -> FrozenSet[str]:
+        return frozenset(self._L2VPN_EVPN_CONTROL_FLAGS)
+
+    def _require_l2vpn_evpn_control_flag(self, flag: str) -> None:
+        if flag not in self.l2vpn_evpn_control_flags():
+            raise ValueError(
+                f"l2vpn-evpn flag {flag} is not supported on this device")
 
     def _base(self, name: str) -> List[str]:
         return ["vrf", "name", name, "protocols", "bgp"]
@@ -1058,6 +1076,7 @@ class VrfBgpMapper:
         return self._af(name, "l2vpn-evpn")
 
     def get_bgp_af_l2vpn_evpn_flag(self, name: str, flag: str) -> List[str]:
+        self._require_l2vpn_evpn_control_flag(flag)
         return self._af(name, "l2vpn-evpn") + [flag]
 
     def get_bgp_af_l2vpn_evpn_advertise_ipv4_unicast(self, name: str) -> List[str]:

--- a/frontend/src/components/bgp/BgpContent.tsx
+++ b/frontend/src/components/bgp/BgpContent.tsx
@@ -243,6 +243,22 @@ export function BgpContent() {
   const currentAf: BgpAddressFamily | undefined = config?.address_families.find(
     (af) => af.afi === selectedAfi
   );
+  const isL2vpnEvpn = selectedAfi === "l2vpn-evpn";
+  const evpnFlags = capabilities?.features.l2vpn_evpn_control_flags?.flags ?? [];
+  const evpnFlagsSupported = Boolean(capabilities?.features.l2vpn_evpn_control_flags?.supported);
+
+  const handleToggleEvpnFlag = async (flag: string, enabled: boolean) => {
+    setAfSaving(true);
+    setAfError(null);
+    try {
+      await bgpService.setL2vpnEvpnFlag(flag, enabled);
+      await loadData(true);
+    } catch (err) {
+      setAfError(err instanceof Error ? err.message : "Failed to update EVPN flag");
+    } finally {
+      setAfSaving(false);
+    }
+  };
 
   const handleAddNetwork = async () => {
     if (!afNetworkPrefix.trim()) return;
@@ -937,7 +953,7 @@ export function BgpContent() {
               <div className="space-y-4">
                 <div className="flex items-center justify-between">
                   <p className="text-sm text-muted-foreground">
-                    Global address family settings for networks, redistribution, and aggregation
+                    Global address family settings for networks, redistribution, aggregation, and EVPN
                   </p>
                   <Select value={selectedAfi} onValueChange={setSelectedAfi}>
                     <SelectTrigger className="w-[220px]">
@@ -961,6 +977,37 @@ export function BgpContent() {
 
                 {selectedAfi && (
                   <div className="space-y-6">
+                    {isL2vpnEvpn && evpnFlagsSupported && (
+                      <Card>
+                        <CardContent className="p-6">
+                          <h3 className="text-sm font-medium mb-4">EVPN control flags</h3>
+                          <p className="text-xs text-muted-foreground mb-4">
+                            Address-family flags for L2VPN EVPN
+                          </p>
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            {evpnFlags.map((flag) => {
+                              const checked = currentAf?.evpn_flags?.includes(flag) ?? false;
+                              return (
+                                <div key={flag} className="flex items-center gap-2">
+                                  <Checkbox
+                                    id={`evpn-flag-${flag}`}
+                                    checked={checked}
+                                    disabled={afSaving}
+                                    onCheckedChange={(c) => handleToggleEvpnFlag(flag, c === true)}
+                                  />
+                                  <Label htmlFor={`evpn-flag-${flag}`} className="text-sm cursor-pointer">
+                                    {flag.replace(/-/g, " ")}
+                                  </Label>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    )}
+
+                    {!isL2vpnEvpn && (
+                    <>
                     {/* Networks */}
                     <Card>
                       <CardContent className="p-6">
@@ -1210,6 +1257,8 @@ export function BgpContent() {
                         </div>
                       </CardContent>
                     </Card>
+                    </>
+                    )}
 
                     {/* Maximum Paths */}
                     {currentAf && (currentAf.maximum_paths_ebgp || currentAf.maximum_paths_ibgp) && (

--- a/frontend/src/components/vrf/schema/SchemaEditor.tsx
+++ b/frontend/src/components/vrf/schema/SchemaEditor.tsx
@@ -98,15 +98,21 @@ export function SchemaEditor({
         .map((s) => ({
           ...s,
           fields: s.fields.filter((f) => {
-            if (!f.capability) return true;
-            const feats = capabilities.features as
-              | Record<string, { supported?: boolean } | undefined>
-              | undefined;
-            return Boolean(feats?.[f.capability]?.supported);
+            if (f.capability) {
+              const feats = capabilities.features as
+                | Record<string, { supported?: boolean } | undefined>
+                | undefined;
+              if (!Boolean(feats?.[f.capability]?.supported)) return false;
+            }
+            if (f.entityIds?.length) {
+              const entityId = contextArgs[contextArgs.length - 1];
+              if (!entityId || !f.entityIds.includes(entityId)) return false;
+            }
+            return true;
           }),
         }))
         .filter((s) => s.fields.length > 0),
-    [sections, capabilities]
+    [sections, capabilities, contextArgs]
   );
 
   const initial = useMemo(() => {

--- a/frontend/src/components/vrf/schema/bgpEntities.ts
+++ b/frontend/src/components/vrf/schema/bgpEntities.ts
@@ -190,6 +190,18 @@ const GLOBAL_AF_SCHEMA: SectionSpec[] = [
       { op: "vrf_bgp_af_route_map_vpn_import", delOp: "vrf_bgp_af_route_map_vpn", label: "Route-map VPN import", type: "text", path: ["route-map", "vpn", "import"] },
     ],
   },
+  {
+    title: "L2VPN EVPN",
+    fields: [
+      { op: "vrf_bgp_af_l2vpn_evpn_advertise_all_vni", label: "Advertise all VNI", type: "toggle", path: ["advertise-all-vni"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+      { op: "vrf_bgp_af_l2vpn_evpn_advertise_default_gw", label: "Advertise default gateway", type: "toggle", path: ["advertise-default-gw"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+      { op: "vrf_bgp_af_l2vpn_evpn_advertise_pip", label: "Advertise PIP", type: "toggle", path: ["advertise-pip"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+      { op: "vrf_bgp_af_l2vpn_evpn_advertise_svi_ip", label: "Advertise SVI IP", type: "toggle", path: ["advertise-svi-ip"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+      { op: "vrf_bgp_af_l2vpn_evpn_rt_auto_derive", label: "RT auto-derive", type: "toggle", path: ["rt-auto-derive"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+      { op: "vrf_bgp_af_l2vpn_evpn_disable_ead_evi_rx", label: "Disable EAD EVI RX", type: "toggle", path: ["disable-ead-evi-rx"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+      { op: "vrf_bgp_af_l2vpn_evpn_disable_ead_evi_tx", label: "Disable EAD EVI TX", type: "toggle", path: ["disable-ead-evi-tx"], entityIds: ["l2vpn-evpn"], capability: "l2vpn_evpn_control_flags" },
+    ],
+  },
 ];
 
 const BGP_AF_REDISTRIBUTE_GROUP: EntityGroupSpec = {

--- a/frontend/src/components/vrf/schema/types.ts
+++ b/frontend/src/components/vrf/schema/types.ts
@@ -31,6 +31,8 @@ export interface FieldSpec {
   help?: string;
   /** Capability flag (capabilities.features[capability].supported) gating the field. */
   capability?: string;
+  /** Only render this field when the current entity id is one of these values. */
+  entityIds?: string[];
 }
 
 export interface SectionSpec {

--- a/frontend/src/lib/api/bgp.ts
+++ b/frontend/src/lib/api/bgp.ts
@@ -213,6 +213,7 @@ export interface BgpAddressFamily {
   redistribute: BgpRedistribute[];
   maximum_paths_ebgp: number | null;
   maximum_paths_ibgp: number | null;
+  evpn_flags: string[];
 }
 
 export interface BgpListenRange {
@@ -249,6 +250,7 @@ export interface BgpCapabilities {
     local_role: { supported: boolean; description: string };
     path_attribute: { supported: boolean; description: string };
     redistribute_nhrp: { supported: boolean; description: string };
+    l2vpn_evpn_control_flags: { supported: boolean; flags: string[]; description: string };
   };
   address_family_types: {
     neighbor: string[];
@@ -869,6 +871,12 @@ class BgpService {
 
   async deleteAggregateAddress(afi: string, prefix: string): Promise<VyOSResponse> {
     return this.batchConfigure({ operations: [{ op: "delete_af_aggregate_address", value: `${afi},${prefix}` }] });
+  }
+
+  async setL2vpnEvpnFlag(flag: string, enabled: boolean): Promise<VyOSResponse> {
+    const name = flag.replace(/-/g, "_");
+    const op = `${enabled ? "set" : "delete"}_af_l2vpn_evpn_${name}`;
+    return this.batchConfigure({ operations: [{ op }] });
   }
 }
 

--- a/frontend/src/lib/api/vrf.ts
+++ b/frontend/src/lib/api/vrf.ts
@@ -298,6 +298,7 @@ export interface VrfCapabilities {
     ospf_redistribute_nhrp: VrfFeatureFlag;
     isis_fast_reroute: VrfFeatureFlag;
     bgp_redistribute_nhrp: VrfFeatureFlag;
+    l2vpn_evpn_control_flags: VrfFeatureFlag;
   };
   version_info: {
     is_1_4: boolean;


### PR DESCRIPTION
The BGP mapper listed l2vpn-evpn as an address-family type but did not expose the global EVPN control flags. Operators could not set advertise-all-vni, advertise-default-gw, advertise-pip, advertise-svi-ip, rt-auto-derive, disable-ead-evi-rx, or disable-ead-evi-tx from VyManager.

The mapper now owns those leaves behind an allowlist (same on 1.4 and 1.5, global and VRF). Builder methods emit the paths, get_capabilities reads the allowlist, GET /config parses the flags, and the BGP address-family tab plus VRF BGP AF editor show the controls. Unknown flags raise ValueError, mapped to HTTP 400.

Lab-validated the seven flags (and VRF equivalents) with validateTmplPath on 1.4 and 1.5. network under l2vpn-evpn is INVALID, so those cards stay hidden for EVPN.

Tests: PYTHONPATH=. ./venv/bin/python -m pytest tests/test_bgp_l2vpn_evpn_flags.py tests/test_bgp_builder_paths.py tests/test_vrf_protocol_prefix.py -q (89 passed). frontend npx tsc --noEmit and npm run lint.

Closes #699